### PR TITLE
JSDec with Annotations

### DIFF
--- a/src/common/Decompiler.cpp
+++ b/src/common/Decompiler.cpp
@@ -10,6 +10,66 @@ Decompiler::Decompiler(const QString &id, const QString &name, QObject *parent)
 {
 }
 
+static char *jsonValueToString(const QJsonValue &str)
+{
+    return strdup(str.toString().toStdString().c_str());
+}
+
+RzAnnotatedCode *Decompiler::rz_annotated_code_from_json(QJsonObject &json)
+{
+    RzAnnotatedCode *code = rz_annotated_code_new(nullptr);
+    code->code = strdup(json["code"].toString().toStdString().c_str());
+    for (const auto &iter : json["annotations"].toArray()) {
+        QJsonObject jsonAnnotation = iter.toObject();
+        RzCodeAnnotation annotation = {};
+        annotation.start = jsonAnnotation["start"].toInt();
+        annotation.end = jsonAnnotation["end"].toInt();
+        QString type = jsonAnnotation["type"].toString();
+        if (type == "offset") {
+            annotation.type = RZ_CODE_ANNOTATION_TYPE_OFFSET;
+            annotation.offset.offset = jsonAnnotation["offset"].toString().toULongLong();
+        } else if (type == "function_name") {
+            annotation.type = RZ_CODE_ANNOTATION_TYPE_FUNCTION_NAME;
+            annotation.reference.name = jsonValueToString(jsonAnnotation["name"]);
+            annotation.reference.offset = jsonAnnotation["offset"].toString().toULongLong();
+        } else if (type == "global_variable") {
+            annotation.type = RZ_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE;
+            annotation.reference.offset = jsonAnnotation["offset"].toString().toULongLong();
+        } else if (type == "constant_variable") {
+            annotation.type = RZ_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE;
+            annotation.reference.offset = jsonAnnotation["offset"].toString().toULongLong();
+        } else if (type == "local_variable") {
+            annotation.type = RZ_CODE_ANNOTATION_TYPE_LOCAL_VARIABLE;
+            annotation.variable.name = jsonValueToString(jsonAnnotation["name"]);
+        } else if (type == "function_parameter") {
+            annotation.type = RZ_CODE_ANNOTATION_TYPE_FUNCTION_PARAMETER;
+            annotation.variable.name = jsonValueToString(jsonAnnotation["name"]);
+        } else if (type == "syntax_highlight") {
+            annotation.type = RZ_CODE_ANNOTATION_TYPE_SYNTAX_HIGHLIGHT;
+            QString highlightType = jsonAnnotation["syntax_highlight"].toString();
+            if (highlightType == "keyword") {
+                annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_KEYWORD;
+            } else if (highlightType == "comment") {
+                annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_COMMENT;
+            } else if (highlightType == "datatype") {
+                annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_DATATYPE;
+            } else if (highlightType == "function_name") {
+                annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_FUNCTION_NAME;
+            } else if (highlightType == "function_parameter") {
+                annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_FUNCTION_PARAMETER;
+            } else if (highlightType == "local_variable") {
+                annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_LOCAL_VARIABLE;
+            } else if (highlightType == "constant_variable") {
+                annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_CONSTANT_VARIABLE;
+            } else if (highlightType == "global_variable") {
+                annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_GLOBAL_VARIABLE;
+            }
+        }
+        rz_annotated_code_add_annotation(code, &annotation);
+    }
+    return code;
+}
+
 RzAnnotatedCode *Decompiler::makeWarning(QString warningMessage)
 {
     std::string temporary = warningMessage.toStdString();
@@ -26,11 +86,6 @@ bool JSDecDecompiler::isAvailable()
     return Core()->cmdList("es").contains("jsdec");
 }
 
