### PR TITLE
Update for RZ_GITTAP Removal

### DIFF
--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -30,6 +30,15 @@
 #    include <RzGhidraDecompiler.h>
 #endif
 
+// Rizin before 301e5af2170d9f3ed1edd658b0f9633f31fc4126
+// has RZ_GITTAP defined and uses it in rz_core_version().
+// After that, RZ_GITTAP is not defined anymore and RZ_VERSION is used.
+#ifdef RZ_GITTAP
+#define CUTTER_COMPILE_TIME_RZ_VERSION "" RZ_GITTAP
+#else
+#define CUTTER_COMPILE_TIME_RZ_VERSION "" RZ_VERSION
+#endif
+
 CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc, argv)
 {
     // Setup application information
@@ -76,7 +85,8 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
 
     // Check rizin version
     QString rzversion = rz_core_version();
-    QString localVersion = "" RZ_GITTAP;
+    QString localVersion = CUTTER_COMPILE_TIME_RZ_VERSION;
+    qDebug() << rzversion << localVersion;
     if (rzversion != localVersion) {
         QMessageBox msg;
         msg.setIcon(QMessageBox::Critical);

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3890,6 +3890,12 @@ void CutterCore::loadScript(const QString &scriptname)
     triggerRefreshAll();
 }
 
+QString CutterCore::getRizinVersionReadable()
+{
+    return QString("%1 (%2)").arg(QString::fromUtf8(RZ_VERSION),
+                                  QString::fromUtf8(RZ_GITTIP).left(7));
+}
+
 QString CutterCore::getVersionInformation()
 {
     int i;
@@ -3924,7 +3930,7 @@ QString CutterCore::getVersionInformation()
         /* ... */
         { NULL, NULL }
     };
-    versionInfo.append(QString("%1 rz\n").arg(RZ_GITTAP));
+    versionInfo.append(QString("%1 rz\n").arg(getRizinVersionReadable()));
     for (i = 0; vcs[i].name; i++) {
         struct vcs_t *v = &vcs[i];
         const char *name = v->callback();

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -147,6 +147,7 @@ public:
     {
         return asyncCmdEsil(command.toUtf8().constData(), task);
     }
+    QString getRizinVersionReadable();
     QString getVersionInformation();
 
     QJsonDocument parseJson(const char *res, const char *cmd = nullptr);

--- a/src/dialogs/AboutDialog.cpp
+++ b/src/dialogs/AboutDialog.cpp
@@ -25,8 +25,9 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent), ui(new Ui::AboutDia
     ui->logoSvgWidget->load(Config()->getLogoFile());
 
     QString aboutString(
-            tr("Version") + " " CUTTER_VERSION_FULL "<br/>" + tr("Using rizin-") + RZ_GITTAP
-            + "<br/>" + buildQtVersionString() + "<p><b>" + tr("Optional Features:") + "</b><br/>"
+            tr("Version") + " " CUTTER_VERSION_FULL "<br/>" + tr("Using rizin ")
+            + Core()->getRizinVersionReadable() + "<br/>" + buildQtVersionString() + "<p><b>"
+            + tr("Optional Features:") + "</b><br/>"
             + QString("Python: %1<br/>")
                       .arg(
 #ifdef CUTTER_ENABLE_PYTHON


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

`RZ_GITTAP` does not exist anymore in rizin dev (but full-size `RZ_GITTIP` does) and `rz_core_version()` returns the rizin-build-time `RZ_VERSION`: https://github.com/rizinorg/rizin/commit/301e5af2170d9f3ed1edd658b0f9633f31fc4126

The main issue I see with this is that in 0.1.1, `rz_core_version()` will still return `RZ_GITTAP` which should always cause a mismatch here. Not sure yet what the best thing to do there would be @XVilka @ret2libc 
