### PR TITLE
Enable macOS adhoc signing.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -185,6 +185,7 @@ jobs:
                 -DCUTTER_ENABLE_DEPENDENCY_DOWNLOADS=ON \
                 -DCUTTER_PACKAGE_RZ_GHIDRA=ON \
                 -DCMAKE_FRAMEWORK_PATH="$BREAKPAD_FRAMEWORK_DIR" \
+                -DCPACK_BUNDLE_APPLE_CERT_APP="-" \
                 .. && \
               make -j4;
         make package

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -48,6 +48,10 @@ if(APPLE)
 	set(CPACK_DMG_BACKGROUND_IMAGE "${CMAKE_CURRENT_SOURCE_DIR}/macos/cutter_mac_app.png")
 	set(CPACK_DMG_DS_STORE "${CMAKE_CURRENT_SOURCE_DIR}/macos/DS_Store_ForDMGBackground")
 	set(CPACK_BUNDLE_APPLE_ENTITLEMENTS "${CMAKE_CURRENT_SOURCE_DIR}/macos/Entitlements.plist")
+	set(CPACK_APPLE_BUNDLE_ID "re.rizin.cutter")
+	if (CUTTER_ENABLE_CRASH_REPORTS)
+		list(APPEND CPACK_BUNDLE_APPLE_CODESIGN_FILES "/Contents/Frameworks/Breakpad.framework/Versions/Current/Resources/breakpadUtilities.dylib")
+	endif()
 
 
 	find_program(MACDEPLOYQT_PATH macdeployqt HINTS "${Qt5_DIR}/../../../bin")

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -47,6 +47,7 @@ if(APPLE)
 	set(CPACK_BUNDLE_ICON "${CMAKE_CURRENT_SOURCE_DIR}/macos/cutter.icns")
 	set(CPACK_DMG_BACKGROUND_IMAGE "${CMAKE_CURRENT_SOURCE_DIR}/macos/cutter_mac_app.png")
 	set(CPACK_DMG_DS_STORE "${CMAKE_CURRENT_SOURCE_DIR}/macos/DS_Store_ForDMGBackground")
+	set(CPACK_BUNDLE_APPLE_ENTITLEMENTS "${CMAKE_CURRENT_SOURCE_DIR}/macos/Entitlements.plist")
 
 
 	find_program(MACDEPLOYQT_PATH macdeployqt HINTS "${Qt5_DIR}/../../../bin")

--- a/dist/appbundle_embed_python.sh
+++ b/dist/appbundle_embed_python.sh
@@ -21,7 +21,7 @@ then
     echo "Cleaning up embedded Python Framework"
     cd "$appbundle/Contents/Frameworks/Python.framework"
     find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
-    rm -r Versions/Current/Resources/* "Versions/Current/lib/$python_version/test" "Versions/Current/lib/$python_version/idlelib" "Versions/Current/lib/$python_version/curses" "Versions/Current/lib/$python_version/lib2to3" || echo "Couldn't remove something"
+    rm -r Versions/Current/Resources/Python.app "Versions/Current/lib/$python_version/test" "Versions/Current/lib/$python_version/idlelib" "Versions/Current/lib/$python_version/curses" "Versions/Current/lib/$python_version/lib2to3" || echo "Couldn't remove something"
 else
     echo "Python.framework already exists, skipping copying"
     cd "$appbundle/Contents/Frameworks/Python.framework"
@@ -48,4 +48,3 @@ then
 else
     echo "site-packages/Pyside2 exists, skipping copying"
 fi
-

--- a/dist/macos/Entitlements.plist
+++ b/dist/macos/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.debugger</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Doesn't help with macOS complaining about unknown developer, but might help with entitlements. Running adhoc signing also helps testing if there isn't anything else that prevents codesign from working.

Don't delete too much from Python.framework as that prevents codesign from recognizing it and causes code sign to fail with error similar to:
```
./Cutter.app: bundle format unrecognized, invalid, or unsuitable
In subcomponent: Cutter.app/Contents/Frameworks/Python.framework
```



**Test plan (required)**

* Download dmg artefact
* codesign -vvvv Cutter.app
* Test if debugger works. Some debugging functionality might be broken since it wasn't runnable for a long time, but at least opening the debug port should succeed.

**Closing issues**

#2220
