### PR TITLE
Enable CUTTER_USE_BUNDLED_RIZIN by default

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -41,7 +41,7 @@ jobs:
           export LD_LIBRARY_PATH="`llvm-config --libdir`:$LD_LIBRARY_PATH"
           mkdir build
           cd build
-          cmake -DCUTTER_USE_BUNDLED_RIZIN=ON ..
+          cmake ..
 
       - name: Build with cov-build
         run: |

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -13,6 +13,6 @@ extraction:
     configure:
       command:
       - "pip3 install --upgrade --user meson"
-      - "cmake -B build -DCUTTER_USE_BUNDLED_RIZIN=ON"
+      - "cmake -B build"
     index:
       build_command: "cmake --build build"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,3 @@
 {
-    "cmake.sourceDirectory": "${workspaceFolder}",
-    "cmake.configureSettings": {
-        "CUTTER_USE_BUNDLED_RIZIN": "ON"
-    }
+    "cmake.sourceDirectory": "${workspaceFolder}"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(Utils)
 
 set(CUTTER_PYTHON_MIN 3.5)
 
-option(CUTTER_USE_BUNDLED_RIZIN "Use rizin from src/rizin submodule instead of searching for it on the system" OFF)
+option(CUTTER_USE_BUNDLED_RIZIN "Use rizin from ./rizin submodule instead of searching for it on the system" ON)
 option(CUTTER_USE_ADDITIONAL_RIZIN_PATHS "Search rizin in additional paths which are not part of default system library paths.\
  Disable this option if you are linking against rizin pacakged as proper system library or in a custom path and additional are paths causing problems." ON)
 option(CUTTER_ENABLE_PYTHON "Enable Python integration. Requires Python >= ${CUTTER_PYTHON_MIN}." OFF)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN apk add --no-cache \
 RUN git clone --recurse-submodules https://github.com/rizinorg/cutter.git /opt/cutter && \
     mkdir -p /opt/cutter/build && \
     cd /opt/cutter/build && \
-    cmake -DCUTTER_USE_BUNDLED_RIZIN=ON .. && \
+    cmake .. && \
     cmake --build . -j $(grep -c ^processor /proc/cpuinfo)
 
 FROM alpine:latest AS runner

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -5,7 +5,10 @@ Building
 
  If you just want to use the latest Release version of Cutter, please note
  that we provide pre-compiled binaries for Windows, Linux, and macOS on
- our `release page. <https://github.com/rizinorg/cutter/releases/latest>`_
+ our `release page <https://github.com/rizinorg/cutter/releases/latest>`_ and
+ `CI page <https://github.com/rizinorg/cutter/actions/workflows/ccpp.yml?query=branch%3Amaster>`_ (requires logging in) for latest development builds.
+
+This page describes how to do basic build from command line. If you are planning to modify Cutter it is recommended to also read :doc:`development environment setup</contributing/code/ide-setup>`.
 
 Getting the Source
 ------------------
@@ -103,6 +106,30 @@ You can now execute Cutter like this:
 
    ./build/cutter
 
+
+Making Linux distribution specific packages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When making a distribution specific packages the default install target should give you a good starting point.
+It uses CMake builtin functionality and `GNUInstallDirs <https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html?highlight=gnu%20directories>`_ for
+installing the executable, desktop file, headers and other files required for plugin compilation. See CMake documentation for adjusting installed file locations and properties.
+It shouldn't be necessary to manually copy files from plain build.
+
+It is recommended to build and package rizin as separate package so that it can be used with or without Cutter. Doing that will also give more control over the way rizin dependencies are handled. We are trying to maintain
+compatibility with latest rizin release at the time of Cutter release and making a new Cutter release when new rizin version is released.
+
+If you are packaging Cutter users will appreciate if you also package `rz-ghidra <https://github.com/rizinorg/rz-ghidra>`_ and `jsdec <https://github.com/rizinorg/jsdec>`_ decompilers as optional packages.
+It should be possible to compile Cutter plugins against proper Cutter installation without having direct access to Cutter source code.
+
+If name Cutter or cutter conflicts with other packages or their content, rz-cutter can be used.
+
+CMAKE options:
+
+* ``-DCMAKE_BUILD_TYPE=Release`` turn on release optimizations, unless your distro has more specific guidelines for common compiler options.
+* ``CUTTER_USE_BUNDLED_RIZIN=OFF`` turn off use of rizin from submodule to use previously packaged rizin. Note that ``CUTTER_USE_BUNDLED_RIZIN=ON`` doesn't install rizin in a way suitable for linux packaging without doing additional manual steps making packaging process more complex. Bundled rizin will also likely conflict with standalone rizin package.
+* Correct install prefix. By default CMake will install to /usr/local suitable for user builds. Change it according to your distro packaging guidelines.
+* ``CUTTER_ENABLE_PYTHON`` and  ``CUTTER_ENABLE_PYTHON_BINDINGS`` it is recommended to turn on for complete user experience. May require manual path specification on distros with multiple python versions.
+* ``CUTTER_ENABLE_GRAPHVIZ`` and ``CUTTER_ENABLE_KSYNTAXHIGHLIGHTING`` optional but nice to have since they are available on most distros.
+* ``CUTTER_EXTRA_PLUGIN_DIRS`` use it to specify additional plugin search locations if distro packaging guidelines require you placing them in locations Cutter doesn't use by default.
 
 Building on Windows
 -------------------

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -77,17 +77,17 @@ The recommended way to build Cutter on Linux is by using CMake. Simply invoke CM
 .. code:: sh
 
    mkdir build && cd build
-   cmake -DCUTTER_USE_BUNDLED_RIZIN=ON ..
+   cmake ..
    cmake --build .
 
 If your operating system has a newer version of CMake (> v3.12) you can use this cleaner solution:
 
 .. code:: sh
 
-   cmake -B build -DCUTTER_USE_BUNDLED_RIZIN=ON
+   cmake -B build
    cmake --build build
 
-If you want to use Cutter with another version of Rizin you can omit ``-DCUTTER_USE_BUNDLED_RIZIN=ON``. Note that using a version of Rizin which isn't the version Cutter is using can cause issues and the compilation might fail.
+If you want to use Cutter with another version of Rizin you can set ``-DCUTTER_USE_BUNDLED_RIZIN=OFF``. Note that using a version of Rizin which isn't the version Cutter is using can cause issues and the compilation might fail.
 
 .. note::
 
@@ -153,7 +153,7 @@ Note that the paths below may vary depending on your version of Qt and Visual St
    $Env:Path += ";C:\Qt\5.15.2\msvc2019_64\bin"
 
    # Build Cutter
-   cmake -B build -DCUTTER_USE_BUNDLED_RIZIN=ON
+   cmake -B build
    cmake --build build
 
 
@@ -188,7 +188,7 @@ Recommended Way for dev builds
 
    mkdir build
    cd build
-   cmake .. -DCUTTER_USE_BUNDLED_RIZIN=ON -DCMAKE_PREFIX_PATH=/local/opt/qt5
+   cmake .. -DCMAKE_PREFIX_PATH=/local/opt/qt5
    make
 
 --------------
@@ -198,7 +198,7 @@ CMake Building Options
 
 Note that there are some major building options available:
 
-* ``CUTTER_USE_BUNDLED_RIZIN`` automatically compile Rizin from submodule.
+* ``CUTTER_USE_BUNDLED_RIZIN`` automatically compile Rizin from submodule (Enabled by default).
 * ``CUTTER_ENABLE_PYTHON`` compile with Python support.
 * ``CUTTER_ENABLE_PYTHON_BINDINGS`` automatically generate Python Bindings with Shiboken2, required for Python plugins!
 * ``CUTTER_ENABLE_KSYNTAXHIGHLIGHTING`` use KSyntaxHighlighting for code highlighting.

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -122,10 +122,10 @@ It should be possible to compile Cutter plugins against proper Cutter installati
 
 If the names "Cutter" or "cutter" conflict with other packages or their content, "rz-cutter" can be used.
 
-CMAKE options:
+:Configuration for packaging:
 
 * ``-DCMAKE_BUILD_TYPE=Release`` turn on release optimizations, unless your distro has more specific guidelines for common compiler options.
-* ``CUTTER_USE_BUNDLED_RIZIN=OFF`` turn off use of rizin from submodule to use previously packaged rizin. Note that ``CUTTER_USE_BUNDLED_RIZIN=ON`` doesn't install rizin in a way suitable for linux packaging without doing additional manual steps making packaging process more complex. Bundled rizin will also likely conflict with standalone rizin package.
+* ``CUTTER_USE_BUNDLED_RIZIN=OFF`` turn off use of rizin from submodule to use previously packaged rizin. Note that keeping it on doesn't install rizin in a way suitable for linux packaging without doing additional manual steps making packaging process more complex. Bundled rizin will also likely conflict with standalone rizin package.
 * Correct install prefix. By default CMake will install to /usr/local suitable for user builds. Change it according to your distro packaging guidelines.
 * ``CUTTER_ENABLE_PYTHON`` and  ``CUTTER_ENABLE_PYTHON_BINDINGS`` it is recommended to turn on for complete user experience. May require manual path specification on distros with multiple python versions.
 * ``CUTTER_ENABLE_GRAPHVIZ`` and ``CUTTER_ENABLE_KSYNTAXHIGHLIGHTING`` optional but nice to have since they are available on most distros.

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -6,9 +6,9 @@ Building
  If you just want to use the latest Release version of Cutter, please note
  that we provide pre-compiled binaries for Windows, Linux, and macOS on
  our `release page <https://github.com/rizinorg/cutter/releases/latest>`_ and
- `CI page <https://github.com/rizinorg/cutter/actions/workflows/ccpp.yml?query=branch%3Amaster>`_ (requires logging in) for latest development builds.
+ `CI page <https://nightly.link/rizinorg/cutter/workflows/ccpp/master>`_ for latest development builds.
 
-This page describes how to do basic build from command line. If you are planning to modify Cutter it is recommended to also read :doc:`development environment setup</contributing/code/ide-setup>`.
+This page describes how to do a basic build from the command line. If you are planning to modify Cutter it is recommended to also read our :doc:`development environment setup</contributing/code/ide-setup>`.
 
 Getting the Source
 ------------------
@@ -109,18 +109,18 @@ You can now execute Cutter like this:
 
 Making Linux distribution specific packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When making a distribution specific packages the default install target should give you a good starting point.
-It uses CMake builtin functionality and `GNUInstallDirs <https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html?highlight=gnu%20directories>`_ for
+When making a distribution specific package, the default install target should give you a good starting point.
+It uses CMake built-in functionality and `GNUInstallDirs <https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html?highlight=gnu%20directories>`_ for
 installing the executable, desktop file, headers and other files required for plugin compilation. See CMake documentation for adjusting installed file locations and properties.
 It shouldn't be necessary to manually copy files from plain build.
 
-It is recommended to build and package rizin as separate package so that it can be used with or without Cutter. Doing that will also give more control over the way rizin dependencies are handled. We are trying to maintain
+It is recommended to build and package rizin as a separate package so that it can be used with or without Cutter. Doing that will also give more control over the way rizin dependencies are handled. We are trying to maintain
 compatibility with latest rizin release at the time of Cutter release and making a new Cutter release when new rizin version is released.
 
-If you are packaging Cutter users will appreciate if you also package `rz-ghidra <https://github.com/rizinorg/rz-ghidra>`_ and `jsdec <https://github.com/rizinorg/jsdec>`_ decompilers as optional packages.
+If you are packaging Cutter, users will appreciate it if you also package `rz-ghidra <https://github.com/rizinorg/rz-ghidra>`_ and `jsdec <https://github.com/rizinorg/jsdec>`_ decompilers as optional packages.
 It should be possible to compile Cutter plugins against proper Cutter installation without having direct access to Cutter source code.
 
-If name Cutter or cutter conflicts with other packages or their content, rz-cutter can be used.
+If the names "Cutter" or "cutter" conflict with other packages or their content, "rz-cutter" can be used.
 
 CMAKE options:
 

--- a/docs/source/contributing/code/ide-setup.rst
+++ b/docs/source/contributing/code/ide-setup.rst
@@ -10,7 +10,7 @@ Everyone has their own preferences for their favorite IDE or code editor.
 There are no strict requirements for using a specific one for Cutter development.
 Any IDE with good CMake integration should work well.
 
-For most development builds, unless you are working on packaging issues, it is recommended to use ``CUTTER_USE_BUNDLED_RIZIN=ON`` Cmake option. It is the easiest way to ensure that a compatible Rizin version is used, and helps you deal with different versions of Rizin when working with multiple Cutter branches. On Linux, in case you have multiple Rizin versions without ``CUTTER_USE_BUNDLED_RIZIN``, the ``PKG_CONFIG_PATH`` environment variable can be used to select the desired Rizin installation.
+For most development builds, unless you are working on packaging issues, it is recommended to build Cutter with the bundled version of Rizin. It is the default configuration and the easiest way to ensure that a compatible Rizin version is used and helps you deal with different versions of Rizin when working with multiple Cutter branches. In case you want to build Cutter with a different version of Rizin installed on your system, you can set `CUTTER_USE_BUNDLED_RIZIN=OFF`. On Linux, in case you have multiple Rizin versions without ``CUTTER_USE_BUNDLED_RIZIN``, the ``PKG_CONFIG_PATH`` environment variable can be used to select the desired Rizin installation.
 
 While `Qt Creator`_ has a builtin visual form and widget editor, not having it in other IDEs is not a major problem. It is also available as a standalone tool called Qt Designer and you can configure the file associations so that ``.ui`` files are opened using it. Depending on the ``.ui`` file and changes you want to make, it is sometimes easier to perform them by editing the ``.ui`` file as a text file. Essentially, ``.ui`` files are XML files. Most code editors should have some support for XML highlighting and possibly block folding.
 
@@ -47,12 +47,6 @@ The following instructions were made based on version 4.12.4 of Qt Creator. The 
 
 - Go to :menuselection:`File --> Open File or Project..` and select :file:`cutter/CMakeList.txt`
 - Select kit and press :guilabel:`Configure Project`
-- Configuration step might fail due to Rizin not being found, that's normal
-- Click :guilabel:`Projects` button with wrench icon on the left side of the screen
-- Click :menuselection:`Add --> Boolean` in the CMake section
-- Enter ``CUTTER_USE_BUNDLED_RIZIN`` as a key name and change the value to ON. In earlier Qt Creator versions it is necessary to do this during the initial kit selection and configuration step.
-- Click :guilabel:`Apply Configuration Changes`: The configuration should succeed now. In case of errors inspect the output log.
-
 
 Formatting using clang-format
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -93,9 +87,6 @@ Project setup
 Changing CMake configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 After the first configuration :kbd:`Ctrl-Shift-P`/:guilabel:`CMake: Edit CMake Cache` opens a text editor with all CMake options. Cutter specific ones mostly start with "CUTTER".
-
-.. note::
-    ``CUTTER_USE_BUNDLED_RIZIN`` option is also defined in ``.vscode/settings.json`` file and it will be overridden from there. It is set to ``ON`` by default as it is recommended during development.
 
 .. _vscode-debug-setup:
 
@@ -142,7 +133,6 @@ Pros and Cons
 Project setup
 ~~~~~~~~~~~~~
 - Go to :menuselection:`File --> Open` and select the folder in which you cloned Cutter
-- Go to :menuselection:`File --> Settings --> Build, Execution, Deployment --> CMake`. In the :guilabel:`CMake Options` field enter ``-DCUTTER_USE_BUNDLED_RIZIN=ON``
 - Open :file:`cutter/CMakeLists.txt` using the project file list on the left side of the screen
 - A yellow bar with a message :guilabel:`CMake project is not loaded` should appear, click :guilabel:`Load CMake project`
 
@@ -189,7 +179,7 @@ Project setup
 ~~~~~~~~~~~~~
 - Open folder in which you cloned Cutter source using Visual Studio
 - Open CMake settings configurator using either :menuselection:`Project --> CMake Settings` or by clicking :guilabel:`Open the CMake Settings Editor` in the overview page.
-- Check ``CUTTER_USE_BUNDLED_RIZIN`` option
+- Check options that you want Cutter to be built with, or leave it as-is for the default options.
 - If you are using vcpkg, Visual Studio should detect it automatically. The list of CMake options in the configurator should have some referring to vcpkg. If they are not there, specify the path to vcpkg toolchain file in the :guilabel:`CMake toolchain file` field.
 - If you are not using vcpkg, configure the path to Qt as mentioned in :ref:`windows CMake instructions<building:Building on Windows>`. You can specify the CMake flag in :guilabel:`CMake command arguments:` field.
 - To Ensure that VS debugger can display Qt types in a readable way, it is recommended to install `Qt Visual Studio Tools <https://marketplace.visualstudio.com/items?itemName=TheQtCompany.QtVisualStudioTools2019>`_ plugin. It will create a :file:`Documents/Visual Studio 2019/Visualizers/qt5.natvis` file. Once :file:`qt5.natvis` has been created you can uninstall the plugin.


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Users and devs are more likely to want to build Cutter with -DCUTTER_USE_BUNDLED_RIZIN enabled. Moreover, it is usually our recommendation and the changes in the docs are a proving this.

I kept some references to `CUTTER_USE_BUNDLED_RIZIN=ON` in a couple of places just for the sake of giving a fuller picture to the reader of these building scripts.

**Test plan (required)**

- CI should pass
- Build with `cmake ..` and see that everything is good

