### PR TITLE
Implement Set As String in the Disassembly widgets

### DIFF
--- a/src/Cutter.cpp
+++ b/src/Cutter.cpp
@@ -399,6 +399,12 @@ void CutterCore::setToCode(RVA addr)
     emit instructionChanged(addr);
 }
 
+void CutterCore::setAsString(RVA addr)
+{
+    cmd("Cs @ " + RAddressString(addr));
+    emit instructionChanged(addr);
+}
+
 void CutterCore::setToData(RVA addr, int size, int repeat)
 {
     if (size <= 0 || repeat <= 0) {

--- a/src/Cutter.h
+++ b/src/Cutter.h
@@ -423,6 +423,7 @@ public:
 
     /* Code/Data */
     void setToCode(RVA addr);
+    void setAsString(RVA addr);
     void setToData(RVA addr, int size, int repeat = 1);
     int sizeofDataMeta(RVA addr);
 

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -70,9 +70,13 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent)
 
     addSetBitsMenu();
 
-    initAction(&actionSetToCode, tr("Set to Code"),
+    initAction(&actionSetToCode, tr("Set as Code"),
                SLOT(on_actionSetToCode_triggered()), getSetToCodeSequence());
     addAction(&actionSetToCode);
+
+    initAction(&actionSetAsString, tr("Set as String"),
+               SLOT(on_actionSetAsString_triggered()), getSetAsStringSequence());
+    addAction(&actionSetAsString);
 
     addSetToDataMenu();
 
@@ -329,6 +333,12 @@ QKeySequence DisassemblyContextMenu::getSetToCodeSequence() const
 {
     return {Qt::Key_C};
 }
+
+QKeySequence DisassemblyContextMenu::getSetAsStringSequence() const
+{
+    return {Qt::Key_A};
+}
+
 
 QKeySequence DisassemblyContextMenu::getSetToDataSequence() const
 {
@@ -663,6 +673,12 @@ void DisassemblyContextMenu::on_actionSetToCode_triggered()
 {
     Core()->setToCode(offset);
 }
+
+void DisassemblyContextMenu::on_actionSetAsString_triggered()
+{
+    Core()->setAsString(offset);
+}
+
 
 void DisassemblyContextMenu::on_actionSetToData_triggered()
 {

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -51,6 +51,7 @@ private slots:
     void on_actionSetPC_triggered();
 
     void on_actionSetToCode_triggered();
+    void on_actionSetAsString_triggered();
     void on_actionSetToData_triggered();
     void on_actionSetToDataEx_triggered();
 
@@ -58,6 +59,7 @@ private:
     QKeySequence getCopySequence() const;
     QKeySequence getCommentSequence() const;
     QKeySequence getSetToCodeSequence() const;
+    QKeySequence getSetAsStringSequence() const;
     QKeySequence getSetToDataSequence() const;
     QKeySequence getSetToDataExSequence() const;
     QKeySequence getAddFlagSequence() const;
@@ -119,6 +121,7 @@ private:
     QAction actionSetPC;
 
     QAction actionSetToCode;
+    QAction actionSetAsString;
 
     QMenu *setToDataMenu;
     QAction actionSetToDataEx;


### PR DESCRIPTION
Explain the **details** for making this change. What existing problem does the pull request solve?

Currently, there wasn't an equivalent for radare2's `Cs` command (`Vds` in Visual Mode) which is responsible for defining a string. This is useful when Cutter fails to recognize a string and treats it as a set of instructions.

**Test plan (required)**

Implementation of the following context-menu item, and a shortcut `A` which corresponds to IDA's:

![image](https://user-images.githubusercontent.com/20182642/48633497-1f263d00-e9cc-11e8-958d-21df29a11983.png)

Clicking on this item will make Cutter show this address(es) as a string:
![2018-11-16_18-24-31](https://user-images.githubusercontent.com/20182642/48633824-d0c56e00-e9cc-11e8-9bad-29008214cb4d.gif)



