### PR TITLE
Set macOS deployment target to 10.14 Mojave.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -180,6 +180,7 @@ jobs:
       shell: bash
       if: contains(matrix.os, 'macos')
       run: |
+        export MACOSX_DEPLOYMENT_TARGET=10.14
         scripts/fetch_deps.sh
         source cutter-deps/env.sh
         set -euo pipefail

--- a/scripts/fetch_deps.sh
+++ b/scripts/fetch_deps.sh
@@ -12,7 +12,7 @@ MACOS_MD5=f921c007430eec38b06acef8cc0fe42a
 MACOS_URL=https://github.com/rizinorg/cutter-deps/releases/download/v14/cutter-deps-macos.tar.gz
 
 WIN_FILE="cutter-deps-win.tar.gz"
-WIN_MD5=3fbfa9432a67c6e786be296d3a455999
+WIN_MD5=09aa544e62cdd786df3598f1ff340f9e
 WIN_URL=https://github.com/rizinorg/cutter-deps/releases/download/v14/cutter-deps-win.tar.gz
 
 if [ "$OS" == "Windows_NT" ]; then

--- a/scripts/fetch_deps.sh
+++ b/scripts/fetch_deps.sh
@@ -4,16 +4,16 @@ cd $(dirname "${BASH_SOURCE[0]}")/..
 mkdir -p cutter-deps && cd cutter-deps
 
 LINUX_FILE="cutter-deps-linux.tar.gz"
-LINUX_MD5=58142d5fe1a596a1ad70a54210d2f6ca
-LINUX_URL=https://github.com/rizinorg/cutter-deps/releases/download/deploy_test_14/cutter-deps-linux.tar.gz
+LINUX_MD5=eb2710548d951823e6b5340c33c8fc99
+LINUX_URL=https://github.com/rizinorg/cutter-deps/releases/download/v14/cutter-deps-linux.tar.gz
 
 MACOS_FILE="cutter-deps-macos.tar.gz"
-MACOS_MD5=7399274ecc8eae3a0ce79adf321703f9
-MACOS_URL=https://github.com/rizinorg/cutter-deps/releases/download/deploy_test_14/cutter-deps-macos.tar.gz
+MACOS_MD5=f921c007430eec38b06acef8cc0fe42a
+MACOS_URL=https://github.com/rizinorg/cutter-deps/releases/download/v14/cutter-deps-macos.tar.gz
 
 WIN_FILE="cutter-deps-win.tar.gz"
-WIN_MD5=5859ce901ea03e2eec5c32f92220a1a4
-WIN_URL=https://github.com/rizinorg/cutter-deps/releases/download/deploy_test_14/cutter-deps-win.tar.gz
+WIN_MD5=3fbfa9432a67c6e786be296d3a455999
+WIN_URL=https://github.com/rizinorg/cutter-deps/releases/download/v14/cutter-deps-win.tar.gz
 
 if [ "$OS" == "Windows_NT" ]; then
 	FILE="${WIN_FILE}"

--- a/scripts/fetch_deps.sh
+++ b/scripts/fetch_deps.sh
@@ -4,16 +4,16 @@ cd $(dirname "${BASH_SOURCE[0]}")/..
 mkdir -p cutter-deps && cd cutter-deps
 
 LINUX_FILE="cutter-deps-linux.tar.gz"
-LINUX_MD5=6cd6dff0b5e33d5ff62c57b4400603f5
-LINUX_URL=https://github.com/rizinorg/cutter-deps/releases/download/v13/cutter-deps-linux.tar.gz
+LINUX_MD5=58142d5fe1a596a1ad70a54210d2f6ca
+LINUX_URL=https://github.com/rizinorg/cutter-deps/releases/download/deploy_test_14/cutter-deps-linux.tar.gz
 
 MACOS_FILE="cutter-deps-macos.tar.gz"
-MACOS_MD5=4a7fe127d99dc6087c290d828aa19f6b
-MACOS_URL=https://github.com/rizinorg/cutter-deps/releases/download/v13/cutter-deps-macos.tar.gz
+MACOS_MD5=7399274ecc8eae3a0ce79adf321703f9
+MACOS_URL=https://github.com/rizinorg/cutter-deps/releases/download/deploy_test_14/cutter-deps-macos.tar.gz
 
 WIN_FILE="cutter-deps-win.tar.gz"
-WIN_MD5=d867df10fb0c2b029faf737453014da6
-WIN_URL=https://github.com/rizinorg/cutter-deps/releases/download/v13/cutter-deps-win.tar.gz
+WIN_MD5=5859ce901ea03e2eec5c32f92220a1a4
+WIN_URL=https://github.com/rizinorg/cutter-deps/releases/download/deploy_test_14/cutter-deps-win.tar.gz
 
 if [ "$OS" == "Windows_NT" ]; then
 	FILE="${WIN_FILE}"

--- a/scripts/prepare_breakpad_macos.sh
+++ b/scripts/prepare_breakpad_macos.sh
@@ -14,8 +14,8 @@ mkdir $BREAKPAD_DUMP_SYMS_DIR
 cd breakpad
 git checkout 4d550cceca107f36c4bc1ea1126b7d32cc50f424
 git apply "$SCRIPTPATH/breakpad_macos.patch"
-cd src/client/mac/ && xcodebuild -sdk macosx
-cp -R build/Release/Breakpad.framework "$BREAKPAD_FRAMEWORK_DIR"
+cd src/client/mac/ && xcodebuild -sdk macosx MACOSX_DEPLOYMENT_TARGET=10.14
+cp -R build/Release/Breakpad.framework "$BREAKPAD_FRAMEWORK_DIR" 
 
 cd $DIR/breakpad
 cp -R src/. framework/Breakpad.framework/Headers


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

* Set the target version for Cutter build using environment variable to 10.14
* set target version for breakpad build
* update cutter-deps which have been rebuilt with target version set

**Test plan (required)**

* no warnings in the log about libs being  built for newer macOS version, similar to ` was built for newer macOS version (10.15) than being linked (10.14)` :heavy_check_mark: 
* Try running the app on macOS 10.14. (needs volunteers for testing) - 2 people confirmed as fixed :heavy_check_mark: 

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

Closes #2648
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
