### PR TITLE
Fix package name for macOS builds

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -187,7 +187,7 @@ jobs:
         source scripts/prepare_breakpad_macos.sh
         mkdir build
         cd build
-        PACKAGE_NAME=Cutter-${PACKAGE_ID}-Darwin
+        PACKAGE_NAME=Cutter-${PACKAGE_ID}-x64.macOS
         cmake \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DPYTHON_LIBRARY="$CUTTER_DEPS_PYTHON_PREFIX/lib/libpython3.9.dylib" \


### PR DESCRIPTION

**Detailed description**
This PR fixes the name of the build for macOS.

Wrong:  Cutter-v2.0.1-Darwin.dmg
Right: Cutter-v2.0.1-x64.macOS.dmg