### PR TITLE
Move Ubuntu 16.04 sytem dependencies build to GHA.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -15,12 +15,18 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-16.04, macos-latest, windows-latest]
         python-version: [3.7.x]
+        system-deps: [false]
+        cc-override: [default]
+        cxx-override: [default]
+        include:
+          - os: ubuntu-16.04
+            python-version: 3.5.10
+            system-deps: true
+            cc-override: '/usr/bin/gcc-5'
+            cxx-override: '/usr/bin/g++-5'
       # Prevent one job from pausing the rest
       fail-fast: false
     steps:
-    - uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
     - uses: actions/checkout@v2
       with:
         submodules: true # 'recursive' 'true' or 'false'
@@ -28,19 +34,36 @@ jobs:
     - name: apt dependencies
       if: contains(matrix.os, 'ubuntu')
       run: |
-        if [[ "${{ matrix.os }}" = "ubuntu-18.04" ]]
-        then
-          # github action VMs currently have broken package list causing install to fail, run update to refresh it
-          # remove this once fixed
-          sudo apt-get update
-        fi
         sudo apt-get install libgraphviz-dev mesa-common-dev
         if [[ "${{ matrix.os }}" = "ubuntu-16.04" ]]
         then
-          sudo apt-get install ninja-build/xenial-backports
+          sudo apt-get install ninja-build/xenial-backports 
+          if [[ "${{ matrix.system-deps }}" = "true" ]]
+          then
+            sudo apt-get install cmake
+            sudo apt-get install --allow-downgrades \
+                g++-5=5.4.\* \
+                gcc-5=5.4.\* \
+                gcc-5-base=5.4.\* \
+                libstdc++-5-dev=5.4.\* \
+                cpp-5=5.4.\* \
+                libgcc-5-dev=5.4.\* \
+                libasan2=5.4.\* \
+                libmpx0=5.4.\*
+           fi
+           # make sure cmake that was just installed is at the front of path before
+           # additiona software installed by GitHub
+           echo /usr/bin >> $GITHUB_PATH
         else
           sudo apt-get install ninja-build
         fi
+        if [[ "${{ matrix.system-deps }}" = "true" ]]
+        then
+          sudo apt-get install qt5-default libqt5svg5-dev qttools5-dev qttools5-dev-tools
+        fi
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: homebrew dependencies
       if: contains(matrix.os, 'macos')
       run: |
@@ -56,24 +79,46 @@ jobs:
     - name: cmake ubuntu
       if: contains(matrix.os, 'ubuntu')
       run: |
-        scripts/fetch_deps.sh
-        source cutter-deps/env.sh
-        export LD_LIBRARY_PATH="`llvm-config --libdir`:$LD_LIBRARY_PATH"
+        if [[ "${{ matrix.system-deps }}" = "false" ]]
+        then
+          scripts/fetch_deps.sh
+          source cutter-deps/env.sh
+          export PKG_CONFIG_PATH="$CUTTER_DEPS_PYTHON_PREFIX/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+          export LD_LIBRARY_PATH="`llvm-config --libdir`:$LD_LIBRARY_PATH"
+        fi
+        set -euo pipefail #TODO: move to top once cutter-deps doesn't fail
+        if [[ "${{ matrix.cc-override }}" != "default" ]]
+        then
+          export CC="${{matrix.cc-override}}"
+          export CXX="${{matrix.cxx-override}}"
+        fi
+
         source scripts/prepare_breakpad_linux.sh
-        export PKG_CONFIG_PATH="$CUSTOM_BREAKPAD_PREFIX/lib/pkgconfig:$CUSTOM_PYTHON_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
+        export PKG_CONFIG_PATH="$CUSTOM_BREAKPAD_PREFIX/lib/pkgconfig:${PKG_CONFIG_PATH:-}" #
         mkdir build
         cd build
