### PR TITLE
Don't depend on unmaintained homebrew repository.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -70,6 +70,7 @@ jobs:
         cd scripts
         brew update --preinstall # temporary workaround for https://github.com/Homebrew/homebrew-bundle/issues/751
         brew bundle
+        brew install coreutils
         brew install pkg-config
     - name: py dependencies
       run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -70,8 +70,6 @@ jobs:
         cd scripts
         brew update --preinstall # temporary workaround for https://github.com/Homebrew/homebrew-bundle/issues/751
         brew bundle
-        brew tap iveney/mocha
-        brew install realpath
         brew install pkg-config
     - name: py dependencies
       run: |


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

The specific homebrew tap(repository) is broken and causes macOS GHA builds to fail.

**Test plan (required)**

GHA macOS build is fixed and no errors introduced by lack of realpath.

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
