### PR TITLE
More QT6 compatibility changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,11 @@ if (CUTTER_QT6)
 else()
     set(QT_PREFIX Qt5)
 endif()
+
 find_package(${QT_PREFIX} REQUIRED COMPONENTS Core Widgets Gui Svg Network)
+if (CUTTER_QT6)
+    find_package(${QT_PREFIX} REQUIRED COMPONENTS Core5Compat SvgWidgets OpenGLWidgets)
+endif()
 
 if(CUTTER_ENABLE_PYTHON)
     find_package(PythonInterp REQUIRED)

--- a/cmake/Translations.cmake
+++ b/cmake/Translations.cmake
@@ -20,8 +20,13 @@ set(TS_FILES
 # translations/pt-BR/cutter_pt.ts #2321 handling multiple versions of a language
 
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/translations)
-find_package(Qt5LinguistTools REQUIRED)
-qt5_add_translation(qmFiles ${TS_FILES})
+if (CUTTER_QT6)
+    find_package(Qt6LinguistTools REQUIRED)
+    qt6_add_translation(qmFiles ${TS_FILES})
+else()
+    find_package(Qt5LinguistTools REQUIRED)
+    qt5_add_translation(qmFiles ${TS_FILES})
+endif()
 add_custom_target(translations ALL DEPENDS ${qmFiles} SOURCES ${TS_FILES})
 
 install(FILES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -459,6 +459,11 @@ if(CUTTER_ENABLE_CRASH_REPORTS)
 endif()
 
 target_link_libraries(Cutter PUBLIC ${QT_PREFIX}::Core ${QT_PREFIX}::Widgets ${QT_PREFIX}::Gui PRIVATE  ${QT_PREFIX}::Svg ${QT_PREFIX}::Network)
+if (CUTTER_QT6)
+    target_link_libraries(Cutter PUBLIC Qt6::Core5Compat Qt6::SvgWidgets)
+    target_link_libraries(Cutter PRIVATE Qt6::OpenGLWidgets)
+endif()
+
 target_link_libraries(Cutter PUBLIC ${RIZIN_TARGET})
 if(CUTTER_ENABLE_PYTHON)
     if (WIN32)

--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -44,7 +44,9 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
     // Setup application information
     setApplicationVersion(CUTTER_VERSION_FULL);
     setWindowIcon(QIcon(":/img/cutter.svg"));
-    setAttribute(Qt::AA_UseHighDpiPixmaps);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    setAttribute(Qt::AA_UseHighDpiPixmaps); // always enabled on Qt >= 6.0.0
+#endif
     setLayoutDirection(Qt::LeftToRight);
 
     // WARN!!! Put initialization code below this line. Code above this line is mandatory to be run

--- a/src/common/ColorThemeWorker.cpp
+++ b/src/common/ColorThemeWorker.cpp
@@ -51,9 +51,9 @@ ColorThemeWorker::ColorThemeWorker(QObject *parent) : QObject(parent)
 
 QColor ColorThemeWorker::mergeColors(const QColor &upper, const QColor &lower) const
 {
-    qreal r1, g1, b1, a1;
-    qreal r2, g2, b2, a2;
-    qreal r, g, b, a;
+    qhelpers::ColorFloat r1, g1, b1, a1;
+    qhelpers::ColorFloat r2, g2, b2, a2;
+    qhelpers::ColorFloat r, g, b, a;
 
     upper.getRgbF(&r1, &g1, &b1, &a1);
     lower.getRgbF(&r2, &g2, &b2, &a2);

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -244,7 +244,8 @@ bool Configuration::setLocaleByName(const QString &language)
             QLocale::matchingLocales(QLocale::AnyLanguage, QLocale::AnyScript, QLocale::AnyCountry);
 
     for (auto &it : allLocales) {
-        if (QString::compare(it.nativeLanguageName(), language, Qt::CaseInsensitive) == 0) {
+        if (QString::compare(it.nativeLanguageName(), language, Qt::CaseInsensitive) == 0 ||
+            it.name() == language) {
             setLocale(it);
             return true;
         }
@@ -650,14 +651,16 @@ QStringList Configuration::getAvailableTranslations()
             QLocale::matchingLocales(QLocale::AnyLanguage, QLocale::AnyScript, QLocale::AnyCountry);
 
     for (auto i : fileNames) {
-        QString localeName = i.mid(sizeof("cutter_") - 1, 2);
-        for (auto j : allLocales) {
-            if (j.name().startsWith(localeName)) {
-                currLanguageName = j.nativeLanguageName();
-                currLanguageName = currLanguageName.at(0).toUpper()
-                        + currLanguageName.right(currLanguageName.length() - 1);
+        QString localeName = i.mid(sizeof("cutter_") - 1, 2); // TODO:#2321 don't asume 2 characters
+        // language code is sometimes 3 characters, and there could also be language_COUNTRY. Qt supports that.
+        QLocale locale(localeName);
+        if (locale.language() != QLocale::C) {
+            currLanguageName = locale.nativeLanguageName();
+            if (currLanguageName.isEmpty()) { // Qt doesn't have native language name for some languages
+                currLanguageName = QLocale::languageToString(locale.language());
+            }
+            if (!currLanguageName.isEmpty()) {
                 languages << currLanguageName;
-                break;
             }
         }
     }

--- a/src/common/Helpers.cpp
+++ b/src/common/Helpers.cpp
@@ -286,4 +286,23 @@ bool filterStringContains(const QString &string, const QSortFilterProxyModel *mo
     return string.contains(model->filterRegularExpression());
 #endif
 }
+
+QPointF mouseEventPos(QMouseEvent *ev)
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    return ev->localPos();
+#else
+    return ev->position();
+#endif
+}
+
+QPoint mouseEventGlobalPos(QMouseEvent *ev)
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    return ev->globalPos();
+#else
+    return ev->globalPosition().toPoint();
+#endif
+}
+
 } // end namespace

--- a/src/common/Helpers.cpp
+++ b/src/common/Helpers.cpp
@@ -278,4 +278,12 @@ void emitColumnChanged(QAbstractItemModel *model, int column)
     }
 }
 
+bool filterStringContains(const QString &string, const QSortFilterProxyModel *model)
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    return string.contains(model->filterRegExp());
+#else
+    return string.contains(model->filterRegularExpression());
+#endif
+}
 } // end namespace

