### PR TITLE
Make SearchWidget set search.in only locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,5 +96,6 @@ src/out
 # astyle backup .orig files
 *.orig
 
-# Gdb's history
+# Local gdb files
 .gdb_history
+.gdbinit

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3349,12 +3349,17 @@ bool CutterCore::isAddressMapped(RVA addr)
     return !Core()->cmdRawAt(QString("om."), addr).isEmpty();
 }
 
-QList<SearchDescription> CutterCore::getAllSearch(QString search_for, QString space)
+QList<SearchDescription> CutterCore::getAllSearch(QString searchFor, QString space, QString in)
 {
     CORE_LOCK();
     QList<SearchDescription> searchRef;
 
-    QJsonArray searchArray = cmdj(space + QString(" ") + search_for).array();
+    QJsonArray searchArray;
+    {
+        TempConfig cfg;
+        cfg.set("search.in", in);
+        searchArray = cmdj(QString("%1 %2").arg(space, searchFor)).array();
+    }
 
     if (space == "/Rj") {
         for (const QJsonValue &value : searchArray) {

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -557,7 +557,7 @@ public:
     bool isAddressMapped(RVA addr);
 
     QList<MemoryMapDescription> getMemoryMap();
-    QList<SearchDescription> getAllSearch(QString search_for, QString space);
+    QList<SearchDescription> getAllSearch(QString searchFor, QString space, QString in);
     BlockStatistics getBlockStatistics(unsigned int blocksCount);
     QList<BreakpointDescription> getBreakpoints();
     QList<ProcessDescription> getAllProcesses();

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -227,7 +227,6 @@ void SearchWidget::updateSearchBoundaries()
 
     mapIter = boundaries.cbegin();
     ui->searchInCombo->setCurrentIndex(ui->searchInCombo->findData(mapIter.key()));
-    Config()->setConfig("search.in", mapIter.key());
 
     ui->searchInCombo->blockSignals(true);
     ui->searchInCombo->clear();
@@ -265,12 +264,12 @@ void SearchWidget::refreshSearchspaces()
 
 void SearchWidget::refreshSearch()
 {
-    QString search_for = ui->filterLineEdit->text();
-    QVariant searchspace_data = ui->searchspaceCombo->currentData();
-    QString searchspace = searchspace_data.toString();
+    QString searchFor = ui->filterLineEdit->text();
+    QString searchSpace = ui->searchspaceCombo->currentData().toString();
+    QString searchIn = ui->searchInCombo->currentData().toString();
 
     search_model->beginResetModel();
-    search = Core()->getAllSearch(search_for, searchspace);
+    search = Core()->getAllSearch(searchFor, searchSpace, searchIn);
     search_model->endResetModel();
 
     qhelpers::adjustColumns(ui->searchTreeView, 3, 0);
@@ -312,10 +311,4 @@ void SearchWidget::updatePlaceholderText(int index)
     default:
         ui->filterLineEdit->setPlaceholderText("jmp rax");
     }
-}
-
-void SearchWidget::on_searchInCombo_currentIndexChanged(int index)
-{
-    Config()->setConfig("search.in",
-                      ui->searchInCombo->itemData(index).toString());
 }

--- a/src/widgets/SearchWidget.h
+++ b/src/widgets/SearchWidget.h
@@ -68,7 +68,6 @@ public:
     ~SearchWidget();
 
 private slots:
-    void on_searchInCombo_currentIndexChanged(int index);
     void searchChanged();
     void updateSearchBoundaries();
     void refreshSearchspaces();


### PR DESCRIPTION
This avoids messing up the global `search.in` which can for example cause confusing behavior when running search commands in the console.