### PR TITLE
Switch to previous appveyor image.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 version: '1.12.0-git-{build}'
-image: 'Visual Studio 2019'
+image: 'Previous Visual Studio 2019'
 clone_depth: 1
 
 # Build configuration


### PR DESCRIPTION


<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

The latest one has updated Visual Studio and it's standard library headers can't be parsed by shiboken in current version of cutter-deps. Rebulding cutter-deps against newer clang would probably also work, but that can be done next time appveyor image gets updated or we have other reason for updating cutter-deps.


**Test plan (required)**

All windows appveyor builds are green.

**Closing issues**

Windows half of #2479
