### PR TITLE
Add Setting for Minimum Font Size in Graphs

### DIFF
--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -173,6 +173,16 @@ public:
         s.setValue("graph.maxcols", ch);
     }
 
+    int getGraphMinFontSize() const
+    {
+        return s.value("graph.minfontsize", 4).toInt();
+    }
+
+    void setGraphMinFontSize(int sz)
+    {
+        s.setValue("graph.minfontsize", sz);
+    }
+
     /**
      * @brief Getters and setters for the transaparent option state and scale factor for bitmap graph exports.
      */

--- a/src/dialogs/preferences/GraphOptionsWidget.cpp
+++ b/src/dialogs/preferences/GraphOptionsWidget.cpp
@@ -43,6 +43,9 @@ void GraphOptionsWidget::updateOptionsFromVars()
     ui->maxColsSpinBox->blockSignals(true);
     ui->maxColsSpinBox->setValue(Config()->getGraphBlockMaxChars());
     ui->maxColsSpinBox->blockSignals(false);
+    ui->minFontSizeSpinBox->blockSignals(true);
+    ui->minFontSizeSpinBox->setValue(Config()->getGraphMinFontSize());
+    ui->minFontSizeSpinBox->blockSignals(false);
     auto blockSpacing = Config()->getGraphBlockSpacing();
     ui->horizontalBlockSpacing->setValue(blockSpacing.x());
     ui->verticalBlockSpacing->setValue(blockSpacing.y());
@@ -62,6 +65,12 @@ void GraphOptionsWidget::triggerOptionsChanged()
 void GraphOptionsWidget::on_maxColsSpinBox_valueChanged(int value)
 {
     Config()->setGraphBlockMaxChars(value);
+    triggerOptionsChanged();
+}
+
+void GraphOptionsWidget::on_minFontSizeSpinBox_valueChanged(int value)
+{
+    Config()->setGraphMinFontSize(value);
     triggerOptionsChanged();
 }
 

--- a/src/dialogs/preferences/GraphOptionsWidget.h
+++ b/src/dialogs/preferences/GraphOptionsWidget.h
@@ -30,6 +30,7 @@ private slots:
     void updateOptionsFromVars();
 
     void on_maxColsSpinBox_valueChanged(int value);
+    void on_minFontSizeSpinBox_valueChanged(int value);
     void on_graphOffsetCheckBox_toggled(bool checked);
 
     void checkTransparentStateChanged(int checked);

--- a/src/dialogs/preferences/GraphOptionsWidget.ui
+++ b/src/dialogs/preferences/GraphOptionsWidget.ui
@@ -43,15 +43,15 @@
          </widget>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
            <widget class="QLabel" name="maxColsLabel">
             <property name="text">
              <string>Maximum Line Length:</string>
             </property>
            </widget>
           </item>
-          <item>
+          <item row="0" column="1">
            <widget class="QSpinBox" name="maxColsSpinBox">
             <property name="minimum">
              <number>25</number>
@@ -61,6 +61,23 @@
             </property>
             <property name="value">
              <number>100</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="minFontSizeLabel">
+            <property name="text">
+             <string>Minimum Font Size to Show (Higher values increase Performance):</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="minFontSizeSpinBox">
+            <property name="maximum">
+             <number>4</number>
+            </property>
+            <property name="value">
+             <number>4</number>
             </property>
            </widget>
           </item>

--- a/src/dialogs/preferences/GraphOptionsWidget.ui
+++ b/src/dialogs/preferences/GraphOptionsWidget.ui
@@ -80,7 +80,7 @@
              <string>Hide text when zooming out and it is smaller than the given value. Higher values can increase Performance.</string>
             </property>
             <property name="maximum">
-             <number>4</number>
+             <number>8</number>
             </property>
             <property name="value">
              <number>4</number>

--- a/src/dialogs/preferences/GraphOptionsWidget.ui
+++ b/src/dialogs/preferences/GraphOptionsWidget.ui
@@ -66,13 +66,19 @@
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="minFontSizeLabel">
+            <property name="toolTip">
+             <string>Hide text when zooming out and it is smaller than the given value. Higher values can increase Performance.</string>
+            </property>
             <property name="text">
-             <string>Minimum Font Size to Show (Higher values increase Performance):</string>
+             <string>Minimum Font Size</string>
             </property>
            </widget>
           </item>
           <item row="1" column="1">
            <widget class="QSpinBox" name="minFontSizeSpinBox">
+            <property name="toolTip">
+             <string>Hide text when zooming out and it is smaller than the given value. Higher values can increase Performance.</string>
+            </property>
             <property name="maximum">
              <number>4</number>
             </property>

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -413,7 +413,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block,
     auto transform = p.combinedTransform();
     QRect screenChar = transform.mapRect(QRect(0, 0, charWidth, charHeight));
 
-    if (screenChar.width() * qhelpers::devicePixelRatio(p.device()) < Config()->getGraphMinFontSize()) {
+    if (screenChar.width() < Config()->getGraphMinFontSize()) {
         return;
     }
 

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -413,7 +413,7 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block,
     auto transform = p.combinedTransform();
     QRect screenChar = transform.mapRect(QRect(0, 0, charWidth, charHeight));
 
-    if (screenChar.width() * qhelpers::devicePixelRatio(p.device()) < 4) {
+    if (screenChar.width() * qhelpers::devicePixelRatio(p.device()) < Config()->getGraphMinFontSize()) {
         return;
     }
 

--- a/src/widgets/SimpleTextGraphView.cpp
+++ b/src/widgets/SimpleTextGraphView.cpp
@@ -114,7 +114,7 @@ void SimpleTextGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block, b
     auto transform = p.combinedTransform();
     QRect screenChar = transform.mapRect(QRect(0, 0, charWidth, charHeight));
 
-    if (screenChar.width() * qhelpers::devicePixelRatio(p.device()) < 4) {
+    if (screenChar.width() * qhelpers::devicePixelRatio(p.device()) < Config()->getGraphMinFontSize()) {
         return;
     }
 

--- a/src/widgets/SimpleTextGraphView.cpp
+++ b/src/widgets/SimpleTextGraphView.cpp
@@ -114,7 +114,7 @@ void SimpleTextGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block, b
     auto transform = p.combinedTransform();
     QRect screenChar = transform.mapRect(QRect(0, 0, charWidth, charHeight));
 
-    if (screenChar.width() * qhelpers::devicePixelRatio(p.device()) < Config()->getGraphMinFontSize()) {
+    if (screenChar.width() < Config()->getGraphMinFontSize()) {
         return;
     }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Adds this option:
![20201218_14h31m01s_grim](https://user-images.githubusercontent.com/1460997/102620105-c6db3f80-413d-11eb-8d39-e3061dd15c9f.png)

**Test plan (required)**

Try different values and zoom out in the CFG Graph and "Rizin graphs":

Lower values, small text still shown:
![20201218_14h32m10s_grim](https://user-images.githubusercontent.com/1460997/102620197-f2f6c080-413d-11eb-81ab-38f0f4cd9b57.png)

Higher values, smaller text not rendered:
![20201218_14h32m28s_grim](https://user-images.githubusercontent.com/1460997/102620236-0013af80-413e-11eb-8fbe-da7ce5df2e53.png)