-        cmake \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DPYTHON_LIBRARY="$CUTTER_DEPS_PYTHON_PREFIX/lib/libpython3.6m.so.1.0" \
-                -DPYTHON_INCLUDE_DIR="$CUTTER_DEPS_PYTHON_PREFIX/include/python3.6m" \
-                -DPYTHON_EXECUTABLE="$CUTTER_DEPS_PYTHON_PREFIX/bin/python3" \
-                -DCUTTER_ENABLE_PYTHON=ON \
-                -DCUTTER_ENABLE_PYTHON_BINDINGS=OFF \
-                -DCUTTER_ENABLE_CRASH_REPORTS=ON \
-                -DCUTTER_USE_BUNDLED_RADARE2=ON \
-                ../src && \
-            make -j4
+        cmake --version
+        if [[ "${{ matrix.system-deps }}" = "false" ]]
+        then
+          cmake \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCUTTER_ENABLE_PYTHON=ON \
+            -DPYTHON_LIBRARY="$CUTTER_DEPS_PYTHON_PREFIX/lib/libpython3.6m.so.1.0" \
+            -DPYTHON_INCLUDE_DIR="$CUTTER_DEPS_PYTHON_PREFIX/include/python3.6m" \
+            -DPYTHON_EXECUTABLE="$CUTTER_DEPS_PYTHON_PREFIX/bin/python3" \
+            -DCUTTER_ENABLE_PYTHON_BINDINGS=OFF \
+            -DCUTTER_ENABLE_CRASH_REPORTS=ON \
+            -DCUTTER_USE_BUNDLED_RADARE2=ON \
+            ../src
+        else
+          cmake \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCUTTER_USE_BUNDLED_RADARE2=ON \
+            ../src
+        fi
+        ninja
     - name: cmake macos
       shell: bash
       if: contains(matrix.os, 'macos')

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -52,7 +52,7 @@ jobs:
                 libmpx0=5.4.\*
            fi
            # make sure cmake that was just installed is at the front of path before
-           # additiona software installed by GitHub
+           # additional software installed by GitHub
            echo /usr/bin >> $GITHUB_PATH
         else
           sudo apt-get install ninja-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,24 +54,24 @@ matrix:
          - libxkbcommon-x11-dev
          - ninja-build/xenial-backports
 
-  - name: Linux Ubuntu 16.04 # test that Cutter can be built on an old distro using system libraries
-    os: linux
-    env: BUILD_SYSTEM=cmake_nodep PATH="/usr/bin:$PATH"
-    dist: xenial
-    addons:
-      apt:
-        packages:
-         - ninja-build
-         - libgraphviz-dev
-         - qt5-default
-         - libqt5svg5-dev
-         - qttools5-dev
-         - qttools5-dev-tools
-         - cmake
-    before_install:
-      - pyenv install 3.5.2
-      - pyenv global 3.5.2
-      - pip install meson==0.52.1
+  #- name: Linux Ubuntu 16.04 # test that Cutter can be built on an old distro using system libraries
+  #  os: linux
+  #  env: BUILD_SYSTEM=cmake_nodep PATH="/usr/bin:$PATH"
+  #  dist: xenial
+  #  addons:
+  #    apt:
+  #      packages:
+  #       - ninja-build
+  #       - libgraphviz-dev
+  #       - qt5-default
+  #       - libqt5svg5-dev
+  #       - qttools5-dev
+  #       - qttools5-dev-tools
+  #       - cmake
+  #  before_install:
+  #    - pyenv install 3.5.2
+  #    - pyenv global 3.5.2
+  #    - pip install meson==0.52.1
 
 
   - name: macOS QMake + Deploy

--- a/scripts/prepare_breakpad_linux.sh
+++ b/scripts/prepare_breakpad_linux.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
+set -euo pipefail
+
 git clone https://github.com/google/breakpad.git
 cd breakpad
 git clone https://chromium.googlesource.com/linux-syscall-support src/third_party/lss
-CFLAGS=-w CXXFLAGS=-w ./configure --prefix=`pwd`/prefix && make -j4 && make install || exit 1
+CFLAGS=-w CXXFLAGS=-w ./configure --disable-tools --prefix=`pwd`/prefix && make -j4 && make install || exit 1
 
 export CUSTOM_BREAKPAD_PREFIX="`pwd`/prefix"
 cd ..


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Since Travis changed their rules for free plans move builds to GHA.

* Downgrade some of the software installed on Github VMs to better match
what's available on Ubuntu 16.04
* Disable breakpad tools, we dont use them and some of them require fresh linux kernel for compilation.

**Test plan (required)**

* The new build is correctly listed and works
* Make sure cmake version printed matches with what should be on Ubuntu 16.04 by default
* gcc version used is 5.4

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->