### PR TITLE
Cutter, fix build for Haiku which doesn't have O_ASYNC yet

### DIFF
--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -434,6 +434,11 @@ void ConsoleWidget::processQueuedOutput()
     }
 }
 
+// Haiku doesn't have O_ASYNC
+#ifdef Q_OS_HAIKU
+#define O_ASYNC O_NONBLOCK
+#endif
+
 void ConsoleWidget::redirectOutput()
 {
     // Make sure that we are running in a valid console with initialized output handles


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Haiku doesn't have O_ASYNC yet, this fixes the build (with the latest radare2 release)

**Test plan (required)**

![Cutter](https://user-images.githubusercontent.com/16057090/99964844-3d318f80-2d94-11eb-9dc0-c2031126f148.png)

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
