### PR TITLE
fixed SIGSEGV caused by wrong initialization order

### DIFF
--- a/src/widgets/ImportsWidget.h
+++ b/src/widgets/ImportsWidget.h
@@ -103,9 +103,9 @@ private slots:
     void refreshImports();
 
 private:
+    QList<ImportDescription> imports;
     ImportsModel *importsModel;
     ImportsProxyModel *importsProxyModel;
-    QList<ImportDescription> imports;
 
     void highlightUnsafe();
 };

--- a/src/widgets/RelocsWidget.h
+++ b/src/widgets/RelocsWidget.h
@@ -61,9 +61,9 @@ private slots:
     void refreshRelocs();
 
 private:
+    QList<RelocDescription> relocs;
     RelocsModel *relocsModel;
     RelocsProxyModel *relocsProxyModel;
-    QList<RelocDescription> relocs;
 };
 
 #endif // RELOCSWIDGET_H


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

For the `ImportsWidget` class, its `importsModel` and `importsProxyModel` are initialized before the constructor, whilst the `imports` variable is initialized **after** them using default initlization order. (See https://en.cppreference.com/w/cpp/language/constructor (**Initialization order** section))

This leads to undefined behaviour when taking the address of `imports` to construct the ones before `imports` itself is constructed. 

This PR changed the order that they three appears in the class member variable declaration, making `imports` the first one of the three to construct, which fixed a possible segmentation fault on my machine.

The same for RelocsWidget

Update: 

My SIGSEGV back trace:

![image](https://user-images.githubusercontent.com/76251897/114594782-3a422780-9cc0-11eb-8a7c-2733a834145e.png)




**Test plan (required)**

Compile and run.


**Closing issues**

Currently none.

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
