### PR TITLE
Add missing rz_diff

### DIFF
--- a/cmake/BundledRizin.cmake
+++ b/cmake/BundledRizin.cmake
@@ -48,7 +48,7 @@ endif()
 
 set (RZ_LIBS rz_core rz_config rz_cons rz_io rz_util rz_flag rz_asm rz_debug
         rz_hash rz_bin rz_lang rz_io rz_analysis rz_parse rz_bp rz_egg rz_reg
-        rz_search rz_syscall rz_socket rz_magic rz_crypto rz_type)
+        rz_search rz_syscall rz_socket rz_magic rz_crypto rz_type rz_diff)
 set (RZ_EXTRA_LIBS rz_main)
 set (RZ_BIN rz-agent rz-bin rizin rz-diff rz-find rz-gg rz-hash rz-run rz-asm rz-ax)
 


### PR DESCRIPTION

**Detailed description**
Windows builds are failing to start because they can't find `rz_diff.dll`. This PR tries to resolve it

**Testing**
Wait for the build to over, download the Windows build of Cutter and run it. You **should not** get an errror