### PR TITLE
Fix Warnings by g++ 10.2

### DIFF
--- a/src/common/Decompiler.cpp
+++ b/src/common/Decompiler.cpp
@@ -57,7 +57,7 @@ void R2DecDecompiler::decompileAt(RVA addr)
             if (lineObject.isEmpty()) {
                 continue;
             }
-            RzCodeAnnotation annotationi = { 0 };
+            RzCodeAnnotation annotationi = {};
             annotationi.start = codeString.length();
             codeString.append(lineObject["str"].toString() + "\n");
             annotationi.end = codeString.length();

--- a/src/widgets/ExportsWidget.cpp
+++ b/src/widgets/ExportsWidget.cpp
@@ -117,10 +117,13 @@ bool ExportsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &rig
             return leftExp.vaddr < rightExp.vaddr;
     // fallthrough
     case ExportsModel::NameColumn:
-        return leftExp.name < rightExp.name;
+        if (leftExp.name != rightExp.name)
+            return leftExp.name < rightExp.name;
+    // fallthrough
     case ExportsModel::TypeColumn:
         if (leftExp.type != rightExp.type)
             return leftExp.type < rightExp.type;
+    // fallthrough
     case ExportsModel::CommentColumn:
         return Core()->getCommentAt(leftExp.vaddr) < Core()->getCommentAt(rightExp.vaddr);
     default:

--- a/src/widgets/GraphGridLayout.cpp
+++ b/src/widgets/GraphGridLayout.cpp
@@ -1336,7 +1336,7 @@ static void optimizeLinearProgramPass(
         int g = queue.top().second;
         int size = queue.top().first;
         queue.pop();
-        if (size != edgeCount[g] || processed[g]) {
+        if ((size_t)size != edgeCount[g] || processed[g]) {
             continue;
         }
         int direction = objectiveFunction[g];

--- a/src/widgets/ImportsWidget.cpp
+++ b/src/widgets/ImportsWidget.cpp
@@ -143,7 +143,7 @@ bool ImportsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &rig
     case ImportsModel::LibraryColumn:
         if (leftImport.libname != rightImport.libname)
             return leftImport.libname < rightImport.libname;
-    // Fallthrough. Sort by Library and then by import name
+    // fallthrough
     case ImportsModel::NameColumn:
         return leftImport.name < rightImport.name;
     case ImportsModel::CommentColumn:


### PR DESCRIPTION
reported by g++ 10.2:
```
../src/widgets/ExportsWidget.cpp: In member function ‘virtual bool ExportsProxyModel::lessThan(const QModelIndex&, const QModelIndex&) const’:
../src/widgets/ExportsWidget.cpp:122:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
  122 |         if (leftExp.type != rightExp.type)
      |         ^~
../src/widgets/ExportsWidget.cpp:124:5: note: here
  124 |     case ExportsModel::CommentColumn:
      |     ^~~~
[30/117] Building CXX object src/CMakeFiles/Cutter.dir/widgets/ImportsWidget.cpp.o
../src/widgets/ImportsWidget.cpp: In member function ‘virtual bool ImportsProxyModel::lessThan(const QModelIndex&, const QModelIndex&) const’:
../src/widgets/ImportsWidget.cpp:144:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
  144 |         if (leftImport.libname != rightImport.libname)
      |         ^~
../src/widgets/ImportsWidget.cpp:147:5: note: here
  147 |     case ImportsModel::NameColumn:
      |     ^~~~
[99/117] Building CXX object src/CMakeFiles/Cutter.dir/common/Decompiler.cpp.o
../src/common/Decompiler.cpp: In lambda function:
../src/common/Decompiler.cpp:60:48: warning: missing initializer for member ‘rz_code_annotation_t::end’ [-Wmissing-field-initializers]
   60 |             RzCodeAnnotation annotationi = { 0 };
      |                                                ^
../src/common/Decompiler.cpp:60:48: warning: missing initializer for member ‘rz_code_annotation_t::type’ [-Wmissing-field-initializers]
../src/common/Decompiler.cpp:60:48: warning: missing initializer for member ‘rz_code_annotation_t::<anonymous>’ [-Wmissing-field-initializers]
[109/117] Building CXX object src/CMakeFiles/Cutter.dir/widgets/GraphGridLayout.cpp.o
../src/widgets/GraphGridLayout.cpp: In function ‘void optimizeLinearProgramPass(size_t, std::vector<int>, std::vector<std::pair<std::pair<int, int>, int> >, std::vector<std::pair<std::pair<int, int>, int> >, std::vector<int>&, bool)’:
../src/widgets/GraphGridLayout.cpp:1339:18: warning: comparison of integer expressions of different signedness: ‘int’ and ‘__gnu_cxx::__alloc_traits<std::allocator<long unsigned int>, long unsigned int>::value_type’ {aka ‘long unsigned int’} [-Wsign-compare]
 1339 |         if (size != edgeCount[g] || processed[g]) {
```