-static char *jsonValueToString(const QJsonValue &str)
-{
-    return strdup(str.toString().toStdString().c_str());
-}
-
 void JSDecDecompiler::decompileAt(RVA addr)
 {
     if (task) {
@@ -45,56 +100,7 @@ void JSDecDecompiler::decompileAt(RVA addr)
             emit finished(Decompiler::makeWarning(tr("Failed to parse JSON from jsdec")));
             return;
         }
-        RzAnnotatedCode *code = rz_annotated_code_new(nullptr);
-        code->code = strdup(json["code"].toString().toStdString().c_str());
-        for (const auto &iter : json["annotations"].toArray()) {
-            QJsonObject jsonAnnotation = iter.toObject();
-            RzCodeAnnotation annotation = {};
-            annotation.start = jsonAnnotation["start"].toInt();
-            annotation.end = jsonAnnotation["end"].toInt();
-            QString type = jsonAnnotation["type"].toString();
-            if (type == "offset") {
-                annotation.type = RZ_CODE_ANNOTATION_TYPE_OFFSET;
-                annotation.offset.offset = jsonAnnotation["offset"].toString().toULongLong();
-            } else if (type == "function_name") {
-                annotation.type = RZ_CODE_ANNOTATION_TYPE_FUNCTION_NAME;
-                annotation.reference.name = jsonValueToString(jsonAnnotation["name"]);
-                annotation.reference.offset = jsonAnnotation["offset"].toString().toULongLong();
-            } else if (type == "global_variable") {
-                annotation.type = RZ_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE;
-                annotation.reference.offset = jsonAnnotation["offset"].toString().toULongLong();
-            } else if (type == "constant_variable") {
-                annotation.type = RZ_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE;
-                annotation.reference.offset = jsonAnnotation["offset"].toString().toULongLong();
-            } else if (type == "local_variable") {
-                annotation.type = RZ_CODE_ANNOTATION_TYPE_LOCAL_VARIABLE;
-                annotation.variable.name = jsonValueToString(jsonAnnotation["name"]);
-            } else if (type == "function_parameter") {
-                annotation.type = RZ_CODE_ANNOTATION_TYPE_FUNCTION_PARAMETER;
-                annotation.variable.name = jsonValueToString(jsonAnnotation["name"]);
-            } else if (type == "syntax_highlight") {
-                annotation.type = RZ_CODE_ANNOTATION_TYPE_SYNTAX_HIGHLIGHT;
-                QString highlightType = jsonAnnotation["syntax_highlight"].toString();
-                if (highlightType == "keyword") {
-                    annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_KEYWORD;
-                } else if (highlightType == "comment") {
-                    annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_COMMENT;
-                } else if (highlightType == "datatype") {
-                    annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_DATATYPE;
-                } else if (highlightType == "function_name") {
-                    annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_FUNCTION_NAME;
-                } else if (highlightType == "function_parameter") {
-                    annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_FUNCTION_PARAMETER;
-                } else if (highlightType == "local_variable") {
-                    annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_LOCAL_VARIABLE;
-                } else if (highlightType == "constant_variable") {
-                    annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_CONSTANT_VARIABLE;
-                } else if (highlightType == "global_variable") {
-                    annotation.syntax_highlight.type = RZ_SYNTAX_HIGHLIGHT_TYPE_GLOBAL_VARIABLE;
-                }
-            }
-            rz_annotated_code_add_annotation(code, &annotation);
-        }
+        RzAnnotatedCode *code = this->rz_annotated_code_from_json(json);
         emit finished(code);
     });
     task->startTask();

--- a/src/common/Decompiler.h
+++ b/src/common/Decompiler.h
@@ -25,6 +25,8 @@ public:
 
     static RzAnnotatedCode *makeWarning(QString warningMessage);
 
+    RzAnnotatedCode *rz_annotated_code_from_json(QJsonObject &json);
+
     QString getId() const { return id; }
     QString getName() const { return name; }
     virtual bool isRunning() { return false; }

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -79,6 +79,11 @@ void DecompilerContextMenu::setCurHighlightedWord(QString word)
     curHighlightedWord = word;
 }
 
