### PR TITLE
Remove Organization Domain to set QSettings path on macOS to ~/.config/rizin/cutter.ini

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -71,7 +71,6 @@ int main(int argc, char *argv[])
     qRegisterMetaType<QList<FunctionDescription>>();
 
     QCoreApplication::setOrganizationName("rizin");
-    QCoreApplication::setOrganizationDomain("rizin.re");
     QCoreApplication::setApplicationName("cutter");
 
     Cutter::initializeSettings();


### PR DESCRIPTION

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Annoyingly, after #2574 on macOS the settings file goes into `~/.config/rizin.re/cutter.ini`, but we want `~/.config/rizin/cutter.ini`. I don't think we need the domain so *should* be ok to not set it.

**Test plan (required)**

Needs re-checking on all three platforms (I only quickly checked macOS so far)

