### PR TITLE
git clone: show progress + make shallow clone (PR 2)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -85,7 +85,7 @@ if [ $? -eq 1 ]; then
     read -r answer
     if [ -z "$answer" ] || [ "$answer" = "Y" ] || [ "$answer" = "y" ]; then
         RZPREFIX=${1:-"/usr"}
-        git submodule init && git submodule update
+        git submodule init && git submodule update --progress --depth 1
         cd rizin || exit 1
         ./sys/install.sh "$RZPREFIX"
         cd ..


### PR DESCRIPTION
replace #2477

the file `cutter/src/cmake/Packaging.cmake` seems to be gone

in the cmake command `ExternalProject_Add`
we can set shallow-clone and progressbar with

```
            ExternalProject_Add(R2Ghidra

                GIT_SHALLOW TRUE
                GIT_PROGRESS TRUE
```
