### PR TITLE
Disable asm.dwarf

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -126,6 +126,7 @@ static const QHash<QString, QVariant> asmOptions = { { "asm.esil", false },
                                                      { "asm.flags.real", true },
                                                      { "asm.reloff", false },
                                                      { "asm.reloff.flags", false },
+                                                     { "asm.dwarf", false },
                                                      { "esil.breakoninvalid", true },
                                                      { "graph.offset", false } };
 

--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -39,6 +39,7 @@ AsmOptionsWidget::AsmOptionsWidget(PreferencesDialog *dialog)
                    { ui->fcnlinesCheckBox, "asm.lines.fcn" },
                    { ui->flgoffCheckBox, "asm.flags.offset" },
                    { ui->emuCheckBox, "asm.emu" },
+                   { ui->dwarfCheckBox, "asm.dwarf" },
                    { ui->emuStrCheckBox, "emu.str" },
                    { ui->varsumCheckBox, "asm.var.summary" },
                    { ui->sizeCheckBox, "asm.size" },

--- a/src/dialogs/preferences/AsmOptionsWidget.ui
+++ b/src/dialogs/preferences/AsmOptionsWidget.ui
@@ -456,6 +456,13 @@
               </widget>
              </item>
              <item>
+              <widget class="QCheckBox" name="dwarfCheckBox">
+               <property name="text">
+                <string>Show dwarf information (asm.dwarf)</string>
+               </property>
+              </widget>
+             </item>
+             <item>
               <widget class="QCheckBox" name="sizeCheckBox">
                <property name="text">
                 <string>Show size of opcodes in disassembly (asm.size)</string>


### PR DESCRIPTION
This commit sets the asm.dwarf option to false by default and adds a
checkbox in the configuration menu to enable it.

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

By default, `asm.dwarf` is enabled. This adds a lot of verbosity to the code especially source code file lines and such which most of the time are not relevant during reverse engineering tasks. Disabling it by default makes the interface much cleaner.

![image](https://user-images.githubusercontent.com/10772605/107887986-31c0b100-6f0a-11eb-9464-fa0cbf3bf5ad.png)
![image](https://user-images.githubusercontent.com/10772605/107887990-36856500-6f0a-11eb-83ba-f8565ee52c66.png)


**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

- Open a binary with dwarf information, make sure that `e asm.dwarf` is set to false
- Enable it in the configuration panel and check that the extra  comments appear/disappear as one would expect


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->
