### PR TITLE
WIP: Expose CutterApplication to Python and add accessor

### DIFF
--- a/src/bindings/bindings.h
+++ b/src/bindings/bindings.h
@@ -7,6 +7,7 @@
 #include "../core/Cutter.h"
 #include "../common/Configuration.h"
 #include "../core/MainWindow.h"
+#include "../CutterApplication.h"
 #include "../widgets/CutterDockWidget.h"
 #include "../plugins/CutterPlugin.h"
 

--- a/src/bindings/bindings.xml
+++ b/src/bindings/bindings.xml
@@ -13,6 +13,9 @@
     <object-type name="MainWindow" >
         <enum-type name="MenuType" />
     </object-type>
+    <object-type name="CutterApplication">
+        <modify-function signature="CutterApplication(int &amp;, char **)" remove="all"/>
+    </object-type>
     <object-type name="BasicBlockHighlighter" />
     <object-type name="CutterDockWidget" />
 

--- a/src/python/cutter.py
+++ b/src/python/cutter.py
@@ -6,6 +6,14 @@ try:
 
     def core():
         return CutterCore.instance()
+
+    def app():
+        # see https://forums.autodesk.com/t5/3ds-max-programming/qapplication-instance-returns-qcoreapplication-instance/td-p/9035295
+        import shiboken2
+        from PySide2 import QtCore
+        coreapp = QtCore.QCoreApplication.instance()
+        ptr = shiboken2.getCppPointer(coreapp)[0]
+        return shiboken2.wrapInstance(ptr, CutterApplication)
 except ImportError:
     pass
 


### PR DESCRIPTION
`QApplication::instance()` will always return a QCoreApplication wrapper in PySide2.
This adds `cutter.app()` which gives you a `CutterApplication`.
see https://forums.autodesk.com/t5/3ds-max-programming/qapplication-instance-returns-qcoreapplication-instance/td-p/9035295