--- a/src/common/Helpers.h
+++ b/src/common/Helpers.h
@@ -24,6 +24,7 @@ class QMenu;
 class QPaintDevice;
 class QComboBox;
 class QSortFilterProxyModel;
+class QMouseEvent;
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 #    define CUTTER_QT_SKIP_EMPTY_PARTS QString::SkipEmptyParts
@@ -88,9 +89,15 @@ CUTTER_EXPORT bool filterStringContains(const QString &string, const QSortFilter
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 using ColorFloat = float;
+using KeyComb = QKeyCombination;
 #else
 using ColorFloat = qreal;
+using KeyComb = int;
 #endif
+
+CUTTER_EXPORT QPointF mouseEventPos(QMouseEvent *ev);
+CUTTER_EXPORT QPoint mouseEventGlobalPos(QMouseEvent *ev);
+
 } // qhelpers
 
 #endif // HELPERS_H

--- a/src/common/Helpers.h
+++ b/src/common/Helpers.h
@@ -23,6 +23,7 @@ class QAction;
 class QMenu;
 class QPaintDevice;
 class QComboBox;
+class QSortFilterProxyModel;
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 #    define CUTTER_QT_SKIP_EMPTY_PARTS QString::SkipEmptyParts
@@ -83,6 +84,7 @@ CUTTER_EXPORT void selectIndexByData(QComboBox *comboBox, QVariant data, int def
  */
 CUTTER_EXPORT void emitColumnChanged(QAbstractItemModel *model, int column);
 
+CUTTER_EXPORT bool filterStringContains(const QString &string, const QSortFilterProxyModel *model);
 } // qhelpers
 
 #endif // HELPERS_H

--- a/src/common/Helpers.h
+++ b/src/common/Helpers.h
@@ -85,6 +85,12 @@ CUTTER_EXPORT void selectIndexByData(QComboBox *comboBox, QVariant data, int def
 CUTTER_EXPORT void emitColumnChanged(QAbstractItemModel *model, int column);
 
 CUTTER_EXPORT bool filterStringContains(const QString &string, const QSortFilterProxyModel *model);
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+using ColorFloat = float;
+#else
+using ColorFloat = qreal;
+#endif
 } // qhelpers
 
 #endif // HELPERS_H

--- a/src/common/JsonModel.cpp
+++ b/src/common/JsonModel.cpp
@@ -1,5 +1,7 @@
 #include "JsonModel.h"
 
