### PR TITLE
Create SyntaxHighlighter based on RAnnotatedCode.

### DIFF
--- a/src/Cutter.pro
+++ b/src/Cutter.pro
@@ -440,7 +440,8 @@ SOURCES += \
     widgets/R2GraphWidget.cpp \
     widgets/CallGraph.cpp \
     widgets/AddressableDockWidget.cpp \
-    dialogs/preferences/AnalOptionsWidget.cpp
+    dialogs/preferences/AnalOptionsWidget.cpp \
+    common/DecompilerHighlighter.cpp
 
 GRAPHVIZ_SOURCES = \
     widgets/GraphvizLayout.cpp
@@ -599,7 +600,8 @@ HEADERS  += \
     widgets/R2GraphWidget.h \
     widgets/CallGraph.h \
     widgets/AddressableDockWidget.h \
-    dialogs/preferences/AnalOptionsWidget.h
+    dialogs/preferences/AnalOptionsWidget.h \
+    common/DecompilerHighlighter.h
 
 GRAPHVIZ_HEADERS = widgets/GraphvizLayout.h
 

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -724,6 +724,17 @@ void Configuration::setDecompilerAutoRefreshEnabled(bool enabled)
     s.setValue("decompilerAutoRefresh", enabled);
 }
 
+void Configuration::enableDecompilerAnnotationHighlighter(bool useDecompilerHighlighter)
+{
+    s.setValue("enableDecompilerAnnotationHighlighter", useDecompilerHighlighter);
+    emit colorsUpdated();
+}
+
+bool Configuration::isDecompilerAnnotationHighlighterEnabled()
+{
+    return s.value("enableDecompilerAnnotationHighlighter", true).value<bool>();
+}
+
 bool Configuration::getBitmapTransparentState()
 {
     return s.value("bitmapGraphExportTransparency", false).value<bool>();

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -726,13 +726,13 @@ void Configuration::setDecompilerAutoRefreshEnabled(bool enabled)
 
 void Configuration::enableDecompilerAnnotationHighlighter(bool useDecompilerHighlighter)
 {
-    s.setValue("enableDecompilerAnnotationHighlighter", useDecompilerHighlighter);
+    s.setValue("decompilerAnnotationHighlighter", useDecompilerHighlighter);
     emit colorsUpdated();
 }
 
 bool Configuration::isDecompilerAnnotationHighlighterEnabled()
 {
-    return s.value("enableDecompilerAnnotationHighlighter", true).value<bool>();
+    return s.value("decompilerAnnotationHighlighter", true).value<bool>();
 }
 
 bool Configuration::getBitmapTransparentState()

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -163,6 +163,9 @@ public:
     bool getDecompilerAutoRefreshEnabled();
     void setDecompilerAutoRefreshEnabled(bool enabled);
 
+    void enableDecompilerAnnotationHighlighter(bool useDecompilerHighlighter);
+    bool isDecompilerAnnotationHighlighterEnabled();
+
     // Graph
     int getGraphBlockMaxChars() const
     {

--- a/src/common/DecompilerHighlighter.cpp
+++ b/src/common/DecompilerHighlighter.cpp
@@ -19,14 +19,23 @@ void DecompilerHighlighter::setAnnotations(RAnnotatedCode *code)
 
 void DecompilerHighlighter::setupTheme()
 {
-    format[R_SYNTAX_HIGHLIGHT_TYPE_KEYWORD].setForeground(Config()->getColor("other"));
-    format[R_SYNTAX_HIGHLIGHT_TYPE_COMMENT].setForeground(Config()->getColor("comment"));
-    format[R_SYNTAX_HIGHLIGHT_TYPE_DATATYPE].setForeground(Config()->getColor("func_var_type"));
-    format[R_SYNTAX_HIGHLIGHT_TYPE_FUNCTION_NAME].setForeground(Config()->getColor("fname"));
-    format[R_SYNTAX_HIGHLIGHT_TYPE_FUNCTION_PARAMETER].setForeground(Config()->getColor("args"));
-    format[R_SYNTAX_HIGHLIGHT_TYPE_LOCAL_VARIABLE].setForeground(Config()->getColor("func_var"));
-    format[R_SYNTAX_HIGHLIGHT_TYPE_CONSTANT_VARIABLE].setForeground(Config()->getColor("num"));
-    format[R_SYNTAX_HIGHLIGHT_TYPE_GLOBAL_VARIABLE].setForeground(Config()->getColor("func_var"));
+    struct {
+        RSyntaxHighlightType type;
+        QString name;
+    } mapping[] = {
+        {R_SYNTAX_HIGHLIGHT_TYPE_KEYWORD, "other"},
+        {R_SYNTAX_HIGHLIGHT_TYPE_COMMENT, "comment"},
+        {R_SYNTAX_HIGHLIGHT_TYPE_DATATYPE, "func_var_type"},
+        {R_SYNTAX_HIGHLIGHT_TYPE_FUNCTION_NAME, "fname"},
+        {R_SYNTAX_HIGHLIGHT_TYPE_FUNCTION_PARAMETER, "args"},
+        {R_SYNTAX_HIGHLIGHT_TYPE_LOCAL_VARIABLE, "func_var"},
+        {R_SYNTAX_HIGHLIGHT_TYPE_CONSTANT_VARIABLE, "num"},
+        {R_SYNTAX_HIGHLIGHT_TYPE_GLOBAL_VARIABLE, "flag"},
+    };
+    for (const auto &pair : mapping) {
+        assert(pair.type < format.size());
+        format[pair.type].setForeground(Config()->getColor(pair.name));
+    }
 }
 
 void DecompilerHighlighter::highlightBlock(const QString &)
@@ -46,7 +55,7 @@ void DecompilerHighlighter::highlightBlock(const QString &)
             continue;
         }
         auto type = annotation->syntax_highlight.type;
-        if (type >= HIGHLIGHT_COUNT) {
+        if (size_t(type) >= HIGHLIGHT_COUNT) {
             continue;
         }
         auto annotationStart = annotation->start;

--- a/src/common/DecompilerHighlighter.cpp
+++ b/src/common/DecompilerHighlighter.cpp
@@ -23,7 +23,7 @@ void DecompilerHighlighter::setupTheme()
         RSyntaxHighlightType type;
         QString name;
     } mapping[] = {
-        {R_SYNTAX_HIGHLIGHT_TYPE_KEYWORD, "other"},
+        {R_SYNTAX_HIGHLIGHT_TYPE_KEYWORD, "pop"},
         {R_SYNTAX_HIGHLIGHT_TYPE_COMMENT, "comment"},
         {R_SYNTAX_HIGHLIGHT_TYPE_DATATYPE, "func_var_type"},
         {R_SYNTAX_HIGHLIGHT_TYPE_FUNCTION_NAME, "fname"},

--- a/src/common/DecompilerHighlighter.cpp
+++ b/src/common/DecompilerHighlighter.cpp
@@ -1,0 +1,62 @@
+
+#include "DecompilerHighlighter.h"
+#include "common/Configuration.h"
+
+DecompilerHighlighter::DecompilerHighlighter(QTextDocument *parent)
+    :   QSyntaxHighlighter(parent)
+{
+    setupTheme();
+    connect(Config(), &Configuration::colorsUpdated, this, [this]() {
+        setupTheme();
+        rehighlight();
+    });
+}
+
+void DecompilerHighlighter::setAnnotations(RAnnotatedCode *code)
+{
+    this->code = code;
+}
+
+void DecompilerHighlighter::setupTheme()
+{
+    format[R_SYNTAX_HIGHLIGHT_TYPE_KEYWORD].setForeground(Config()->getColor("other"));
+    format[R_SYNTAX_HIGHLIGHT_TYPE_COMMENT].setForeground(Config()->getColor("comment"));
+    format[R_SYNTAX_HIGHLIGHT_TYPE_DATATYPE].setForeground(Config()->getColor("func_var_type"));
+    format[R_SYNTAX_HIGHLIGHT_TYPE_FUNCTION_NAME].setForeground(Config()->getColor("fname"));
+    format[R_SYNTAX_HIGHLIGHT_TYPE_FUNCTION_PARAMETER].setForeground(Config()->getColor("args"));
+    format[R_SYNTAX_HIGHLIGHT_TYPE_LOCAL_VARIABLE].setForeground(Config()->getColor("func_var"));
+    format[R_SYNTAX_HIGHLIGHT_TYPE_CONSTANT_VARIABLE].setForeground(Config()->getColor("num"));
+    format[R_SYNTAX_HIGHLIGHT_TYPE_GLOBAL_VARIABLE].setForeground(Config()->getColor("func_var"));
+}
+
+void DecompilerHighlighter::highlightBlock(const QString &)
+{
+    if (!code) {
+        return;
+    }
+    auto block = currentBlock();
+    size_t start = block.position();
+    size_t end = block.position() + block.length();
+
+    std::unique_ptr<RPVector, typeof(&r_pvector_free)> annotations(r_annotated_code_annotations_range(code, start, end), &r_pvector_free);
+    void **iter;
+    r_pvector_foreach(annotations.get(), iter) {
+        RCodeAnnotation *annotation = static_cast<RCodeAnnotation*>(*iter);
+        if (annotation->type != R_CODE_ANNOTATION_TYPE_SYNTAX_HIGHLIGHT) {
+            continue;
+        }
+        auto type = annotation->syntax_highlight.type;
+        if (type >= HIGHLIGHT_COUNT) {
+            continue;
+        }
+        auto annotationStart = annotation->start;
+        if (annotationStart < start) {
+            annotationStart = 0;
+        } else {
+            annotationStart -= start;
+        }
+        auto annotationEnd = annotation->end - start;
+
+        setFormat(annotationStart, annotationEnd - annotationStart, format[type]);
+    }
+}

--- a/src/common/DecompilerHighlighter.cpp
+++ b/src/common/DecompilerHighlighter.cpp
@@ -47,7 +47,7 @@ void DecompilerHighlighter::highlightBlock(const QString &)
     size_t start = block.position();
     size_t end = block.position() + block.length();
 
-    std::unique_ptr<RPVector, typeof(&r_pvector_free)> annotations(r_annotated_code_annotations_range(code, start, end), &r_pvector_free);
+    std::unique_ptr<RPVector, decltype(&r_pvector_free)> annotations(r_annotated_code_annotations_range(code, start, end), &r_pvector_free);
     void **iter;
     r_pvector_foreach(annotations.get(), iter) {
         RCodeAnnotation *annotation = static_cast<RCodeAnnotation*>(*iter);

--- a/src/common/DecompilerHighlighter.h
+++ b/src/common/DecompilerHighlighter.h
@@ -35,8 +35,8 @@ protected:
 private:
     void setupTheme();
 
-    static const int HIGHLIGHT_COUNT= R_SYNTAX_HIGHLIGHT_TYPE_GLOBAL_VARIABLE + 1;
-    QTextCharFormat format[HIGHLIGHT_COUNT];
+    static const int HIGHLIGHT_COUNT = R_SYNTAX_HIGHLIGHT_TYPE_GLOBAL_VARIABLE + 1;
+    std::array<QTextCharFormat, HIGHLIGHT_COUNT> format;
     RAnnotatedCode *code = nullptr;
 };
 

--- a/src/common/DecompilerHighlighter.h
+++ b/src/common/DecompilerHighlighter.h
@@ -6,6 +6,7 @@
 #include <QSyntaxHighlighter>
 #include <QTextDocument>
 #include <QTextCharFormat>
+#include <array>
 
 /**
  * \brief SyntaxHighlighter based on annotations from decompiled code.

--- a/src/common/DecompilerHighlighter.h
+++ b/src/common/DecompilerHighlighter.h
@@ -1,0 +1,43 @@
+#ifndef DECOMPILER_HIGHLIGHTER_H
+#define DECOMPILER_HIGHLIGHTER_H
+
+#include "CutterCommon.h"
+#include <r_util/r_annotated_code.h>
+#include <QSyntaxHighlighter>
+#include <QTextDocument>
+#include <QTextCharFormat>
+
+/**
+ * \brief SyntaxHighlighter based on annotations from decompiled code.
+ * Can be only used in combination with DecompilerWidget.
+ */
+class CUTTER_EXPORT DecompilerHighlighter : public QSyntaxHighlighter
+{
+    Q_OBJECT
+
+public:
+    DecompilerHighlighter(QTextDocument *parent = nullptr);
+    virtual ~DecompilerHighlighter() = default;
+
+    /**
+     * @brief Set the code with annotations to be used for highlighting.
+     * 
+     * It is callers responsibility to ensure that it is synchronized with currentTextDocument and
+     * has sufficiently long lifetime.
+     * 
+     * @param code 
+     */
+    void setAnnotations(RAnnotatedCode *code);
+protected:
+    void highlightBlock(const QString &text) override;
+
+
+private:
+    void setupTheme();
+
+    static const int HIGHLIGHT_COUNT= R_SYNTAX_HIGHLIGHT_TYPE_GLOBAL_VARIABLE + 1;
+    QTextCharFormat format[HIGHLIGHT_COUNT];
+    RAnnotatedCode *code = nullptr;
+};
+
+#endif

--- a/src/dialogs/preferences/AppearanceOptionsWidget.cpp
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.cpp
@@ -67,6 +67,10 @@ AppearanceOptionsWidget::AppearanceOptionsWidget(PreferencesDialog *dialog)
         static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
         this,
         &AppearanceOptionsWidget::onFontZoomBoxValueChanged);
+
+    ui->useDecompilerHighlighter->setChecked(Config()->isDecompilerAnnotationHighlighterEnabled());
+    connect(ui->useDecompilerHighlighter, &QCheckBox::toggled,
+            this, [](bool checked){ Config()->enableDecompilerAnnotationHighlighter(checked); });
 }
 
 AppearanceOptionsWidget::~AppearanceOptionsWidget() {}

