### PR TITLE
Graph edge highlight

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -601,6 +601,11 @@ GraphView::EdgeConfiguration DisassemblerGraphView::edgeConfiguration(GraphView:
     }
     ec.start_arrow = false;
     ec.end_arrow = true;
+    if (from.entry == currentBlockAddress) {
+        ec.lineStyle = Qt::DashLine;
+    } else if (to->entry == currentBlockAddress) {
+        ec.lineStyle = Qt::DashDotLine;
+    }
     return ec;
 }
 
@@ -922,6 +927,8 @@ void DisassemblerGraphView::blockClicked(GraphView::GraphBlock &block, QMouseEve
         return;
     }
 
+    currentBlockAddress = block.entry;
+
     highlight_token = getToken(instr, pos.x());
 
     RVA addr = instr->addr;
@@ -983,6 +990,7 @@ bool DisassemblerGraphView::helpEvent(QHelpEvent *event)
 
 void DisassemblerGraphView::blockTransitionedTo(GraphView::GraphBlock *to)
 {
+    currentBlockAddress = to->entry;
     if (transition_dont_seek) {
         transition_dont_seek = false;
         return;

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -152,6 +152,8 @@ DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable* se
     // Add header as widget to layout so it stretches to the layout width
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setAlignment(Qt::AlignTop);
+
+    this->scale_thickness_multiplier = true;
 }
 
 void DisassemblerGraphView::connectSeekChanged(bool disconn)

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -602,9 +602,9 @@ GraphView::EdgeConfiguration DisassemblerGraphView::edgeConfiguration(GraphView:
     ec.start_arrow = false;
     ec.end_arrow = true;
     if (from.entry == currentBlockAddress) {
-        ec.lineStyle = Qt::DashLine;
+        ec.width_scale = 2.0;
     } else if (to->entry == currentBlockAddress) {
-        ec.lineStyle = Qt::DashDotLine;
+        ec.width_scale = 2.0;
     }
     return ec;
 }

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -147,6 +147,7 @@ private:
     int charOffset;
     int baseline;
     bool emptyGraph;
+    ut64 currentBlockAddress = RVA_INVALID;
 
     DisassemblyContextMenu *blockMenu;
     QMenu *contextMenu;

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -918,9 +918,9 @@ void DisassemblyLeftPanel::paintEvent(QPaintEvent *event)
 
         bool jumpDown = l.arrow > l.offset;
         p.setPen(jumpDown ? penDown : penUp);
-        if (l.offset == currOffset) {
+        if (l.offset == currOffset || l.arrow == currOffset) {
             QPen pen = p.pen();
-            pen.setWidth((penSizePix * 3) / 2);
+            pen.setWidthF((penSizePix * 3) / 2.0);
             p.setPen(pen);
         }
         bool endVisible = true;

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -338,8 +338,8 @@ void GraphView::paintGraphCache()
             QPen pen(ec.color);
             pen.setStyle(ec.lineStyle);
             pen.setWidthF(pen.width() * ec.width_scale);
-            if (ec.width_scale > 1.01 && pen.widthF() * current_scale < 2) {
-                pen.setWidthF(2.0 / current_scale);
+            if (scale_thickness_multiplier * ec.width_scale > 1.01 && pen.widthF() * current_scale < 2) {
+                pen.setWidthF(ec.width_scale / current_scale);
             }
             if (pen.widthF() * current_scale < 2) {
                 pen.setWidth(0);

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -337,8 +337,11 @@ void GraphView::paintGraphCache()
             EdgeConfiguration ec = edgeConfiguration(block, &blocks[edge.target]);
             QPen pen(ec.color);
             pen.setStyle(ec.lineStyle);
-            pen.setWidth(pen.width() / ec.width_scale);
-            if (pen.width() * current_scale < 2) {
+            pen.setWidthF(pen.width() * ec.width_scale);
+            if (ec.width_scale > 1.01 && pen.widthF() * current_scale < 2) {
+                pen.setWidthF(2.0 / current_scale);
+            }
+            if (pen.widthF() * current_scale < 2) {
                 pen.setWidth(0);
             }
             p.setPen(pen);

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -336,6 +336,7 @@ void GraphView::paintGraphCache()
             QPolygonF polyline = recalculatePolygon(edge.polyline);
             EdgeConfiguration ec = edgeConfiguration(block, &blocks[edge.target]);
             QPen pen(ec.color);
+            pen.setStyle(ec.lineStyle);
             pen.setWidth(pen.width() / ec.width_scale);
             if (pen.width() * current_scale < 2) {
                 pen.setWidth(0);

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -97,6 +97,7 @@ protected:
 
     int width = 0;
     int height = 0;
+    bool scale_thickness_multiplier = false;
 
     void clampViewOffset();
     void setViewOffsetInternal(QPoint pos, bool emitSignal = true);
@@ -125,9 +126,6 @@ private:
     int scroll_base_x = 0;
     int scroll_base_y = 0;
     bool scroll_mode = false;
-
-    // Todo: remove charheight/charwidth cause it should be handled in child class
-    qreal charWidth = 10.0;
 
     bool useGL;
 

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -38,6 +38,7 @@ public:
         bool start_arrow = false;
         bool end_arrow = true;
         qreal width_scale = 1.0;
+        Qt::PenStyle lineStyle = Qt::PenStyle::SolidLine;
     };
 
     explicit GraphView(QWidget *parent);

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -137,7 +137,7 @@ GraphView::EdgeConfiguration OverviewView::edgeConfiguration(GraphView::GraphBlo
     auto baseEcIt = edgeConfigurations.find({from.entry, to->entry});
     if (baseEcIt != edgeConfigurations.end())
         ec = baseEcIt->second;
-    ec.width_scale = getViewScale();
+    ec.width_scale = 1.0 / getViewScale();
     return ec;
 }
 


### PR DESCRIPTION
 <!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Detailed description**

Make edges going to and from current block in graph or current line disassembly more visible by changing line style. Helps tracking where it goes when there is a bunch of them together.

The new disassembly arrow widget already had such code but it was broken.


**Test plan (required)**
In disassembly
* select line with outgoing edge
* select line with incoming edge
* move to line with arrow using keyboard
In graph
* click on a block
* move between blocks using t, f, alt+left arrrow, alt+right arrow
* change seek using different memory widget or bar at the top
![arrows](https://user-images.githubusercontent.com/7101031/61998618-497fdc80-b0bb-11e9-9d6a-4b830b0aaf17.png)
