### PR TITLE
Better handle project names

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -696,7 +696,7 @@ RzProjectErr MainWindow::saveProjectAs(bool *canceled)
 {
     QString dir = core->getConfig("prj.file");
     if (dir.isEmpty()) {
-        dir = QDir(filename).dirName();
+        dir = QFileInfo(filename).absolutePath();
     }
     QString file = QFileDialog::getSaveFileName(this, tr("Save Project"), dir, PROJECT_FILE_FILTER);
     if (file.isEmpty()) {

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -694,11 +694,20 @@ RzProjectErr MainWindow::saveProject(bool *canceled)
 
 RzProjectErr MainWindow::saveProjectAs(bool *canceled)
 {
-    QString dir = core->getConfig("prj.file");
-    if (dir.isEmpty()) {
-        dir = QFileInfo(filename).absolutePath();
+    QString projectFile = core->getConfig("prj.file");
+    if (projectFile.isEmpty()) {
+        projectFile = filename;
     }
-    QString file = QFileDialog::getSaveFileName(this, tr("Save Project"), dir, PROJECT_FILE_FILTER);
+
+    QFileInfo projectFileInfo = QFileInfo(projectFile);
+
+    // preferred name is of fromat 'binary.exe.rzdb'
+    QString preferredName = QString("%1.%2").arg(projectFileInfo.absoluteFilePath()).arg("rzdb");
+
+    QFileDialog fileDialog(this);
+    // Append 'rzdb' suffix if it does not exist
+    fileDialog.setDefaultSuffix("rzdb");
+    QString file = fileDialog.getSaveFileName(this, tr("Save Project"), preferredName, PROJECT_FILE_FILTER);
     if (file.isEmpty()) {
         if (canceled) {
             *canceled = true;

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -696,18 +696,14 @@ RzProjectErr MainWindow::saveProjectAs(bool *canceled)
 {
     QString projectFile = core->getConfig("prj.file");
     if (projectFile.isEmpty()) {
-        projectFile = filename;
+        // preferred name is of fromat 'binary.exe.rzdb'
+        projectFile = QString("%1.%2").arg(filename).arg("rzdb");
     }
-
-    QFileInfo projectFileInfo = QFileInfo(projectFile);
-
-    // preferred name is of fromat 'binary.exe.rzdb'
-    QString preferredName = QString("%1.%2").arg(projectFileInfo.absoluteFilePath()).arg("rzdb");
 
     QFileDialog fileDialog(this);
     // Append 'rzdb' suffix if it does not exist
     fileDialog.setDefaultSuffix("rzdb");
-    QString file = fileDialog.getSaveFileName(this, tr("Save Project"), preferredName, PROJECT_FILE_FILTER);
+    QString file = fileDialog.getSaveFileName(this, tr("Save Project"), projectFile, PROJECT_FILE_FILTER);
     if (file.isEmpty()) {
         if (canceled) {
             *canceled = true;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

This Pull Request does the following:
1. Fix issue with the pre-defined project name
2. Open the Save file dialog in the directory in which the binary relies
3. Now Projects will be saved with `.rzdb` extension.
4. Suggest the name of the saved project (e.g `demo.exe.rzdb` for a file named `demo.exe`).

**Test plan (required)**
1. Open a binary and save the project as (Ctrl Shift S)
2. Verify that the suggested name is `[full binary name].rzdb`
3. Verify that the directory that is opened is the one in which the binary relies in
4. Save the project file and verify that the saved file on disk has the same name as in the dialog (e.g that `file.exe.rzdb` saved as `file.exe.rzdb`)
5. Close Cutter and open a new instance
6. Open the project file from the Projects tab in the Open File dialog
7. Check that the project works correctly.
8. Make some changes, save the project (Ctrl S)
9. Close cutter
10. Verify that the saved project override the current one and did not create a new file
11. open a new instance of Cutter and open the saved project file
10. Check that the project contained the changes you made
12. Try to save the project in a different name
13. Check that now you have two different project files saved
14. Open new instance of Cutter and check that you have (at least) the two project files in the Open File dialog