--- a/src/dialogs/preferences/AppearanceOptionsWidget.ui
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.ui
@@ -284,6 +284,16 @@
     </layout>
    </item>
    <item>
+    <widget class="QCheckBox" name="useDecompilerHighlighter">
+     <property name="toolTip">
+      <string>Use information provided by decompiler when highlighting code.</string>
+     </property>
+     <property name="text">
+      <string>Decompiler based highlighting</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -232,6 +232,8 @@ private:
      * @return True if the specified is a part of the decompiled function, False otherwise.
      */
     bool addressInRange(RVA addr);
+
+    void setCode(RAnnotatedCode *code);
 };
 
 #endif // DECOMPILERWIDGET_H

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -60,7 +60,8 @@ private:
 
     RefreshDeferrer *refreshDeferrer;
 
-    QSyntaxHighlighter *syntaxHighlighter;
+    bool usingAnnotationBasedHighlighting = false;
+    std::unique_ptr<QSyntaxHighlighter> syntaxHighlighter;
     bool decompilerSelectionEnabled;
 
     /**
@@ -234,6 +235,8 @@ private:
     bool addressInRange(RVA addr);
 
     void setCode(RAnnotatedCode *code);
+
+    void setHighlighter(bool annotationBasedHighlighter);
 };
 
 #endif // DECOMPILERWIDGET_H


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Create a syntax highlighter which uses syntax highlighting annotations from decompiler. User can choose whether to use decompiler based highlighting or ksyntaxhighlighter/fallback highlighter like before.

**Topics for discussions**

Should the new highlighter be enabled by default?
Changes to annotation <-> r2 color pallet mapping.

**Test plan (required)**

Cutter color theme:
![Screenshot from 2020-08-29 16-42-37](https://user-images.githubusercontent.com/7101031/91639372-c8fa8080-ea1e-11ea-8715-941d215c13f9.png)
ayu:
![Screenshot from 2020-08-29 16-44-42](https://user-images.githubusercontent.com/7101031/91639373-c9931700-ea1e-11ea-94e2-d0dfca44e8b4.png)

**Closing issues**

Closes #2324

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
