### PR TITLE
Fix debug seek to PC with newshell

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1581,7 +1581,7 @@ RVA CutterCore::getProgramCounterValue()
     if (currentlyDebugging) {
         // Use cmd because cmdRaw would not work with inner command backticked
         // TODO: Risky command due to changes in API, search for something safer
-        RVA addr = cmd("dr?`drn PC`").toULongLong(&ok, 16);
+        RVA addr = cmd("dr `drn PC`").toULongLong(&ok, 16);
         if (ok) {
             return addr;
         }
@@ -1746,9 +1746,7 @@ void CutterCore::attachRemote(const QString &uri)
                 connected = true;
             }
         }
-        // Use cmd because cmdRaw would not with inner command backticked
-        QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-        seekAndShow(programCounterValue);
+        seekAndShow(getProgramCounterValue());
         if (!connected) {
             emit attachedRemote(false);
             emit debugTaskStateChanged();
@@ -1868,9 +1866,7 @@ void CutterCore::stopDebug()
 
 void CutterCore::syncAndSeekProgramCounter()
 {
-    // Use cmd because cmdRaw would not work with inner command backticked
-    QString programCounterValue = cmd("dr?`drn PC`").trimmed();
-    seekAndShow(programCounterValue);
+    seekAndShow(getProgramCounterValue());
     emit registersChanged();
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

``` dr?`drn PC` ``` returns the help message for `dr?` in newshell, ``` dr `drn PC` ``` works for both.

**Test plan (required)**

Step in debug and see that seek works.
