### PR TITLE
Fix crash in StringsWidget::on_actionX_refs_triggered.

### DIFF
--- a/src/widgets/StringsWidget.cpp
+++ b/src/widgets/StringsWidget.cpp
@@ -273,7 +273,6 @@ void StringsWidget::on_actionX_refs_triggered()
 
     XrefsDialog x(nullptr);
     x.fillRefsForAddress(str.vaddr, RAddressString(str.vaddr), false);
-    x.setAttribute(Qt::WA_DeleteOnClose);
     x.exec();
 }
 


### PR DESCRIPTION
Qt::WA_DeleteOnClose is set for a dialog that is allocated on the stack. This
causes Qt to attempt to delete the object when the XrefsDialog calls its close
method.

This appears to be a regression introduced in f59dce17. That changed the allocation of this object from heap to stack memory, but this flag was overlooked.


**Test plan (required)**

Repro case:
- Right click on a referenced string in the strings list.
- Choose Xrefs.
- Double click on a referenced item.
- Crash occurs.