### PR TITLE
Add setting import from Cutter before RadareOrg to rizin renames.

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -73,6 +73,12 @@ int main(int argc, char *argv[])
     QCoreApplication::setOrganizationName("rizin");
     QCoreApplication::setApplicationName("cutter");
 
+    // Importing settings after setting rename, needs separate handling in addition to regular version to version upgrade.
+    if (Cutter::shouldOfferSettingImport())
+    {
+        Cutter::showSettingImportDialog(argc, argv);
+    }
+
     Cutter::initializeSettings();
 
     QCoreApplication::setAttribute(

--- a/src/common/ColorThemeWorker.cpp
+++ b/src/common/ColorThemeWorker.cpp
@@ -309,3 +309,11 @@ QStringList ColorThemeWorker::customThemes() const
     }
     return ret;
 }
+
+const QStringList &ColorThemeWorker::getRizinSpecificOptions()
+{
+    if (rizinSpecificOptions.isEmpty()) {
+        rizinSpecificOptions = Core()->cmdj("ecj").object().keys();
+    }
+    return rizinSpecificOptions;
+}

--- a/src/common/ColorThemeWorker.h
+++ b/src/common/ColorThemeWorker.h
@@ -18,11 +18,6 @@ class ColorThemeWorker : public QObject
     Q_OBJECT
 public:
     /**
-     * @brief rizinSpecificOptions is list of all available Rizin-only color options.
-     */
-    const QStringList rizinSpecificOptions = Core()->cmdj("ecj").object().keys();
-
-    /**
      * @brief cutterSpecificOptions is list of all available Cutter-only color options.
      */
     static const QStringList cutterSpecificOptions;
@@ -117,7 +112,17 @@ public:
      */
     QStringList customThemes() const;
 
+    QString getStandardThemesPath() { return standardRzThemesLocationPath; }
+    QString getCustomThemesPath() { return customRzThemesLocationPath; }
+
+    const QStringList &getRizinSpecificOptions();
+
 private:
+    /**
+     * @brief list of all available Rizin-only color options.
+     */
+    QStringList rizinSpecificOptions;
+
     QString standardRzThemesLocationPath;
     QString customRzThemesLocationPath;
 

--- a/src/common/SettingsUpgrade.h
+++ b/src/common/SettingsUpgrade.h
@@ -6,6 +6,17 @@
 
 namespace Cutter {
 void initializeSettings();
+/**
+ * @brief Check if Cutter should offer importing settings from version that can't be directly updated.
+ * @return True if this is first time running Cutter and r2 based Cutter <= 1.12 settings exist.
+ */
+bool shouldOfferSettingImport();
+/**
+ * @brief Ask user if Cutter should import settings from pre-rizin Cutter.
+ *
+ * This function assume that QApplication isn't running yet.
+ */
+void showSettingImportDialog(int &argc, char **argv);
 void migrateThemes();
 }
 

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -240,7 +240,7 @@ void ColorThemeListView::currentChanged(const QModelIndex &current, const QModel
 {
     ColorOption prev = previous.data(Qt::UserRole).value<ColorOption>();
     Config()->setColor(prev.optionName, prev.color);
-    if (ThemeWorker().rizinSpecificOptions.contains(prev.optionName)) {
+    if (ThemeWorker().getRizinSpecificOptions().contains(prev.optionName)) {
         Core()->cmdRaw(QString("ec %1 %2").arg(prev.optionName).arg(prev.color.name()));
     }
 
@@ -306,7 +306,7 @@ void ColorThemeListView::blinkTimeout()
 
     auto updateColor = [](const QString &name, const QColor &color) {
         Config()->setColor(name, color);
-        if (ThemeWorker().rizinSpecificOptions.contains(name)) {
+        if (ThemeWorker().getRizinSpecificOptions().contains(name)) {
             Core()->cmdRaw(QString("ec %1 %2").arg(name).arg(color.name()));
         }
     };


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

* Remove rizin/cutter settings
* Open Cutter 1.12, create 2 custom color themes with easy to remember colors and a view layout, close cutter
* Open the new Cutter, make sure there is a dialog asking to import settings
   *  Try confirming and compare the content of imported settings, make settings with more complicated structure like color themes and layout were correctly imported. Make sure first time dialog isn't shown.
   * Choose not to import settings, make sure initial configuration is displayed
* Open cutter second time make sure import isn't offered anymore 
* Delete the new and old settings, make sure initial configuration is displayed and old import isn't offered if there are no RadareOrg/Cutter settings
* Test what happens on macOS. Does it use the domain thing. Can the new Cutter even access old Cutter settings.


**Closing issues**

#2576 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
