### PR TITLE
Support loading projects from the command line

### DIFF
--- a/docs/source/user-docs/command-line.rst
+++ b/docs/source/user-docs/command-line.rst
@@ -4,7 +4,7 @@ Command-line Options
 Synopsis
 --------
 
-**Cutter** [*options*] [<*filename*>]
+**Cutter** [*options*] [<*filename*> | --project <*project*>]
 
 
 Options

--- a/docs/source/user-docs/command-line.rst
+++ b/docs/source/user-docs/command-line.rst
@@ -52,6 +52,10 @@ Options
 
    Run script file
 
+.. option:: -p, --project <file>
+  
+   Load project file 
+
 .. option:: -w, --writemode
 
    Open a file in write mode, instead of the default read-only mode.

--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -133,7 +133,7 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
     setStyle(new CutterProxyStyle());
 #endif // QT_VERSION_CHECK(5, 10, 0) < QT_VERSION
 
-    if (clOptions.args.empty()) {
+    if (clOptions.args.empty() && clOptions.fileOpenOptions.projectFile.isEmpty()) {
         // check if this is the first execution of Cutter in this computer
         // Note: the execution after the preferences been reset, will be considered as
         // first-execution
@@ -142,7 +142,8 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
         }
         mainWindow->displayNewFileDialog();
     } else { // filename specified as positional argument
-        bool askOptions = clOptions.analLevel != AutomaticAnalysisLevel::Ask;
+        bool askOptions = (clOptions.analLevel != AutomaticAnalysisLevel::Ask)
+                || !clOptions.fileOpenOptions.projectFile.isEmpty();
         mainWindow->openNewFile(clOptions.fileOpenOptions, askOptions);
     }
 
@@ -330,6 +331,10 @@ bool CutterApplication::parseCommandLineOptions()
     QCommandLineOption scriptOption("i", QObject::tr("Run script file"), QObject::tr("file"));
     cmd_parser.addOption(scriptOption);
 
+    QCommandLineOption projectOption({ "p", "project" }, QObject::tr("Load project file"),
+                                     QObject::tr("project file"));
+    cmd_parser.addOption(projectOption);
+
     QCommandLineOption writeModeOption({ "w", "writemode" },
                                        QObject::tr("Open file in write mode"));
     cmd_parser.addOption(writeModeOption);
@@ -423,6 +428,8 @@ bool CutterApplication::parseCommandLineOptions()
 
         opts.fileOpenOptions.writeEnabled = cmd_parser.isSet(writeModeOption);
     }
+
+    opts.fileOpenOptions.projectFile = cmd_parser.value(projectOption);
 
     if (cmd_parser.isSet(pythonHomeOption)) {
         opts.pythonHome = cmd_parser.value(pythonHomeOption);

--- a/src/common/InitialOptions.h
+++ b/src/common/InitialOptions.h
@@ -18,6 +18,7 @@ struct InitialOptions
     enum class Endianness { Auto, Little, Big };
 
     QString filename;
+    QString projectFile;
 
     bool useVA = true;
     RVA binLoadAddr = RVA_INVALID;

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -591,7 +591,11 @@ void MainWindow::displayInitialOptionsDialog(const InitialOptions &options, bool
     o->loadOptions(options);
 
     if (skipOptionsDialog) {
-        o->setupAndStartAnalysis();
+        if (!options.projectFile.isEmpty()) {
+            openProject(options.projectFile);
+        } else {
+            o->setupAndStartAnalysis();
+        }
     } else {
         o->show();
     }

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -592,7 +592,9 @@ void MainWindow::displayInitialOptionsDialog(const InitialOptions &options, bool
 
     if (skipOptionsDialog) {
         if (!options.projectFile.isEmpty()) {
-            openProject(options.projectFile);
+            if (!openProject(options.projectFile)) {
+                displayNewFileDialog();
+            };
         } else {
             o->setupAndStartAnalysis();
         }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

This PR adds the option to load projects straight from the command line by passing the `-p` command line flag.

```
$ cutter.exe -p project.rzdb
```

Future plans are to check whether a binary file that is about to be opened has a `.rzdb` file with the same next to it and offer the user to load the existing project.

**Test plan (required)**

1. Try to load a project file using `-p`
2. Try to load a non-project file using `-p` (should get an error and return to the regular New File Dialog)


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #2602  