### PR TITLE
Offer a default function name in actionAnalyzeFunction input box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ src/*_automoc.cpp
 *CMakeCache.txt*
 *cmake_install.cmake*
 src/CMakeFiles/*
+CMakeSettings.json
 
 # Prepare_r2
 ninja.exe

--- a/dist/WindowsBundleQt.cmake
+++ b/dist/WindowsBundleQt.cmake
@@ -1,10 +1,14 @@
 message("Running windeployqt")
-execute_process(COMMAND windeployqt cutter.exe
+find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS "${_qt_bin_dir}")
+if(NOT WINDEPLOYQT_EXECUTABLE)
+	message(FATAL_ERROR "Failed to find windeployqt")
+endif()
+execute_process(COMMAND "${WINDEPLOYQT_EXECUTABLE}" cutter.exe
         --plugindir "qtplugins"
         --no-translations # Cutter currently isn't loading Qt translation file
     WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}
     RESULT_VARIABLE SCRIPT_RESULT)
 if (SCRIPT_RESULT)
-    message(FATAL_ERROR "Failed to bundle python")
+    message(FATAL_ERROR "Failed to bundle qt")
 endif()
 file(WRITE "${CMAKE_INSTALL_PREFIX}/qt.conf" "[PATHS]\nPlugins = qtplugins")

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1247,7 +1247,7 @@ QString CutterCore::createFunctionAt(RVA addr)
 
 QString CutterCore::createFunctionAt(RVA addr, QString name)
 {
-    static const QRegularExpression regExp("[^a-zA-Z0-9_]");
+    static const QRegularExpression regExp("[^a-zA-Z0-9_.]");
     name.remove(regExp);
     QString ret = cmdRawAt(QString("af %1").arg(name), addr);
     emit functionsChanged();
@@ -3613,9 +3613,7 @@ QString CutterCore::nearestFlag(RVA offset, RVA *flagOffsetOut)
     QString name = r.value("name").toString();
     if (flagOffsetOut) {
         auto offsetValue = r.value("offset");
-        *flagOffsetOut = offsetValue.isUndefined()
-            ? offset
-            : offsetValue.toVariant().toULongLong();
+        *flagOffsetOut = offsetValue.isUndefined() ? offset : offsetValue.toVariant().toULongLong();
     }
     return name;
 }

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3612,8 +3612,10 @@ QString CutterCore::nearestFlag(RVA offset, RVA *flagOffsetOut)
     auto r = cmdj(QString("fdj @") + QString::number(offset)).object();
     QString name = r.value("name").toString();
     if (flagOffsetOut) {
-        int queryOffset = r.value("offset").toInt(0);
-        *flagOffsetOut = offset + static_cast<RVA>(-queryOffset);
+        auto offsetValue = r.value("offset");
+        *flagOffsetOut = offsetValue.isUndefined()
+            ? offset
+            : offsetValue.toVariant().toULongLong();
     }
     return name;
 }

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -819,7 +819,7 @@ void DisassemblyContextMenu::on_actionAnalyzeFunction_triggered()
         if (pfx.isEmpty()) {
             pfx = QString("fcn");
         }
-        name = pfx + "." + RAddressString(offset);
+        name = pfx + QString::asprintf(".%llx", offset);
     }
 
     // Create dialog

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -811,10 +811,21 @@ void DisassemblyContextMenu::on_actionAddComment_triggered()
 void DisassemblyContextMenu::on_actionAnalyzeFunction_triggered()
 {
     bool ok;
+    RVA flagOffset;
+    QString name = Core()->nearestFlag(offset, &flagOffset);
+    if (name.isEmpty() || flagOffset != offset) {
+        // Create a default name for the function
+        QString pfx = Config()->getConfigString("analysis.fcnprefix");
+        if (pfx.isEmpty()) {
+            pfx = QString("fcn");
+        }
+        name = pfx + "." + RAddressString(offset);
+    }
+
     // Create dialog
     QString functionName =
-            QInputDialog::getText(this, tr("New function %1").arg(RAddressString(offset)),
-                                  tr("Function name:"), QLineEdit::Normal, QString(), &ok);
+            QInputDialog::getText(this, tr("New function at %1").arg(RAddressString(offset)),
+                                  tr("Function name:"), QLineEdit::Normal, name, &ok);
 
     // If user accepted
     if (ok && !functionName.isEmpty()) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
* Fix WindowsBundleQt if windeployqt not in PATH
* Add CMakeSettings.json to .gitignore
* Fix `CutterCore::nearestFlag()` flagOffsetOut output (use `toVariant().toULongLong()` instead of `toInt()`)
* Offer a default function name in actionAnalyzeFunction input box
  - Use flag name if exists at address of new function.
  - If flag doesn't exist, generate a default name.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->
1. Open a binary (analysis disabled)
2. Go to disassembly
3. Seek to some flag
4. Right-click on the flag and click on `Define function here`
5. Verify `New function` dialog gets pre-populated with the flag name
6. Right-click on a address without a flag
7. Verify `New function` dialog gets pre-populated a generated name based of the `analysis.fcnprefix` config var and the address
<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->


<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
