### PR TITLE
Fix a crash when printing disassembly arrows

### DIFF
--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -870,16 +870,17 @@ void DisassemblyLeftPanel::paintEvent(QPaintEvent *event)
     p.fillRect(event->rect(), Config()->getColor("gui.background").darker(115));
 
     QList<DisassemblyLine> lines = disas->getLines();
+    if (lines.size() == 0) {
+        // No line to print, abort early
+        return;
+    }
 
     using LineInfo = std::pair<RVA, int>;
     std::vector<LineInfo> lineOffsets;
     lineOffsets.reserve(lines.size() + arrows.size());
 
     RVA minViewOffset = 0, maxViewOffset = 0;
-
-    if (lines.size() > 0) {
-        minViewOffset = maxViewOffset = lines[0].offset;
-    }
+    minViewOffset = maxViewOffset = lines[0].offset;
 
     for (int i = 0; i < lines.size(); i++) {
         lineOffsets.emplace_back(lines[i].offset, i);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Added a condition to abort early in the (rare) event that the disassembly window does not contain any line.
Maybe adding an assert will be better.
Anyways a second patch will come to fix the original issue.