### PR TITLE
Lock the decompiler versions used.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ environment:
       DEPLOY: false
 
 install:
-  - cmd: if defined QMAKE ( git clone --depth 1 --recurse-submodules https://github.com/radareorg/r2ghidra-dec.git %APPVEYOR_BUILD_FOLDER%/r2ghidra-dec )
+  - cmd: if defined QMAKE ( git clone --depth 1 --recurse-submodules https://github.com/radareorg/r2ghidra-dec.git --branch v4.5.0 %APPVEYOR_BUILD_FOLDER%/r2ghidra-dec )
   - ps: $env:path = ($env:path -split ";").Where({!($_ -like "*Microsoft SQL Server*")}) -join ";"
   - cmd: C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER && scripts/fetch_deps.sh"
   - cmd: set "CUTTER_DEPS_DIR=%APPVEYOR_BUILD_FOLDER%\cutter-deps"

--- a/scripts/bundle_r2dec.ps1
+++ b/scripts/bundle_r2dec.ps1
@@ -1,7 +1,7 @@
 $dist = $args[0]
 $python = Split-Path((Get-Command python.exe).Path)
 
-git clone https://github.com/wargio/r2dec-js.git
+git clone --depth 1 https://github.com/radareorg/r2dec-js.git --branch 4.5.0
 cd r2dec-js
 & meson.exe --buildtype=release -Dc_args=-DDUK_USE_DATE_NOW_WINDOWS --prefix=$dist --libdir=lib\plugins --datadir=lib\plugins p build
 ninja -C build install

--- a/scripts/r2dec.sh
+++ b/scripts/r2dec.sh
@@ -7,7 +7,7 @@ SCRIPTPATH=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 cd "$SCRIPTPATH/.."
 
 if [[ ! -d r2dec-js ]]; then
-	git clone --depth 1 https://github.com/wargio/r2dec-js.git
+	git clone --depth 1 https://github.com/radareorg/r2dec-js.git --branch 4.5.0
 fi
 
 cd r2dec-js

--- a/scripts/r2ghidra.sh
+++ b/scripts/r2ghidra.sh
@@ -5,7 +5,7 @@ SCRIPTPATH=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 cd "$SCRIPTPATH/.."
 
 if [[ ! -d r2ghidra-dec ]]; then
-    git clone --depth 1 --recurse-submodules https://github.com/radareorg/r2ghidra-dec.git || exit 1
+    git clone --depth 1 --recurse-submodules https://github.com/radareorg/r2ghidra-dec.git --branch v4.5.0 || exit 1
 fi
 cd r2ghidra-dec || exit 1
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

In future r2ghidra-dec and r2dec-js will depend on latest r2 versions. Lock the version downloaded by scripts so that bugfix release can be built more reliably and the release tag better represent a fixed version of code.

**Test plan (required)**
 
* CI is green
* Carefully inspect CI logs, in some of the cases decompilers are build after main CI compilation step and decompiler compilation failure doesn't cause whole job to fail
* Try running Appveyor artifact

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