+#include <QIODevice>
+
 JsonModel::JsonModel(QObject *parent) : QAbstractItemModel(parent)
 {
     mRootItem = new JsonTreeItem;

--- a/src/common/ResourcePaths.cpp
+++ b/src/common/ResourcePaths.cpp
@@ -5,6 +5,7 @@
 #include <QFileInfo>
 #include <QApplication>
 #include <QDebug>
+#include <QStandardPaths>
 
 #ifdef APPIMAGE
 static QDir appimageRoot()
@@ -76,7 +77,7 @@ QString Cutter::writableLocation(QStandardPaths::StandardLocation type)
 
 QStringList Cutter::getTranslationsDirectories()
 {
-    auto result = locateAll(QStandardPaths::DataLocation, "translations",
+    auto result = locateAll(QStandardPaths::AppDataLocation, "translations",
                             QStandardPaths::LocateDirectory);
     result << QLibraryInfo::location(QLibraryInfo::TranslationsPath);
     return result;

--- a/src/common/UpdateWorker.cpp
+++ b/src/common/UpdateWorker.cpp
@@ -12,6 +12,7 @@
 #    include <QDesktopServices>
 #    include <QtNetwork/QNetworkReply>
 #    include <QtNetwork/QNetworkRequest>
+#    include <QStandardPaths>
 
 #    include <QProgressDialog>
 #    include <QPushButton>
@@ -57,7 +58,12 @@ void UpdateWorker::download(QString filename, QString version)
     downloadFile.open(QIODevice::WriteOnly);
 
     QNetworkRequest request;
+#    if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0) && QT_VERSION < QT_VERSION_CHECK(5, 9, 0)
     request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+#    elif QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                         QNetworkRequest::RedirectPolicy::NoLessSafeRedirectPolicy);
+#    endif
     QUrl url(QString("https://github.com/rizinorg/cutter/releases/"
                      "download/v%1/%2")
                      .arg(version)

--- a/src/dialogs/AttachProcDialog.cpp
+++ b/src/dialogs/AttachProcDialog.cpp
@@ -156,7 +156,7 @@ bool ProcessProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) con
     QModelIndex index = sourceModel()->index(row, 0, parent);
     ProcessDescription item =
             index.data(ProcessModel::ProcDescriptionRole).value<ProcessDescription>();
-    return item.path.contains(filterRegExp());
+    return qhelpers::filterStringContains(item.path, this);
 }
 
 bool ProcessProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const

--- a/src/dialogs/WelcomeDialog.cpp
+++ b/src/dialogs/WelcomeDialog.cpp
@@ -26,7 +26,6 @@ WelcomeDialog::WelcomeDialog(QWidget *parent) : QDialog(parent), ui(new Ui::Welc
     QStringList langs = Config()->getAvailableTranslations();
     ui->languageComboBox->addItems(langs);
     QString curr = Config()->getCurrLocale().nativeLanguageName();
-    curr = curr.at(0).toUpper() + curr.right(curr.length() - 1);
     if (!langs.contains(curr)) {
         curr = "English";
     }
@@ -64,7 +63,7 @@ void WelcomeDialog::on_themeComboBox_currentIndexChanged(int index)
  */
 void WelcomeDialog::onLanguageComboBox_currentIndexChanged(int index)
 {
-    QString language = ui->languageComboBox->itemText(index).toLower();
+    QString language = ui->languageComboBox->itemText(index);
     Config()->setLocaleByName(language);
 
     QMessageBox mb;

--- a/src/dialogs/preferences/AppearanceOptionsWidget.cpp
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.cpp
@@ -33,7 +33,6 @@ AppearanceOptionsWidget::AppearanceOptionsWidget(PreferencesDialog *dialog)
     ui->languageComboBox->addItems(langs);
 
     QString curr = Config()->getCurrLocale().nativeLanguageName();
-    curr = curr.at(0).toUpper() + curr.right(curr.length() - 1);
     if (!langs.contains(curr)) {
         curr = "English";
     }

--- a/src/menus/AddressableItemContextMenu.cpp
+++ b/src/menus/AddressableItemContextMenu.cpp
@@ -20,7 +20,7 @@ AddressableItemContextMenu::AddressableItemContextMenu(QWidget *parent, MainWind
 
     connect(actionCopyAddress, &QAction::triggered, this,
             &AddressableItemContextMenu::onActionCopyAddress);
-    actionCopyAddress->setShortcuts({ Qt::CTRL + Qt::SHIFT + Qt::Key_C });
+    actionCopyAddress->setShortcuts({ Qt::CTRL | Qt::SHIFT | Qt::Key_C });
     actionCopyAddress->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
 
     connect(actionShowXrefs, &QAction::triggered, this,

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -275,7 +275,8 @@ void DecompilerContextMenu::setActionCopy() // Set all three copy actions
     connect(&actionCopyReferenceAddress, &QAction::triggered, this,
             &DecompilerContextMenu::actionCopyReferenceAddressTriggered);
     addAction(&actionCopyReferenceAddress);
-    actionCopyReferenceAddress.setShortcut({ Qt::CTRL + Qt::SHIFT + Qt::Key_C });
+    actionCopyReferenceAddress.setShortcut({ Qt::KeyboardModifier::ControlModifier
+                                             | Qt::KeyboardModifier::ControlModifier | Qt::Key_C });
 }
 
 void DecompilerContextMenu::setActionShowInSubmenu()
@@ -339,14 +340,14 @@ void DecompilerContextMenu::setActionToggleBreakpoint()
 {
     connect(&actionToggleBreakpoint, &QAction::triggered, this,
             &DecompilerContextMenu::actionToggleBreakpointTriggered);
-    actionToggleBreakpoint.setShortcuts({ Qt::Key_F2, Qt::CTRL + Qt::Key_B });
+    actionToggleBreakpoint.setShortcuts({ Qt::Key_F2, Qt::CTRL | Qt::Key_B });
 }
 
 void DecompilerContextMenu::setActionAdvancedBreakpoint()
 {
     connect(&actionAdvancedBreakpoint, &QAction::triggered, this,
             &DecompilerContextMenu::actionAdvancedBreakpointTriggered);
-    actionAdvancedBreakpoint.setShortcut({ Qt::CTRL + Qt::Key_F2 });
+    actionAdvancedBreakpoint.setShortcut({ Qt::CTRL | Qt::Key_F2 });
 }
 
 void DecompilerContextMenu::setActionContinueUntil()

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -135,8 +135,7 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
     addAction(&actionXRefs);
 
     initAction(&actionXRefsForVariables, tr("X-Refs for local variables"),
-               SLOT(on_actionXRefsForVariables_triggered()),
-               QKeySequence({ Qt::SHIFT + Qt::Key_X }));
+               SLOT(on_actionXRefsForVariables_triggered()), QKeySequence(Qt::SHIFT | Qt::Key_X));
     addAction(&actionXRefsForVariables);
 
     initAction(&actionDisplayOptions, tr("Show Options"), SLOT(on_actionDisplayOptions_triggered()),
@@ -302,7 +301,7 @@ void DisassemblyContextMenu::addBreakpointMenu()
                SLOT(on_actionAddBreakpoint_triggered()), getAddBPSequence());
     breakpointMenu->addAction(&actionAddBreakpoint);
     initAction(&actionAdvancedBreakpoint, tr("Advanced breakpoint"),
-               SLOT(on_actionAdvancedBreakpoint_triggered()), QKeySequence(Qt::CTRL + Qt::Key_F2));
+               SLOT(on_actionAdvancedBreakpoint_triggered()), QKeySequence(Qt::CTRL | Qt::Key_F2));
     breakpointMenu->addAction(&actionAdvancedBreakpoint);
 }
 
@@ -675,7 +674,7 @@ QKeySequence DisassemblyContextMenu::getLinkTypeSequence() const
 
 QList<QKeySequence> DisassemblyContextMenu::getAddBPSequence() const
 {
-    return { Qt::Key_F2, Qt::CTRL + Qt::Key_B };
+    return { Qt::Key_F2, Qt::CTRL | Qt::Key_B };
 }
 
 QKeySequence DisassemblyContextMenu::getDefineNewFunctionSequence() const
@@ -685,7 +684,7 @@ QKeySequence DisassemblyContextMenu::getDefineNewFunctionSequence() const
 
 QKeySequence DisassemblyContextMenu::getEditFunctionSequence() const
 {
-    return { Qt::SHIFT + Qt::Key_P };
+    return { Qt::SHIFT | Qt::Key_P };
 }
 
 QKeySequence DisassemblyContextMenu::getUndefineFunctionSequence() const

--- a/src/widgets/ClassesWidget.cpp
+++ b/src/widgets/ClassesWidget.cpp
@@ -525,7 +525,7 @@ ClassesSortFilterProxyModel::ClassesSortFilterProxyModel(QObject *parent)
 bool ClassesSortFilterProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) const
 {
     QModelIndex index = sourceModel()->index(row, 0, parent);
-    return index.data(ClassesModel::NameRole).toString().contains(filterRegExp());
+    return qhelpers::filterStringContains(index.data(ClassesModel::NameRole).toString(), this);
 }
 
 bool ClassesSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const

--- a/src/widgets/ColorThemeComboBox.cpp
+++ b/src/widgets/ColorThemeComboBox.cpp
@@ -47,7 +47,7 @@ void ColorThemeComboBox::updateFromConfig(bool interfaceThemeChanged)
         }
     }
     setMinimumContentsLength(maxThemeLen);
-    setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLength);
+    setSizeAdjustPolicy(QComboBox::AdjustToContents);
 }
 
 void ColorThemeComboBox::onCurrentIndexChanged(int index)

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -372,6 +372,7 @@ bool ColorSettingsModel::setData(const QModelIndex &index, const QVariant &value
 
 void ColorSettingsModel::updateTheme()
 {
+    beginResetModel();
     theme.clear();
     QJsonObject obj = ThemeWorker().getTheme(Config()->getColorTheme()).object();
 
@@ -391,9 +392,7 @@ void ColorSettingsModel::updateTheme()
         int r = s1.compare(s2, Qt::CaseSensitivity::CaseInsensitive);
         return r < 0;
     });
-    if (!theme.isEmpty()) {
-        dataChanged(index(0), index(theme.size() - 1));
-    }
+    endResetModel();
 }
 
 QJsonDocument ColorSettingsModel::getTheme() const