+RzCodeAnnotation *DecompilerContextMenu::getAnnotationHere()
+{
+    return annotationHere;
+}
+
 void DecompilerContextMenu::setOffset(RVA newOffset)
 {
     offset = newOffset;

--- a/src/menus/DecompilerContextMenu.h
+++ b/src/menus/DecompilerContextMenu.h
@@ -19,6 +19,7 @@ public:
 
     bool getIsTogglingBreakpoints();
     void setAnnotationHere(RzCodeAnnotation *annotation);
+    RzCodeAnnotation *getAnnotationHere();
     RVA getFirstOffsetInLine();
 
 signals:

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -478,9 +478,6 @@ void DecompilerWidget::showDecompilerContextMenu(const QPoint &pt)
 
 void DecompilerWidget::seekToReference()
 {
-    // size_t pos = ui->textEdit->textCursor().position();
-    // RVA offset = offsetForPosition(pos);
-    // seekable->seekToReference(offset);
     RzCodeAnnotation *annotationHere = mCtxMenu->getAnnotationHere();
     if (annotationHere && rz_annotation_is_reference(annotationHere)) {
         seekable->seek(annotationHere->reference.offset);

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -478,9 +478,13 @@ void DecompilerWidget::showDecompilerContextMenu(const QPoint &pt)
 
 void DecompilerWidget::seekToReference()
 {
-    size_t pos = ui->textEdit->textCursor().position();
-    RVA offset = offsetForPosition(pos);
-    seekable->seekToReference(offset);
+    // size_t pos = ui->textEdit->textCursor().position();
+    // RVA offset = offsetForPosition(pos);
+    // seekable->seekToReference(offset);
+    RzCodeAnnotation *annotationHere = mCtxMenu->getAnnotationHere();
+    if (annotationHere && rz_annotation_is_reference(annotationHere)) {
+        seekable->seek(annotationHere->reference.offset);
+    }
 }
 
 bool DecompilerWidget::eventFilter(QObject *obj, QEvent *event)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
This PR implements annotations for the JSDec decompiler. Earlier, we were parsing to `RzAnnotatedCode` from the `pddj` output. Now, a command `pddA` has been implemented by @wargio recently for outputting annotations. The JSON output from `pddA` should ideally give all the information we need to make annotations as we have in rz-ghidra. This PR makes JSON parser for `pddA` output to `RzAnnotatedCode`.



<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**
1. [Install latest JSDec](https://github.com/rizinorg/jsdec#install).
2. Compile this PR and open cutter.
3. You should be able to see the features available to JSDec with context-annotations.
4. Test all the actions available with annotations, compare with rz-ghidra.

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->

---
#### Older version of the PR description from Aug 2020 (For archive)
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
This PR implements annotations for the r2dec decompiler. Earlier, we were parsing to RAnnotatedCode from the `pddj` output. Now, a command `pddA` has been implemented by @wargio recently for outputting annotations. The JSON output from `pddA` should ideally give all the information we need to make annotations as we have in r2ghidra-dec. This PR makes JSON parser for `pddA` output to `RAnnotatedCode`.

~~**Note**
This branch is created from the branch in PR #2402. Hence to see the changes made for just this PR, select commits from the commit with the message "output and looping for annotation.".~~
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**
1. Fetch latest r2dec [ `r2pm -ci r2dec` ].
2. Compile this PR and open cutter.
3. You should be able to see the features available to r2dec with context-annotations.
4. Test all the actions (see note below)

**Note**
The `pddA` output ~~as noted before,~~ is still not perfect. There were some confusions, and because of that, the address of the references are not correct. Also, r2dec crashes while running `pddA` in some functions. Hopefully, this will get patched soon.
1. So for the function related actions, and targeted show-in, the only reference that will work now is the one for the declaration/definition of the functions. Test this.
2.  As of now, only function variable(arguments and local variables) declarations have annotations, so variable related actions (Rename and Edit) will work only for them.
3. Global variables and constant variables cannot be tested before it gets patched.
<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
