### PR TITLE
 Add dbg.trace_continue to debug options

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -127,6 +127,7 @@ static const QHash<QString, QVariant> asmOptions = { { "asm.esil", false },
                                                      { "asm.reloff", false },
                                                      { "asm.reloff.flags", false },
                                                      { "esil.breakoninvalid", true },
+                                                     { "dbg.trace_continue", true },
                                                      { "graph.offset", false } };
 
 Configuration::Configuration() : QObject(), nativePalette(qApp->palette())

--- a/src/dialogs/preferences/DebugOptionsWidget.cpp
+++ b/src/dialogs/preferences/DebugOptionsWidget.cpp
@@ -25,7 +25,13 @@ DebugOptionsWidget::~DebugOptionsWidget() {}
 
 void DebugOptionsWidget::updateDebugPlugin()
 {
+    ui->traceContinue->setChecked(Config()->getConfigBool("dbg.trace_continue"));
+    connect(ui->traceContinue, &QCheckBox::toggled, this,
+            [](bool checked) { Config()->setConfig("dbg.trace_continue", checked); });
     ui->esilBreakOnInvalid->setChecked(Config()->getConfigBool("esil.breakoninvalid"));
+    connect(ui->esilBreakOnInvalid, &QCheckBox::toggled, this,
+            [](bool checked) { Config()->setConfig("esil.breakoninvalid", checked); });
+
     disconnect(ui->pluginComboBox, &QComboBox::currentTextChanged, this,
                &DebugOptionsWidget::onDebugPluginChanged);
 
@@ -66,9 +72,4 @@ void DebugOptionsWidget::updateStackAddr()
     QString newAddr = ui->stackAddr->text();
     Core()->setConfig("esil.stack.addr", newAddr);
     ui->stackAddr->setPlaceholderText(newAddr);
-}
-
-void DebugOptionsWidget::on_esilBreakOnInvalid_toggled(bool checked)
-{
-    Config()->setConfig("esil.breakoninvalid", checked);
 }

--- a/src/dialogs/preferences/DebugOptionsWidget.h
+++ b/src/dialogs/preferences/DebugOptionsWidget.h
@@ -27,5 +27,4 @@ private slots:
     void updateStackAddr();
     void updateStackSize();
     void onDebugPluginChanged(const QString &index);
-    void on_esilBreakOnInvalid_toggled(bool checked);
 };

--- a/src/dialogs/preferences/DebugOptionsWidget.ui
+++ b/src/dialogs/preferences/DebugOptionsWidget.ui
@@ -6,81 +6,127 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>489</width>
-    <height>201</height>
+    <width>742</width>
+    <height>698</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Debug</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_1">
    <item>
-    <layout class="QFormLayout" name="formLayout">
-     <property name="fieldGrowthPolicy">
-      <enum>QFormLayout::ExpandingFieldsGrow</enum>
-     </property>
-     <property name="labelAlignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="pluginLabel">
-       <property name="text">
-        <string>Debug Plugin:</string>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <layout class="QFormLayout" name="formLayout_1">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetDefaultConstraint</enum>
        </property>
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::ExpandingFieldsGrow</enum>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="pluginLabel">
+         <property name="text">
+          <string>Debug plugin:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="pluginComboBox"/>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="EsilOptions">
+       <property name="title">
+        <string>ESIL options</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetDefaultConstraint</enum>
+        </property>
+        <property name="topMargin">
+         <number>24</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="esilBreakOnInvalid">
+          <property name="text">
+           <string>Break esil execution when instruction is invalid (esil.breakoninvalid)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QFormLayout" name="formLayout_2">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetDefaultConstraint</enum>
+          </property>
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::FieldsStayAtSizeHint</enum>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="stackAddrLabel">
+            <property name="text">
+             <string>ESIL stack address:</string>
+            </property>
+            <property name="scaledContents">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="stackSizeLabel">
+            <property name="toolTip">
+             <string>Hide text when zooming out and it is smaller than the given value. Higher values can increase Performance.</string>
+            </property>
+            <property name="text">
+             <string>ESIL stack size:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="stackAddr"/>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="stackSize"/>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="pluginComboBox"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="esilstackAddr">
-       <property name="text">
-        <string>ESIL stack address:</string>
+     <item>
+      <widget class="QGroupBox" name="TraceOptions">
+       <property name="title">
+        <string>Trace options</string>
        </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="stackAddr">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="esilStackSize">
-       <property name="text">
-        <string>ESIL stack size:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QLineEdit" name="stackSize">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0" colspan="2">
-      <widget class="QCheckBox" name="esilBreakOnInvalid">
-       <property name="text">
-        <string>Break esil execution when instruction is invalid (esil.breakoninvalid)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0" colspan="2">
-      <widget class="QCheckBox" name="traceContinue">
-       <property name="text">
-        <string>Trace each step during continue in a trace session (dbg.trace_continue)</string>
-       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <property name="topMargin">
+         <number>24</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="traceContinue">
+          <property name="text">
+           <string>Trace each step during continue in a trace session (dbg.trace_continue)</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/dialogs/preferences/DebugOptionsWidget.ui
+++ b/src/dialogs/preferences/DebugOptionsWidget.ui
@@ -108,6 +108,9 @@
           <property name="text">
            <string>Trace each step during continue in a trace session (dbg.trace_continue)</string>
           </property>
+          <property name="toolTip">
+           <string>Disabling this option means that stepping back after continue will return to the previous PC. Significantly improves performance.</string>
+          </property>
          </widget>
         </item>
        </layout>

--- a/src/dialogs/preferences/DebugOptionsWidget.ui
+++ b/src/dialogs/preferences/DebugOptionsWidget.ui
@@ -73,6 +73,13 @@
        </property>
       </widget>
      </item>
+     <item row="5" column="0" colspan="2">
+      <widget class="QCheckBox" name="traceContinue">
+       <property name="text">
+        <string>Trace each step during continue in a trace session (dbg.trace_continue)</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Allow the user to toggle dbg.trace_continue in the options. Toggling this option lets the user only record the initial PC before pressing continue and the PC that the program stopped at instead of tracing each step.

**Test plan (required)**

* Start debug and enable tracing
* Place a breakpoint somewhere and continue to it
  * See that stepping back returns to the original PC before continue if dbg.trace_continue is toggled off
  * See that stepping back returns to the previous instruction if dbg.trace_continue is toggled on