### PR TITLE
Change Executable to Lowercase and use re.rizin.cutter everywhere

### DIFF
--- a/dist/MacOSBundlePython.cmake.in
+++ b/dist/MacOSBundlePython.cmake.in
@@ -12,7 +12,7 @@ execute_process(COMMAND
 	"${EMBED_PYTHON_SH}"
 	"${PYTHON_FRAMEWORK_DIR}"
 	"${BUNDLE_PATH}"
-	"${BUNDLE_PATH}/Contents/MacOS/Cutter"
+	"${BUNDLE_PATH}/Contents/MacOS/cutter"
     RESULT_VARIABLE SCRIPT_RESULT)
 if(SCRIPT_RESULT)
     message(FATAL_ERROR "Failed to bundle python")

--- a/dist/MacOSSetupBundle.cmake.in
+++ b/dist/MacOSSetupBundle.cmake.in
@@ -39,7 +39,7 @@ foreach(_lib ${ADJUST_RIZIN_LIBS})
 	# Cutter reference to lib
 	run_or_die(COMMAND install_name_tool
 		-change "${_lib}" "@rpath/${_name}"
-		"${EXECUTABLE_DIR}/Cutter")
+		"${EXECUTABLE_DIR}/cutter")
 	# lib LC_ID_DYLIB
 	run_or_die(COMMAND install_name_tool
 			-id "@rpath/${_name}"	
@@ -57,10 +57,10 @@ endforeach()
 # Add rpaths because macdeployqt fails to do that properly
 run_or_die(COMMAND install_name_tool
 	-add_rpath "@executable_path/../Frameworks"
-	"${EXECUTABLE_DIR}/Cutter")
+	"${EXECUTABLE_DIR}/cutter")
 run_or_die(COMMAND install_name_tool
 	-add_rpath "@executable_path/../Resources/lib"
-	"${EXECUTABLE_DIR}/Cutter")
+	"${EXECUTABLE_DIR}/cutter")
 
 set(MACDEPLOYQT_COMMAND "${MACDEPLOYQT_PATH}" "${BUNDLE_PATH}" "-verbose=2" "-libpath=${CMAKE_INSTALL_PREFIX}/lib")
 message("Running macdeployqt \"${MACDEPLOYQT_COMMAND}\"")

--- a/dist/WindowsBundleQt.cmake
+++ b/dist/WindowsBundleQt.cmake
@@ -1,5 +1,5 @@
 message("Running windeployqt")
