### PR TITLE
fix opening correct panel in the preferences dialog via the contextmenu

### DIFF
--- a/src/dialogs/preferences/PreferencesDialog.cpp
+++ b/src/dialogs/preferences/PreferencesDialog.cpp
@@ -20,8 +20,7 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
     setAttribute(Qt::WA_DeleteOnClose);
     ui->setupUi(this);
 
-    QList<PreferenceCategory> prefs
-    {
+    QList<PreferenceCategory> prefs {
         {
             "General",
             new GeneralOptionsWidget(this),
@@ -45,8 +44,8 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
         c.addItem(*ui->configCategories, *ui->configPanel);
 
     connect(ui->configCategories,
-            SIGNAL(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)),
-            this, SLOT(changePage(QTreeWidgetItem*, QTreeWidgetItem*)));
+            SIGNAL(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)),
+            this, SLOT(changePage(QTreeWidgetItem *, QTreeWidgetItem *)));
     connect(ui->saveButtons,
             SIGNAL(accepted()),
             this, SLOT(close()));
@@ -61,12 +60,17 @@ PreferencesDialog::~PreferencesDialog()
 
 void PreferencesDialog::showSection(PreferencesDialog::Section section)
 {
+    QTreeWidgetItem *defitem;
     switch (section) {
     case Section::General:
         ui->configPanel->setCurrentIndex(0);
+        defitem = ui->configCategories->topLevelItem(0);
+        ui->configCategories->setCurrentItem(defitem, 0);
         break;
     case Section::Disassembly:
         ui->configPanel->setCurrentIndex(1);
+        defitem = ui->configCategories->topLevelItem(1);
+        ui->configCategories->setCurrentItem(defitem, 1);
         break;
     }
 }
@@ -79,5 +83,5 @@ void PreferencesDialog::changePage(QTreeWidgetItem *current, QTreeWidgetItem *pr
     int index = current->data(0, Qt::UserRole).toInt();
 
     if (index)
-        ui->configPanel->setCurrentIndex(index-1);
+        ui->configPanel->setCurrentIndex(index - 1);
 }


### PR DESCRIPTION
When opening options via right-click, the wrong menu would be open, as well as the wrong separator selected on the left