### PR TITLE
Remove duplicate aplication of scaling factor.

### DIFF
--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -41,7 +41,7 @@ void ColorOptionDelegate::paint(QPainter *painter,
                                 const QStyleOptionViewItem &option,
                                 const QModelIndex &index) const
 {
-    int margin = this->margin * qhelpers::devicePixelRatio(painter->device());
+    int margin = this->margin;
     painter->save();
     painter->setFont(option.font);
     painter->setRenderHint(QPainter::Antialiasing);
@@ -140,7 +140,7 @@ void ColorOptionDelegate::paint(QPainter *painter,
     // Create chess-like pattern of black and white squares
     // and fill background of roundedColorRect with it
     if (currCO.color.alpha() < 255) {
-        const int c1 = static_cast<int>(8 * qhelpers::devicePixelRatio(painter->device()));
+        const int c1 = static_cast<int>(8);
         const int c2 = c1 / 2;
         QPixmap p(c1, c1);
         QPainter paint(&p);
@@ -167,7 +167,7 @@ void ColorOptionDelegate::paint(QPainter *painter,
 
 QSize ColorOptionDelegate::sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const
 {
-    qreal margin = this->margin * qhelpers::devicePixelRatio(option.widget);
+    qreal margin = this->margin;
     qreal fontHeight = option.fontMetrics.height();
     qreal h = QPen().width();
     h += fontHeight; // option name


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

It seems the way things are currently setup, additional multiplying using pixel ratio was unnecessary and caused it to be applied twice. 

**Test plan (required)**

On screen with scaling factor that isn't 1 open theme editor, select color items in the list and make sure highlight doesn't overlap.

Tested local build on Linux with wayland and Windows. In case of Windows items weren't overlapping before, but after the changes item size relative to rest of widgets in windows was closer to what it is when display scaling factor is 1.

Will need to retest using builds from CI.


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**
closes #1826