### PR TITLE
Set rz-ghidra to rz-0.1.1 Tag

### DIFF
--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -108,7 +108,7 @@ if(CUTTER_PACKAGE_RZ_GHIDRA)
 		# installed Cutter.
 		ExternalProject_Add(rz-ghidra
 			GIT_REPOSITORY https://github.com/rizinorg/rz-ghidra
-			GIT_TAG master
+			GIT_TAG rz-0.1.1
 			CONFIGURE_COMMAND ""
 			BUILD_COMMAND ""
 			INSTALL_COMMAND ""


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

rz-ghidra master has been updated for https://github.com/rizinorg/rizin/commit/8baacdddf20b43ad19a465dbb76aee3fbea4a2e6 which will probably not be in 0.1.1 and is also not in the current submodule state.