--- a/src/widgets/CommentsWidget.cpp
+++ b/src/widgets/CommentsWidget.cpp
@@ -195,7 +195,7 @@ bool CommentsProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) co
     QModelIndex index = sourceModel()->index(row, 0, parent);
     auto comment = index.data(CommentsModel::CommentDescriptionRole).value<CommentDescription>();
 
-    return comment.name.contains(filterRegExp());
+    return qhelpers::filterStringContains(comment.name, this);
 }
 
 bool CommentsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const

--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -77,7 +77,7 @@ ConsoleWidget::ConsoleWidget(MainWindow *main)
     addAction(actionClear);
 
     // Ctrl+l to clear the output
-    actionClear->setShortcut(Qt::CTRL + Qt::Key_L);
+    actionClear->setShortcut(Qt::CTRL | Qt::Key_L);
     actionClear->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     actions.append(actionClear);
 

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -2,7 +2,7 @@
 #include "core/MainWindow.h"
 
 #include <QEvent>
-#include <QtWidgets/QShortcut>
+#include <QShortcut>
 
 CutterDockWidget::CutterDockWidget(MainWindow *parent, QAction *) : CutterDockWidget(parent) {}
 

--- a/src/widgets/CutterGraphView.cpp
+++ b/src/widgets/CutterGraphView.cpp
@@ -10,9 +10,11 @@
 #include <QStandardPaths>
 #include <QActionGroup>
 
-static const int KEY_ZOOM_IN = Qt::Key_Plus + Qt::ControlModifier;
-static const int KEY_ZOOM_OUT = Qt::Key_Minus + Qt::ControlModifier;
-static const int KEY_ZOOM_RESET = Qt::Key_Equal + Qt::ControlModifier;
+static const qhelpers::KeyComb KEY_ZOOM_IN = Qt::Key_Plus | Qt::ControlModifier;
+static const qhelpers::KeyComb KEY_ZOOM_IN2 =
+        Qt::Key_Plus | (Qt::ControlModifier | Qt::ShiftModifier);
+static const qhelpers::KeyComb KEY_ZOOM_OUT = Qt::Key_Minus | Qt::ControlModifier;
+static const qhelpers::KeyComb KEY_ZOOM_RESET = Qt::Key_Equal | Qt::ControlModifier;
 
 static const uint64_t BITMPA_EXPORT_WARNING_SIZE = 32 * 1024 * 1024;
 
@@ -205,9 +207,9 @@ bool CutterGraphView::event(QEvent *event)
     switch (event->type()) {
     case QEvent::ShortcutOverride: {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
-        int key = keyEvent->key() + keyEvent->modifiers();
+        qhelpers::KeyComb key = Qt::Key(keyEvent->key()) | keyEvent->modifiers();
         if (key == KEY_ZOOM_OUT || key == KEY_ZOOM_RESET || key == KEY_ZOOM_IN
-            || (key == (KEY_ZOOM_IN | Qt::ShiftModifier))) {
+            || key == KEY_ZOOM_IN2) {
             event->accept();
             return true;
         }
@@ -215,8 +217,8 @@ bool CutterGraphView::event(QEvent *event)
     }
     case QEvent::KeyPress: {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
-        int key = keyEvent->key() + keyEvent->modifiers();
-        if (key == KEY_ZOOM_IN || (key == (KEY_ZOOM_IN | Qt::ShiftModifier))) {
+        qhelpers::KeyComb key = Qt::Key(keyEvent->key()) | keyEvent->modifiers();
+        if (key == KEY_ZOOM_IN || key == KEY_ZOOM_IN2) {
             zoomIn();
             return true;
         } else if (key == KEY_ZOOM_OUT) {

--- a/src/widgets/CutterGraphView.cpp
+++ b/src/widgets/CutterGraphView.cpp
@@ -97,7 +97,7 @@ void CutterGraphView::initFont()
     setFont(Config()->getFont());
     QFontMetricsF metrics(font());
     baseline = int(metrics.ascent());
-    charWidth = metrics.width('X');
+    charWidth = metrics.maxWidth();
     charHeight = static_cast<int>(metrics.height());
     charOffset = 0;
     mFontMetrics.reset(new CachedFontMetrics<qreal>(font()));

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -68,15 +68,15 @@ DebugActions::DebugActions(QToolBar *toolBar, MainWindow *main) : QObject(main),
     actionContinueUntilCall = new QAction(continueUCLabel, this);
     actionContinueUntilSyscall = new QAction(continueUSLabel, this);
     actionContinueBack = new QAction(continueBackIcon, continueBackLabel, this);
-    actionContinueBack->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_F5));
+    actionContinueBack->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_F5));
     actionStep = new QAction(stepLabel, this);
     actionStep->setShortcut(QKeySequence(Qt::Key_F7));
     actionStepOver = new QAction(stepOverLabel, this);
     actionStepOver->setShortcut(QKeySequence(Qt::Key_F8));
     actionStepOut = new QAction(stepOutLabel, this);
-    actionStepOut->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_F8));
+    actionStepOut->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_F8));
     actionStepBack = new QAction(stepBackIcon, stepBackLabel, this);
-    actionStepBack->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_F7));
+    actionStepBack->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_F7));
     actionTrace = new QAction(startTraceIcon, startTraceLabel, this);
 
     QToolButton *startButton = new QToolButton;

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -64,7 +64,7 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main)
     // Setup the disassembly content
     auto *layout = new QHBoxLayout;
     layout->addWidget(mDisasTextEdit);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     mDisasScrollArea->viewport()->setLayout(layout);
     splitter->addWidget(mDisasScrollArea);
     mDisasScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAlwaysOff);

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -650,8 +650,7 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
         && (obj == mDisasTextEdit || obj == mDisasTextEdit->viewport())) {
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
 
-        const QTextCursor &cursor =
-                mDisasTextEdit->cursorForPosition(QPoint(mouseEvent->x(), mouseEvent->y()));
+        const QTextCursor &cursor = mDisasTextEdit->cursorForPosition(mouseEvent->pos());
         jumpToOffsetUnderCursor(cursor);
 
         return true;

--- a/src/widgets/ExportsWidget.cpp
+++ b/src/widgets/ExportsWidget.cpp
@@ -98,7 +98,7 @@ bool ExportsProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) con
     QModelIndex index = sourceModel()->index(row, 0, parent);
     auto exp = index.data(ExportsModel::ExportDescriptionRole).value<ExportDescription>();
 
