### PR TITLE
Use Rizin seek API instead of commands

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -889,9 +889,11 @@ void CutterCore::seek(ut64 offset)
         return;
     }
 
-    // use cmd and not cmdRaw to make sure seekChanged is emitted
-    cmd(QString("s %1").arg(offset));
-    // cmd already does emit seekChanged(core_->offset);
+    RVA o_offset = core->offset;
+    rz_core_seek_and_save(core, offset, true);
+    if (o_offset != core->offset) {
+        updateSeek();
+    }
 }
 
 void CutterCore::showMemoryWidget()
@@ -919,14 +921,16 @@ void CutterCore::seek(QString thing)
 
 void CutterCore::seekPrev()
 {
-    // Use cmd because cmdRaw does not work with seek history
-    cmd("s-");
+    CORE_LOCK ();
+    rz_core_seek_undo (core);
+    updateSeek();
 }
 
 void CutterCore::seekNext()
 {
-    // Use cmd because cmdRaw does not work with seek history
-    cmd("s+");
+    CORE_LOCK ();
+    rz_core_seek_redo (core);
+    updateSeek();
 }
 
 void CutterCore::updateSeek()


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

With recent Rizin changes, seek commands were changed, so `s-` and `s+` are not undo/redo anymore. In their place there are `sHu`/`sHr`, however there is even a nicer API to use. This PR replaces the cmd call with the API `rz_core_seek_undo`/`rz_core_seek_redo`.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

Move around in a binary and use the arrows to move back and forth.

<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
