### PR TITLE
Don't print Warnings for whitespace-only JSON Failures

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -521,6 +521,10 @@ QJsonDocument CutterCore::parseJson(const char *res, const char *cmd)
     QJsonDocument doc = QJsonDocument::fromJson(json, &jsonError);
 
     if (jsonError.error != QJsonParseError::NoError) {
+        // don't call trimmed() before knowing that parsing failed to avoid copying huge jsons all the time
+        if (json.trimmed().isEmpty()) {
+            return doc;
+        }
         if (cmd) {
             eprintf("Failed to parse JSON for command \"%s\": %s\n", cmd,
                     jsonError.errorString().toLocal8Bit().constData());


### PR DESCRIPTION
We do not print errors when a json to be parsed is just an empty string, but we did when it was a string of just whitespaces. This change also ignors errors for these cases. 

This in particular avoids printed error messages like these, where the json will come directly out of a plugin, but the plugin may or may not supply it:
```
Failed to parse JSON for command "iCj": illegal value


Failed to parse JSON for command "iVj": illegal value


Failed to parse JSON for command "ihj": illegal value


Failed to parse JSON for command "iRj": illegal value


Failed to parse JSON for command "iMj": illegal value

```