-    return exp.name.contains(filterRegExp());
+    return qhelpers::filterStringContains(exp.name, this);
 }
 
 bool ExportsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -107,7 +107,7 @@ bool FlagsSortFilterProxyModel::filterAcceptsRow(int row, const QModelIndex &par
 {
     QModelIndex index = sourceModel()->index(row, 0, parent);
     FlagDescription flag = index.data(FlagsModel::FlagDescriptionRole).value<FlagDescription>();
-    return flag.name.contains(filterRegExp()) || flag.realname.contains(filterRegExp());
+    return qhelpers::filterStringContains(flag.name, this);
 }
 
 bool FlagsSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -368,7 +368,8 @@ bool FunctionSortFilterProxyModel::filterAcceptsRow(int row, const QModelIndex &
     QModelIndex index = sourceModel()->index(row, 0, parent);
     FunctionDescription function =
             index.data(FunctionModel::FunctionDescriptionRole).value<FunctionDescription>();
-    return function.name.contains(filterRegExp());
+
+    return qhelpers::filterStringContains(function.name, this);
 }
 
 bool FunctionSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const

--- a/src/widgets/GraphGridLayout.cpp
+++ b/src/widgets/GraphGridLayout.cpp
@@ -1600,9 +1600,11 @@ void GraphGridLayout::optimizeLayout(GraphGridLayout::LayoutState &state) const
     };
 
     auto copyVariablesToPositions = [&](const std::vector<int> &solution, bool horizontal = false) {
+#ifndef NDEBUG
         for (auto v : solution) {
             assert(v >= 0);
         }
+#endif
         size_t variableIndex = blockMapping.size();
         for (auto &blockIt : *state.blocks) {
             auto &block = blockIt.second;

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -156,8 +156,7 @@ void GraphView::cleanupEdges(GraphLayout::Graph &graph)
 
 void GraphView::beginMouseDrag(QMouseEvent *event)
 {
-    scroll_base_x = event->x();
-    scroll_base_y = event->y();
+    scrollBase = event->pos();
     scroll_mode = true;
     setCursor(Qt::ClosedHandCursor);
     viewport()->grabMouse();
@@ -690,10 +689,8 @@ void GraphView::mousePressEvent(QMouseEvent *event)
 void GraphView::mouseMoveEvent(QMouseEvent *event)
 {
     if (scroll_mode) {
-        addViewOffset(QPoint(scroll_base_x - event->x(), scroll_base_y - event->y())
-                      / current_scale);
-        scroll_base_x = event->x();
-        scroll_base_y = event->y();
+        addViewOffset((scrollBase - event->pos()) / current_scale);
+        scrollBase = event->pos();
         viewport()->update();
     }
 }

--- a/src/widgets/GraphView.h
+++ b/src/widgets/GraphView.h
@@ -189,9 +189,7 @@ private:
 
     std::unique_ptr<GraphLayout> graphLayoutSystem;
 
-    // Scrolling data
-    int scroll_base_x = 0;
-    int scroll_base_y = 0;
+    QPoint scrollBase;
     bool scroll_mode = false;
 
     bool useGL;

--- a/src/widgets/HeadersWidget.cpp
+++ b/src/widgets/HeadersWidget.cpp
@@ -89,7 +89,7 @@ bool HeadersProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) con
     QModelIndex index = sourceModel()->index(row, 0, parent);
     HeaderDescription item =
             index.data(HeadersModel::HeaderDescriptionRole).value<HeaderDescription>();
-    return item.name.contains(filterRegExp());
+    return qhelpers::filterStringContains(item.name, this);
 }
 
 bool HeadersProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -1168,7 +1168,7 @@ void HexWidget::updateMetrics()
 {
     QFontMetricsF fontMetrics(this->monospaceFont);
     lineHeight = fontMetrics.height();
-    charWidth = fontMetrics.width(QLatin1Char('F'));
+    charWidth = fontMetrics.maxWidth();
 
     updateCounts();
     updateAreasHeight();

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -116,7 +116,7 @@ HexWidget::HexWidget(QWidget *parent)
 
     actionCopyAddress = new QAction(tr("Copy address"), this);
     actionCopyAddress->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
-    actionCopyAddress->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_C);
+    actionCopyAddress->setShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_C);
     connect(actionCopyAddress, &QAction::triggered, this, &HexWidget::copyAddress);
     addAction(actionCopyAddress);
 
@@ -472,7 +472,7 @@ void HexWidget::mouseMoveEvent(QMouseEvent *event)
 
     QString metaData = getFlagsAndComment(mouseAddr);
     if (!metaData.isEmpty() && itemArea.contains(pos)) {
-        QToolTip::showText(event->globalPos(), metaData.replace(",", ", "), this);
+        QToolTip::showText(mapToGlobal(event->pos()), metaData.replace(",", ", "), this);
     } else {
         QToolTip::hideText();
     }

--- a/src/widgets/ImportsWidget.cpp
+++ b/src/widgets/ImportsWidget.cpp
@@ -9,14 +9,11 @@
 #include <QShortcut>
 #include <QTreeWidget>
 
-ImportsModel::ImportsModel(QList<ImportDescription> *imports, QObject *parent)
-    : AddressableItemModel(parent), imports(imports)
-{
-}
+ImportsModel::ImportsModel(QObject *parent) : AddressableItemModel(parent) {}
 
 int ImportsModel::rowCount(const QModelIndex &parent) const
 {
-    return parent.isValid() ? 0 : imports->count();
+    return parent.isValid() ? 0 : imports.count();
 }
 
 int ImportsModel::columnCount(const QModelIndex &) const
