### PR TITLE
Don't use @a: for listing cpus.

### DIFF
--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -113,7 +113,7 @@ void InitialOptionsDialog::updateCPUComboBox()
 #if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
             cpus = pluginDescr->cpus.split(",", Qt::SkipEmptyParts);
 #else
-            cpus = pluginDescr->cpus.split(",", Qt::SkipEmptyParts);
+            cpus = pluginDescr->cpus.split(",", QString::SkipEmptyParts);
 #endif
         }
     }

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -110,7 +110,11 @@ void InitialOptionsDialog::updateCPUComboBox()
             return plugin.name == arch;
         });
         if (pluginDescr != asmPlugins.end()) {
+#if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
             cpus = pluginDescr->cpus.split(",", Qt::SkipEmptyParts);
+#else
+            cpus = pluginDescr->cpus.split(",", Qt::SkipEmptyParts);
+#endif
         }
     }
 

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -27,9 +27,9 @@ InitialOptionsDialog::InitialOptionsDialog(MainWindow *main):
     ui->logoSvgWidget->load(Config()->getLogoFile());
 
     // Fill the plugins combo
-    asm_plugins = core->getAsmPluginNames();
-    for (const auto &plugin : asm_plugins) {
-        ui->archComboBox->addItem(plugin, plugin);
+    asmPlugins = core->getRAsmPluginDescriptions();
+    for (const auto &plugin : asmPlugins) {
+        ui->archComboBox->addItem(plugin.name, plugin.name);
     }
 
     setTooltipWithConfigHelp(ui->archComboBox,"asm.arch");
@@ -103,15 +103,19 @@ void InitialOptionsDialog::updateCPUComboBox()
     QString currentText = ui->cpuComboBox->lineEdit()->text();
     ui->cpuComboBox->clear();
 
-    QString cmd = "e asm.cpu=?";
-
     QString arch = getSelectedArch();
-    if (!arch.isNull()) {
-        cmd += " @a:" + arch;
+    QStringList cpus;
+    if (!arch.isEmpty()) {
+        auto pluginDescr = std::find_if(asmPlugins.begin(), asmPlugins.end(), [&](const RAsmPluginDescription &plugin) {
+            return plugin.name == arch;
+        });
+        if (pluginDescr != asmPlugins.end()) {
+            cpus = pluginDescr->cpus.split(",", Qt::SkipEmptyParts);
+        }
     }
 
     ui->cpuComboBox->addItem("");
-    ui->cpuComboBox->addItems(core->cmdList(cmd));
+    ui->cpuComboBox->addItems(cpus);
 
     ui->cpuComboBox->lineEdit()->setText(currentText);
 }

--- a/src/dialogs/InitialOptionsDialog.h
+++ b/src/dialogs/InitialOptionsDialog.h
@@ -46,7 +46,7 @@ private:
     QString analysisDescription(int level);
     QString shellcode;
     int analLevel;
-    QStringList asm_plugins;
+    QList<RAsmPluginDescription> asmPlugins;
 
 
     void updateCPUComboBox();


### PR DESCRIPTION
For some architectures like 8051 doing `@a:` has sideeffects.

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

* In the initial options change arch to 8051
* Change arch to arm
* Open a file, make sure there are no errors during opening, file opens and the bytes can bee seen
* Test that cpu listing works, Try selecting a few different cpus in the initial dialog, make sure cpu list gets filled with expected values.

**Closing issues**
Closes #2304 