### PR TITLE
Show stack address value in executable addresses

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1508,7 +1508,7 @@ QJsonObject CutterCore::getAddrRefs(RVA addr, int depth)
     }
 
     // Try to telescope further if depth permits it
-    if ((type & RZ_ANALYSIS_ADDR_TYPE_READ) && !(type & RZ_ANALYSIS_ADDR_TYPE_EXEC)) {
+    if ((type & RZ_ANALYSIS_ADDR_TYPE_READ)) {
         buf.resize(64);
         ut32 *n32 = (ut32 *)buf.data();
         ut64 *n64 = (ut64 *)buf.data();
@@ -1517,7 +1517,7 @@ QJsonObject CutterCore::getAddrRefs(RVA addr, int depth)
         // The value of the next address will serve as an indication that there's more to
         // telescope if we have reached the depth limit
         json["value"] = QString::number(n);
-        if (depth && n != addr) {
+        if (depth && n != addr && !(type & RZ_ANALYSIS_ADDR_TYPE_EXEC)) {
             // Make sure we aren't telescoping the same address
             QJsonObject ref = getAddrRefs(n, depth - 1);
             if (!ref.empty() && !ref["type"].isNull()) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

The "value" field in the stack widget wasn't updated for addresses with executable permissions.

**Test plan (required)**

See that the x5 binary from #2121(or a program built with gcc -z execstack) shows valid stack values for each address instead of zeroes.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #2121