@@ -26,7 +23,7 @@ int ImportsModel::columnCount(const QModelIndex &) const
 
 QVariant ImportsModel::data(const QModelIndex &index, int role) const
 {
-    const ImportDescription &import = imports->at(index.row());
+    const ImportDescription &import = imports.at(index.row());
     switch (role) {
     case Qt::ForegroundRole:
         if (index.column() < ImportsModel::ColumnCount) {
@@ -91,20 +88,27 @@ QVariant ImportsModel::headerData(int section, Qt::Orientation, int role) const
 
 RVA ImportsModel::address(const QModelIndex &index) const
 {
-    const ImportDescription &import = imports->at(index.row());
+    const ImportDescription &import = imports.at(index.row());
     return import.plt;
 }
 
 QString ImportsModel::name(const QModelIndex &index) const
 {
-    const ImportDescription &import = imports->at(index.row());
+    const ImportDescription &import = imports.at(index.row());
     return import.name;
 }
 
 QString ImportsModel::libname(const QModelIndex &index) const
 {
-    const ImportDescription &import = imports->at(index.row());
+    const ImportDescription &import = imports.at(index.row());
     return import.libname;
+}
+
+void ImportsModel::reload()
+{
+    beginResetModel();
+    imports = Core()->getAllImports();
+    endResetModel();
 }
 
 ImportsProxyModel::ImportsProxyModel(ImportsModel *sourceModel, QObject *parent)
@@ -162,7 +166,7 @@ bool ImportsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &rig
 
 ImportsWidget::ImportsWidget(MainWindow *main)
     : ListDockWidget(main),
-      importsModel(new ImportsModel(&imports, this)),
+      importsModel(new ImportsModel(this)),
       importsProxyModel(new ImportsProxyModel(importsModel, this))
 {
     setWindowTitle(tr("Imports"));
@@ -184,8 +188,6 @@ ImportsWidget::~ImportsWidget() {}
 
 void ImportsWidget::refreshImports()
 {
-    importsModel->beginResetModel();
-    imports = Core()->getAllImports();
-    importsModel->endResetModel();
+    importsModel->reload();
     qhelpers::adjustColumns(ui->treeView, 4, 0);
 }

--- a/src/widgets/ImportsWidget.cpp
+++ b/src/widgets/ImportsWidget.cpp
@@ -123,7 +123,7 @@ bool ImportsProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) con
     QModelIndex index = sourceModel()->index(row, 0, parent);
     auto import = index.data(ImportsModel::ImportDescriptionRole).value<ImportDescription>();
 
-    return import.name.contains(filterRegExp());
+    return qhelpers::filterStringContains(import.name, this);
 }
 
 bool ImportsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const

--- a/src/widgets/ImportsWidget.h
+++ b/src/widgets/ImportsWidget.h
@@ -52,7 +52,7 @@ private:
                            "OemToChar|OemToCharA|OemToCharW|CharToOemBuffA|CharToOemBuffW|alloca|_"
                            "alloca|strlen|wcslen|_mbslen|_mbstrlen|StrLen|lstrlen|"
                            "ChangeWindowMessageFilter)\\z"));
-    QList<ImportDescription> *imports;
+    QList<ImportDescription> imports;
 
 public:
     enum Column {
@@ -66,7 +66,7 @@ public:
     };
     enum Role { ImportDescriptionRole = Qt::UserRole, AddressRole };
 
-    ImportsModel(QList<ImportDescription> *imports, QObject *parent = nullptr);
+    ImportsModel(QObject *parent = nullptr);
 
     int rowCount(const QModelIndex &parent) const override;
     int columnCount(const QModelIndex &parent) const override;
@@ -77,6 +77,7 @@ public:
     RVA address(const QModelIndex &index) const override;
     QString name(const QModelIndex &index) const override;
     QString libname(const QModelIndex &index) const;
+    void reload();
 };
 
 class ImportsProxyModel : public AddressableFilterProxyModel
@@ -105,7 +106,6 @@ private slots:
 private:
     ImportsModel *importsModel;
     ImportsProxyModel *importsProxyModel;
-    QList<ImportDescription> imports;
 
     void highlightUnsafe();
 };

--- a/src/widgets/MemoryMapWidget.cpp
+++ b/src/widgets/MemoryMapWidget.cpp
@@ -88,7 +88,7 @@ bool MemoryProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) cons
     QModelIndex index = sourceModel()->index(row, 0, parent);
     MemoryMapDescription item =
             index.data(MemoryMapModel::MemoryDescriptionRole).value<MemoryMapDescription>();