-execute_process(COMMAND windeployqt Cutter.exe
+execute_process(COMMAND windeployqt cutter.exe
         --plugindir "qtplugins"
         --no-translations # Cutter currently isn't loading Qt translation file
     WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,4 +6,4 @@ usermod -u $LOCAL_USER_ID $USERNAME
 usermod -g $LOCAL_GROUP_ID $USERNAME
 export HOME=/home/$USERNAME
 
-exec su-exec $USERNAME "/opt/cutter/build/Cutter" $@
+exec su-exec $USERNAME "/opt/cutter/build/cutter" $@

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -101,7 +101,7 @@ You can now execute Cutter like this:
 
 .. code:: sh
 
-   ./build/Cutter
+   ./build/cutter
 
 
 Building on Windows
@@ -249,9 +249,9 @@ containing bin/, lib/, include/, etc.) and specify it to CMake using
 
 * **Rizin's librz_*.so cannot be found when running Cutter**
 
-   ./Cutter: error while loading shared libraries: librz_lang.so: cannot open shared object file: No such file or directory
+   ./cutter: error while loading shared libraries: librz_lang.so: cannot open shared object file: No such file or directory
 
-The exact Rizin .so file that cannot be found may vary. On some systems, the linker by default uses RUNPATH instead of RPATH which is incompatible with the way Rizin is currently compiled. It results in some of the Rizin libraries not being found when running cutter. You can verify if this is the problem by running `ldd ./Cutter`. If all the Rizin libraries are missing you have a different problem.
+The exact Rizin .so file that cannot be found may vary. On some systems, the linker by default uses RUNPATH instead of RPATH which is incompatible with the way Rizin is currently compiled. It results in some of the Rizin libraries not being found when running cutter. You can verify if this is the problem by running `ldd ./cutter`. If all the Rizin libraries are missing you have a different problem.
 The workaround is to either add the `--disable-new-dtags` linker flag when compiling Cutter or add the Rizin installation path to LD_LIBRARY_PATH environment variable.
 
 ::

--- a/scripts/breakpad_extract_symbols_appimage.py
+++ b/scripts/breakpad_extract_symbols_appimage.py
@@ -44,7 +44,7 @@ def kill_appimage():
 atexit.register(kill_appimage)
 mount_dir = appimage_p.stdout.readline().strip().decode("utf-8")
 
-binaries = [ os.path.join(mount_dir, "usr/bin/Cutter") ]
+binaries = [ os.path.join(mount_dir, "usr/bin/cutter") ]
 for f in os.scandir(os.path.join(mount_dir, "usr/lib")):
 	if f.is_dir() or f.is_symlink():
 		continue

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -425,6 +425,7 @@ endif()
 
 add_executable(Cutter ${UI_FILES} ${QRC_FILES} ${PLATFORM_RESOURCES} ${SOURCES} ${HEADER_FILES} ${BINDINGS_SOURCE})
 set_target_properties(Cutter PROPERTIES
+        OUTPUT_NAME cutter
         RUNTIME_OUTPUT_DIRECTORY ..
         PDB_OUTPUT_DIRECTORY ..
         ENABLE_EXPORTS ON
@@ -548,7 +549,7 @@ endforeach()
 if(UNIX AND NOT APPLE)
     install (FILES "img/cutter.svg"
                 DESTINATION "share/icons/hicolor/scalable/apps/")
-    install(FILES "org.rizin.Cutter.desktop"
+    install(FILES "re.rizin.cutter.desktop"
         DESTINATION "share/applications"
         COMPONENT Devel)
 endif()

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -70,8 +70,9 @@ int main(int argc, char *argv[])
     qRegisterMetaType<QList<StringDescription>>();
     qRegisterMetaType<QList<FunctionDescription>>();
 
-    QCoreApplication::setOrganizationName("RizinOrg");
-    QCoreApplication::setApplicationName("Cutter");
+    QCoreApplication::setOrganizationName("rizin");
+    QCoreApplication::setOrganizationDomain("rizin.re");
+    QCoreApplication::setApplicationName("cutter");
 
     Cutter::initializeSettings();
 

--- a/src/plugins/CutterPlugin.h
+++ b/src/plugins/CutterPlugin.h
@@ -47,7 +47,7 @@ public:
     virtual QString getVersion() const = 0;
 };
 
-#define CutterPlugin_iid "org.rizin.cutter.plugins.CutterPlugin"
+#define CutterPlugin_iid "re.rizin.cutter.plugins.CutterPlugin"
 
 Q_DECLARE_INTERFACE(CutterPlugin, CutterPlugin_iid)
 

--- a/src/plugins/sample-cpp/CutterSamplePlugin.h
+++ b/src/plugins/sample-cpp/CutterSamplePlugin.h
@@ -8,7 +8,7 @@
 class CutterSamplePlugin : public QObject, CutterPlugin
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "org.rizin.cutter.plugins.CutterPlugin")
+    Q_PLUGIN_METADATA(IID "re.rizin.cutter.plugins.CutterPlugin")
     Q_INTERFACES(CutterPlugin)
 
 public:

--- a/src/re.rizin.cutter.appdata.xml
+++ b/src/re.rizin.cutter.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>org.rizin.Cutter</id>
+  <id>re.rizin.cutter</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0</project_license>
   <name>Cutter</name>
@@ -12,7 +12,7 @@
     </p>
   </description>
 
-  <launchable type="desktop-id">org.rizin.Cutter.desktop</launchable>
+  <launchable type="desktop-id">re.rizin.cutter.desktop</launchable>
 
   <screenshots>
     <screenshot>

--- a/src/re.rizin.cutter.desktop
+++ b/src/re.rizin.cutter.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
 Name=Cutter
-Exec=Cutter
+Exec=cutter
 Icon=cutter
 Categories=Development;


### PR DESCRIPTION
The lowercase executable name is nicer to type and fits better into UNIX envs.

In Rizin, it was decided to use `re.rizin.<lowercase-project>` for all reverse-dns ids because this conforms to all requirements of known places where such an id is needed and thus it can be consistent for all of them.