-    return item.name.contains(filterRegExp());
+    return qhelpers::filterStringContains(item.name, this);
 }
 
 bool MemoryProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -88,16 +88,13 @@ void OverviewView::paintEvent(QPaintEvent *event)
 void OverviewView::mousePressEvent(QMouseEvent *event)
 {
     mouseActive = true;
-    if (rangeRect.contains(event->pos())) {
-        initialDiff = QPointF(event->localPos().x() - rangeRect.x(),
-                              event->localPos().y() - rangeRect.y());
+    auto pos = qhelpers::mouseEventPos(event);
+    if (rangeRect.contains(pos)) {
+        initialDiff = pos - rangeRect.topLeft();
     } else {
-        qreal w = rangeRect.width();
-        qreal h = rangeRect.height();
-        qreal x = event->localPos().x() - w / 2;
-        qreal y = event->localPos().y() - h / 2;
-        rangeRect = QRectF(x, y, w, h);
-        initialDiff = QPointF(w / 2, h / 2);
+        QPointF size(rangeRect.width(), rangeRect.height());
+        initialDiff = size * 0.5;
+        rangeRect.moveCenter(pos);
         viewport()->update();
         emit mouseMoved();
     }
@@ -114,9 +111,8 @@ void OverviewView::mouseMoveEvent(QMouseEvent *event)
     if (!mouseActive) {
         return;
     }
-    qreal x = event->localPos().x() - initialDiff.x();
-    qreal y = event->localPos().y() - initialDiff.y();
-    rangeRect = QRectF(x, y, rangeRect.width(), rangeRect.height());
+    QPointF topLeft = qhelpers::mouseEventPos(event) - initialDiff;
+    rangeRect.setTopLeft(topLeft);
     viewport()->update();
     emit mouseMoved();
 }

--- a/src/widgets/ProcessesWidget.cpp
+++ b/src/widgets/ProcessesWidget.cpp
@@ -166,7 +166,8 @@ void ProcessesWidget::onActivated(const QModelIndex &index)
     for (QJsonValue value : processesValues) {
         QString status = value.toObject()["status"].toString();
         if (pid == value.toObject()["pid"].toInt()) {
-            if (QString(RZ_DBG_PROC_ZOMBIE) == status || QString(RZ_DBG_PROC_DEAD) == status) {
+            if (QString(QChar(RZ_DBG_PROC_ZOMBIE)) == status
+                || QString(QChar(RZ_DBG_PROC_DEAD)) == status) {
                 QMessageBox msgBox;
                 msgBox.setText(tr("Unable to switch to the requested process."));
                 msgBox.exec();

--- a/src/widgets/ProcessesWidget.cpp
+++ b/src/widgets/ProcessesWidget.cpp
@@ -191,7 +191,7 @@ bool ProcessesFilterModel::filterAcceptsRow(int row, const QModelIndex &parent) 
     // All columns are checked for a match
     for (int i = COLUMN_PID; i <= COLUMN_PATH; ++i) {
         QModelIndex index = sourceModel()->index(row, i, parent);
-        if (sourceModel()->data(index).toString().contains(filterRegExp())) {
+        if (qhelpers::filterStringContains(sourceModel()->data(index).toString(), this)) {
             return true;
         }
     }

--- a/src/widgets/RegisterRefsWidget.cpp
+++ b/src/widgets/RegisterRefsWidget.cpp
@@ -90,7 +90,7 @@ bool RegisterRefProxyModel::filterAcceptsRow(int row, const QModelIndex &parent)
     QModelIndex index = sourceModel()->index(row, 0, parent);
     RegisterRefDescription item = index.data(RegisterRefModel::RegisterRefDescriptionRole)
                                           .value<RegisterRefDescription>();
-    return item.reg.contains(filterRegExp());
+    return qhelpers::filterStringContains(item.reg, this);
 }
 
 bool RegisterRefProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const

--- a/src/widgets/RegistersWidget.cpp
+++ b/src/widgets/RegistersWidget.cpp
@@ -88,7 +88,7 @@ void RegistersWidget::setRegisterGrid()
             registerEditValue = qobject_cast<QLineEdit *>(regValueWidget);
         }
         // decide to highlight QLine Box in case of change of register value
-        if (regValue != registerEditValue->text() && registerEditValue->text() != 0) {
+        if (regValue != registerEditValue->text() && !registerEditValue->text().isEmpty()) {
             registerEditValue->setStyleSheet("border: 1px solid green;");
         } else {
             // reset stylesheet

--- a/src/widgets/RelocsWidget.cpp
+++ b/src/widgets/RelocsWidget.cpp
@@ -6,14 +6,11 @@
 #include <QShortcut>
 #include <QTreeWidget>
 
-RelocsModel::RelocsModel(QList<RelocDescription> *relocs, QObject *parent)
-    : AddressableItemModel<QAbstractTableModel>(parent), relocs(relocs)
-{
-}
+RelocsModel::RelocsModel(QObject *parent) : AddressableItemModel<QAbstractTableModel>(parent) {}
 
 int RelocsModel::rowCount(const QModelIndex &parent) const
 {
-    return parent.isValid() ? 0 : relocs->count();
+    return parent.isValid() ? 0 : relocs.count();
 }
 
 int RelocsModel::columnCount(const QModelIndex &) const
@@ -23,7 +20,7 @@ int RelocsModel::columnCount(const QModelIndex &) const
 
 QVariant RelocsModel::data(const QModelIndex &index, int role) const
 {
-    const RelocDescription &reloc = relocs->at(index.row());
+    const RelocDescription &reloc = relocs.at(index.row());
     switch (role) {
     case Qt::DisplayRole:
         switch (index.column()) {
@@ -67,14 +64,21 @@ QVariant RelocsModel::headerData(int section, Qt::Orientation, int role) const
 
 RVA RelocsModel::address(const QModelIndex &index) const
 {
-    const RelocDescription &reloc = relocs->at(index.row());
+    const RelocDescription &reloc = relocs.at(index.row());
     return reloc.vaddr;
 }
 
 QString RelocsModel::name(const QModelIndex &index) const
 {
-    const RelocDescription &reloc = relocs->at(index.row());
+    const RelocDescription &reloc = relocs.at(index.row());
     return reloc.name;
+}
+
+void RelocsModel::reload()
+{
+    beginResetModel();
+    relocs = Core()->getAllRelocs();
+    endResetModel();
 }
 
 RelocsProxyModel::RelocsProxyModel(RelocsModel *sourceModel, QObject *parent)
@@ -121,7 +125,7 @@ bool RelocsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &righ
 
 RelocsWidget::RelocsWidget(MainWindow *main)
     : ListDockWidget(main),
-      relocsModel(new RelocsModel(&relocs, this)),
+      relocsModel(new RelocsModel(this)),
       relocsProxyModel(new RelocsProxyModel(relocsModel, this))
 {
     setWindowTitle(tr("Relocs"));
@@ -140,8 +144,6 @@ RelocsWidget::~RelocsWidget() {}
 
 void RelocsWidget::refreshRelocs()
 {
-    relocsModel->beginResetModel();
-    relocs = Core()->getAllRelocs();
-    relocsModel->endResetModel();
+    relocsModel->reload();
     qhelpers::adjustColumns(ui->treeView, 3, 0);
 }

--- a/src/widgets/RelocsWidget.cpp
+++ b/src/widgets/RelocsWidget.cpp
@@ -93,7 +93,7 @@ bool RelocsProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) cons
     QModelIndex index = sourceModel()->index(row, 0, parent);
     auto reloc = index.data(RelocsModel::RelocDescriptionRole).value<RelocDescription>();
 
-    return reloc.name.contains(filterRegExp());
+    return qhelpers::filterStringContains(reloc.name, this);
 }
 
 bool RelocsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const

--- a/src/widgets/RelocsWidget.h
+++ b/src/widgets/RelocsWidget.h
@@ -19,13 +19,13 @@ class RelocsModel : public AddressableItemModel<QAbstractTableModel>
     friend RelocsWidget;
 
 private:
-    QList<RelocDescription> *relocs;
+    QList<RelocDescription> relocs;
 
 public:
     enum Column { VAddrColumn = 0, TypeColumn, NameColumn, CommentColumn, ColumnCount };
     enum Role { RelocDescriptionRole = Qt::UserRole, AddressRole };
 
-    RelocsModel(QList<RelocDescription> *relocs, QObject *parent = nullptr);
+    RelocsModel(QObject *parent = nullptr);
 
     int rowCount(const QModelIndex &parent) const override;
     int columnCount(const QModelIndex &parent) const override;
@@ -35,6 +35,8 @@ public:
 
     RVA address(const QModelIndex &index) const override;
     QString name(const QModelIndex &index) const override;
+
+    void reload();
 };
 
 class RelocsProxyModel : public AddressableFilterProxyModel
@@ -63,7 +65,6 @@ private slots:
 private:
     RelocsModel *relocsModel;
     RelocsProxyModel *relocsProxyModel;
-    QList<RelocDescription> relocs;
 };
 
 #endif // RELOCSWIDGET_H

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -145,7 +145,7 @@ bool SearchSortFilterProxyModel::filterAcceptsRow(int row, const QModelIndex &pa
     QModelIndex index = sourceModel()->index(row, 0, parent);
     SearchDescription search =
             index.data(SearchModel::SearchDescriptionRole).value<SearchDescription>();
-    return search.code.contains(filterRegExp());
+    return qhelpers::filterStringContains(search.code, this);
 }
 
 bool SearchSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const

--- a/src/widgets/StringsWidget.h
+++ b/src/widgets/StringsWidget.h
@@ -59,10 +59,9 @@ class StringsProxyModel : public AddressableFilterProxyModel
 {
     Q_OBJECT
 
-    friend StringsWidget;
-
 public:
     StringsProxyModel(StringsModel *sourceModel, QObject *parent = nullptr);
+    void setSelectedSection(QString section);
 
 protected:
     bool filterAcceptsRow(int row, const QModelIndex &parent) const override;

--- a/src/widgets/SymbolsWidget.cpp
+++ b/src/widgets/SymbolsWidget.cpp
@@ -94,7 +94,7 @@ bool SymbolsProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) con
     QModelIndex index = sourceModel()->index(row, 0, parent);
     auto symbol = index.data(SymbolsModel::SymbolDescriptionRole).value<SymbolDescription>();
 
-    return symbol.name.contains(filterRegExp());
+    return qhelpers::filterStringContains(symbol.name, this);
 }
 
 bool SymbolsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const

--- a/src/widgets/ThreadsWidget.cpp
+++ b/src/widgets/ThreadsWidget.cpp
@@ -174,7 +174,7 @@ bool ThreadsFilterModel::filterAcceptsRow(int row, const QModelIndex &parent) co
     // All columns are checked for a match
     for (int i = COLUMN_PID; i <= COLUMN_PATH; ++i) {
         QModelIndex index = sourceModel()->index(row, i, parent);
-        if (sourceModel()->data(index).toString().contains(filterRegExp())) {
+        if (qhelpers::filterStringContains(sourceModel()->data(index).toString(), this)) {
             return true;
         }
     }

--- a/src/widgets/TypesWidget.h
+++ b/src/widgets/TypesWidget.h
@@ -50,10 +50,9 @@ class TypesSortFilterProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
 
-    friend TypesWidget;
-
 public:
     TypesSortFilterProxyModel(TypesModel *source_model, QObject *parent = nullptr);
+    void setCategory(QString category);
 
 protected:
     bool filterAcceptsRow(int row, const QModelIndex &parent) const override;

--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -240,10 +240,11 @@ void VisualNavbar::on_seekChanged(RVA addr)
 
 void VisualNavbar::mousePressEvent(QMouseEvent *event)
 {
-    qreal x = event->localPos().x();
+    qreal x = qhelpers::mouseEventPos(event).x();
     RVA address = localXToAddress(x);
     if (address != RVA_INVALID) {
-        QToolTip::showText(event->globalPos(), toolTipForAddress(address), this);
+        auto tooltipPos = qhelpers::mouseEventGlobalPos(event);
+        QToolTip::showText(tooltipPos, toolTipForAddress(address), this, this->rect());
         if (event->buttons() & Qt::LeftButton) {
             event->accept();
             Core()->seek(address);

--- a/src/widgets/WidgetShortcuts.h
+++ b/src/widgets/WidgetShortcuts.h
@@ -1,10 +1,14 @@
 #ifndef WIDGETSHORTCUTS_H
 #define WIDGETSHORTCUTS_H
 
+#include <QKeySequence>
+#include <QHash>
+#include <QString>
+
 static const QHash<QString, QKeySequence> widgetShortcuts = {
-    { "StringsWidget", Qt::SHIFT + Qt::Key_F12 },      { "GraphWidget", Qt::SHIFT + Qt::Key_G },
-    { "ImportsWidget", Qt::SHIFT + Qt::Key_I },        { "ExportsWidget", Qt::SHIFT + Qt::Key_E },
-    { "ConsoleWidget", Qt::CTRL + Qt::Key_QuoteLeft }, { "ConsoleWidgetAlternative", Qt::Key_Colon }
+    { "StringsWidget", Qt::SHIFT | Qt::Key_F12 },      { "GraphWidget", Qt::SHIFT | Qt::Key_G },
+    { "ImportsWidget", Qt::SHIFT | Qt::Key_I },        { "ExportsWidget", Qt::SHIFT | Qt::Key_E },
+    { "ConsoleWidget", Qt::CTRL | Qt::Key_QuoteLeft }, { "ConsoleWidgetAlternative", Qt::Key_Colon }
 };
 
 #endif

--- a/src/widgets/ZignaturesWidget.cpp
+++ b/src/widgets/ZignaturesWidget.cpp
@@ -87,7 +87,7 @@ bool ZignaturesProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) 
     QModelIndex index = sourceModel()->index(row, 0, parent);
     ZignatureDescription item =
             index.data(ZignaturesModel::ZignatureDescriptionRole).value<ZignatureDescription>();
-    return item.name.contains(filterRegExp());
+    return qhelpers::filterStringContains(item.name, this);
 }
 
 bool ZignaturesProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

For now should build in minimal config  `-DCUTTER_QT6=ON -DCUTTER_ENABLE_PYTHON=OFF -DCUTTER_ENABLE_PYTHON_BINDINGS=OFF -DCUTTER_ENABLE_KSYNTAXHIGHLIGHTING=OFF`

It's necessary to manually disable CUTTER_ENABLE_KSYNTAXHIGHLIGHTING because otherwise it might find the QT5 version of it and then complain that it's incompatible with rest of QT libs which are QT6.

**Test plan (required)**

* Ubuntu 16.04 job with oldest supported Qt5 version still builds :heavy_check_mark: 
* test one of the filters QT5-:heavy_check_mark: QT6-:heavy_check_mark: 
* test that filter reset using invalidateRowsFilter works as intended  QT5-:heavy_check_mark:  QT6-:heavy_check_mark: 
* test color picker
* when built with Qt6 Cutter opens and basic functionality works :heavy_check_mark: 
* test refactored shortcuts  QT5-:heavy_check_mark:  QT6-:heavy_check_mark:
* mouse drag in graph view QT5-:heavy_check_mark: QT6-:heavy_check_mark:
* navbar drag QT5-:heavy_check_mark: QT6-:heavy_check_mark:

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

Related #2464
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
