### PR TITLE
Heap bins view

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,6 +144,7 @@ set(SOURCES
     dialogs/GlibcHeapInfoDialog.cpp
     widgets/HeapDockWidget.cpp
     widgets/GlibcHeapWidget.cpp
+        dialogs/GlibcHeapBinsDialog.cpp
 )
 set(HEADER_FILES
     core/Cutter.h
@@ -299,7 +300,8 @@ set(HEADER_FILES
     common/DecompilerHighlighter.h
     dialogs/GlibcHeapInfoDialog.h
     widgets/HeapDockWidget.h
-    widgets/GlibcHeapWidget.h
+        widgets/GlibcHeapWidget.h
+        dialogs/GlibcHeapBinsDialog.h
 )
 set(UI_FILES
     dialogs/AboutDialog.ui
@@ -368,7 +370,8 @@ set(UI_FILES
     dialogs/preferences/AnalOptionsWidget.ui
     dialogs/GlibcHeapInfoDialog.ui
     widgets/HeapDockWidget.ui
-    widgets/GlibcHeapWidget.ui
+        widgets/GlibcHeapWidget.ui
+        dialogs/GlibcHeapBinsDialog.ui
 )
 set(QRC_FILES
     resources.qrc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,18 +134,18 @@ set(SOURCES
     common/CutterLayout.cpp
     widgets/GraphHorizontalAdapter.cpp
     common/ResourcePaths.cpp
-        widgets/CutterGraphView.cpp
-        widgets/SimpleTextGraphView.cpp
-        widgets/RizinGraphWidget.cpp
-        widgets/CallGraph.cpp
-        widgets/AddressableDockWidget.cpp
-        dialogs/preferences/AnalOptionsWidget.cpp
-        common/DecompilerHighlighter.cpp
-        dialogs/GlibcHeapInfoDialog.cpp
-        widgets/HeapDockWidget.cpp
-        widgets/GlibcHeapWidget.cpp
-        dialogs/GlibcHeapBinsDialog.cpp
-        widgets/HeapBinsGraphView.cpp
+    widgets/CutterGraphView.cpp
+    widgets/SimpleTextGraphView.cpp
+    widgets/RizinGraphWidget.cpp
+    widgets/CallGraph.cpp
+    widgets/AddressableDockWidget.cpp
+    dialogs/preferences/AnalOptionsWidget.cpp
+    common/DecompilerHighlighter.cpp
+    dialogs/GlibcHeapInfoDialog.cpp
+    widgets/HeapDockWidget.cpp
+    widgets/GlibcHeapWidget.cpp
+    dialogs/GlibcHeapBinsDialog.cpp
+    widgets/HeapBinsGraphView.cpp
         )
 set(HEADER_FILES
     core/Cutter.h
@@ -291,19 +291,19 @@ set(HEADER_FILES
     common/BinaryTrees.h
     common/LinkedListPool.h
     widgets/GraphHorizontalAdapter.h
-        common/ResourcePaths.h
-        widgets/CutterGraphView.h
-        widgets/SimpleTextGraphView.h
-        widgets/RizinGraphWidget.h
-        widgets/CallGraph.h
-        widgets/AddressableDockWidget.h
-        dialogs/preferences/AnalOptionsWidget.h
-        common/DecompilerHighlighter.h
-        dialogs/GlibcHeapInfoDialog.h
-        widgets/HeapDockWidget.h
-        widgets/GlibcHeapWidget.h
-        dialogs/GlibcHeapBinsDialog.h
-        widgets/HeapBinsGraphView.h
+    common/ResourcePaths.h
+    widgets/CutterGraphView.h
+    widgets/SimpleTextGraphView.h
+    widgets/RizinGraphWidget.h
+    widgets/CallGraph.h
+    widgets/AddressableDockWidget.h
+    dialogs/preferences/AnalOptionsWidget.h
+    common/DecompilerHighlighter.h
+    dialogs/GlibcHeapInfoDialog.h
+    widgets/HeapDockWidget.h
+    widgets/GlibcHeapWidget.h
+    dialogs/GlibcHeapBinsDialog.h
+    widgets/HeapBinsGraphView.h
         )
 set(UI_FILES
     dialogs/AboutDialog.ui
@@ -362,18 +362,18 @@ set(UI_FILES
     dialogs/WelcomeDialog.ui
     dialogs/EditMethodDialog.ui
     dialogs/TypesInteractionDialog.ui
-        widgets/SdbWidget.ui
-        dialogs/LinkTypeDialog.ui
-        widgets/ColorPicker.ui
-        dialogs/preferences/ColorThemeEditDialog.ui
-        widgets/ListDockWidget.ui
-        dialogs/LayoutManager.ui
-        widgets/RizinGraphWidget.ui
-        dialogs/preferences/AnalOptionsWidget.ui
-        dialogs/GlibcHeapInfoDialog.ui
-        widgets/HeapDockWidget.ui
-        widgets/GlibcHeapWidget.ui
-        dialogs/GlibcHeapBinsDialog.ui
+    widgets/SdbWidget.ui
+    dialogs/LinkTypeDialog.ui
+    widgets/ColorPicker.ui
+    dialogs/preferences/ColorThemeEditDialog.ui
+    widgets/ListDockWidget.ui
+    dialogs/LayoutManager.ui
+    widgets/RizinGraphWidget.ui
+    dialogs/preferences/AnalOptionsWidget.ui
+    dialogs/GlibcHeapInfoDialog.ui
+    widgets/HeapDockWidget.ui
+    widgets/GlibcHeapWidget.ui
+    dialogs/GlibcHeapBinsDialog.ui
         )
 set(QRC_FILES
     resources.qrc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,18 +134,19 @@ set(SOURCES
     common/CutterLayout.cpp
     widgets/GraphHorizontalAdapter.cpp
     common/ResourcePaths.cpp
-    widgets/CutterGraphView.cpp
-    widgets/SimpleTextGraphView.cpp
-    widgets/RizinGraphWidget.cpp
-    widgets/CallGraph.cpp
-    widgets/AddressableDockWidget.cpp
-    dialogs/preferences/AnalOptionsWidget.cpp
-    common/DecompilerHighlighter.cpp
-    dialogs/GlibcHeapInfoDialog.cpp
-    widgets/HeapDockWidget.cpp
-    widgets/GlibcHeapWidget.cpp
+        widgets/CutterGraphView.cpp
+        widgets/SimpleTextGraphView.cpp
+        widgets/RizinGraphWidget.cpp
+        widgets/CallGraph.cpp
+        widgets/AddressableDockWidget.cpp
+        dialogs/preferences/AnalOptionsWidget.cpp
+        common/DecompilerHighlighter.cpp
+        dialogs/GlibcHeapInfoDialog.cpp
+        widgets/HeapDockWidget.cpp
+        widgets/GlibcHeapWidget.cpp
         dialogs/GlibcHeapBinsDialog.cpp
-)
+        widgets/HeapBinsGraphView.cpp
+        )
 set(HEADER_FILES
     core/Cutter.h
     core/CutterCommon.h
@@ -290,19 +291,20 @@ set(HEADER_FILES
     common/BinaryTrees.h
     common/LinkedListPool.h
     widgets/GraphHorizontalAdapter.h
-    common/ResourcePaths.h
-    widgets/CutterGraphView.h
-    widgets/SimpleTextGraphView.h
-    widgets/RizinGraphWidget.h
-    widgets/CallGraph.h
-    widgets/AddressableDockWidget.h
-    dialogs/preferences/AnalOptionsWidget.h
-    common/DecompilerHighlighter.h
-    dialogs/GlibcHeapInfoDialog.h
-    widgets/HeapDockWidget.h
+        common/ResourcePaths.h
+        widgets/CutterGraphView.h
+        widgets/SimpleTextGraphView.h
+        widgets/RizinGraphWidget.h
+        widgets/CallGraph.h
+        widgets/AddressableDockWidget.h
+        dialogs/preferences/AnalOptionsWidget.h
+        common/DecompilerHighlighter.h
+        dialogs/GlibcHeapInfoDialog.h
+        widgets/HeapDockWidget.h
         widgets/GlibcHeapWidget.h
         dialogs/GlibcHeapBinsDialog.h
-)
+        widgets/HeapBinsGraphView.h
+        )
 set(UI_FILES
     dialogs/AboutDialog.ui
     dialogs/EditStringDialog.ui
@@ -360,19 +362,19 @@ set(UI_FILES
     dialogs/WelcomeDialog.ui
     dialogs/EditMethodDialog.ui
     dialogs/TypesInteractionDialog.ui
-    widgets/SdbWidget.ui
-    dialogs/LinkTypeDialog.ui
-    widgets/ColorPicker.ui
-    dialogs/preferences/ColorThemeEditDialog.ui
-    widgets/ListDockWidget.ui
-    dialogs/LayoutManager.ui
-    widgets/RizinGraphWidget.ui
-    dialogs/preferences/AnalOptionsWidget.ui
-    dialogs/GlibcHeapInfoDialog.ui
-    widgets/HeapDockWidget.ui
+        widgets/SdbWidget.ui
+        dialogs/LinkTypeDialog.ui
+        widgets/ColorPicker.ui
+        dialogs/preferences/ColorThemeEditDialog.ui
+        widgets/ListDockWidget.ui
+        dialogs/LayoutManager.ui
+        widgets/RizinGraphWidget.ui
+        dialogs/preferences/AnalOptionsWidget.ui
+        dialogs/GlibcHeapInfoDialog.ui
+        widgets/HeapDockWidget.ui
         widgets/GlibcHeapWidget.ui
         dialogs/GlibcHeapBinsDialog.ui
-)
+        )
 set(QRC_FILES
     resources.qrc
     themes/native/native.qrc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,7 +146,7 @@ set(SOURCES
     widgets/GlibcHeapWidget.cpp
     dialogs/GlibcHeapBinsDialog.cpp
     widgets/HeapBinsGraphView.cpp
-        )
+)
 set(HEADER_FILES
     core/Cutter.h
     core/CutterCommon.h
@@ -304,7 +304,7 @@ set(HEADER_FILES
     widgets/GlibcHeapWidget.h
     dialogs/GlibcHeapBinsDialog.h
     widgets/HeapBinsGraphView.h
-        )
+)
 set(UI_FILES
     dialogs/AboutDialog.ui
     dialogs/EditStringDialog.ui
@@ -374,7 +374,7 @@ set(UI_FILES
     widgets/HeapDockWidget.ui
     widgets/GlibcHeapWidget.ui
     dialogs/GlibcHeapBinsDialog.ui
-        )
+)
 set(QRC_FILES
     resources.qrc
     themes/native/native.qrc

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1631,7 +1631,7 @@ QVector<RzHeapBin *> CutterCore::getHeapBins(ut64 arena_addr)
 
     // get small, large, unsorted bins
     for (int i = 0; i <= NBINS - 2; i++) {
-        RzHeapBin *bin = rz_heap_bin_content(core, arena, i);
+        RzHeapBin *bin = rz_heap_bin_content(core, arena, i, arena_addr);
         if (!bin) {
             continue;
         }

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1629,7 +1629,7 @@ QVector<RzHeapBin *> CutterCore::getHeapBins(ut64 arena_addr)
         return bins_vector;
     }
 
-    // get chunks for small, large, unsorted bins
+    // get small, large, unsorted bins
     for (int i = 0; i <= NBINS - 2; i++) {
         RzHeapBin *bin = rz_heap_bin_content(core, arena, i);
         if (!bin) {
@@ -1641,7 +1641,7 @@ QVector<RzHeapBin *> CutterCore::getHeapBins(ut64 arena_addr)
         }
         bins_vector.append(bin);
     }
-    // get chunks for fastbins
+    // get fastbins
     for (int i = 0; i < 10; i++) {
         RzHeapBin *bin = rz_heap_fastbin_content(core, arena, i);
         if (!bin) {

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1623,11 +1623,13 @@ QVector<RzHeapBin *> CutterCore::getHeapBins(ut64 arena_addr)
 {
     CORE_LOCK();
     QVector<RzHeapBin *> bins_vector;
+
     MallocState *arena = rz_heap_get_arena(core, arena_addr);
     if (!arena) {
         return bins_vector;
     }
-    // small large unsorted
+
+    // get chunks for small, large, unsorted bins
     for (int i = 0; i <= NBINS - 2; i++) {
         RzHeapBin *bin = rz_heap_bin_content(core, arena, i);
         if (!bin) {
@@ -1639,7 +1641,7 @@ QVector<RzHeapBin *> CutterCore::getHeapBins(ut64 arena_addr)
         }
         bins_vector.append(bin);
     }
-    // fastbins
+    // get chunks for fastbins
     for (int i = 0; i < 10; i++) {
         RzHeapBin *bin = rz_heap_fastbin_content(core, arena, i);
         if (!bin) {
@@ -1651,6 +1653,7 @@ QVector<RzHeapBin *> CutterCore::getHeapBins(ut64 arena_addr)
         }
         bins_vector.append(bin);
     }
+
     return bins_vector;
 }
 

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -419,6 +419,7 @@ public:
      * @return RzHeapChunkSimple struct pointer for the heap chunk
      */
     RzHeapChunkSimple *getHeapChunk(ut64 addr);
+    QVector<RzHeapBin *> getHeapBins(ut64 arena_addr);
     void startDebug();
     void startEmulation();
     /**

--- a/src/dialogs/GlibcHeapBinsDialog.cpp
+++ b/src/dialogs/GlibcHeapBinsDialog.cpp
@@ -31,6 +31,7 @@ void GlibcHeapBinsDialog::onCurrentChanged(const QModelIndex &current, const QMo
     auto currentIndex = ui->viewBins->selectionModel()->currentIndex();
     setChainInfo(currentIndex.row());
 }
+
 void GlibcHeapBinsDialog::setChainInfo(int index)
 {
     RzListIter *iter;
@@ -47,10 +48,12 @@ void GlibcHeapBinsDialog::setChainInfo(int index)
     }
     ui->chainInfoEdit->setPlainText(chainInfo);
 }
+
 BinsModel::BinsModel(RVA arena_addr, QObject *parent)
     : QAbstractTableModel(parent), arena_addr(arena_addr)
 {
 }
+
 void BinsModel::reload()
 {
     beginResetModel();
@@ -58,14 +61,17 @@ void BinsModel::reload()
     values = Core()->getHeapBins(arena_addr);
     endResetModel();
 }
+
 int BinsModel::rowCount(const QModelIndex &) const
 {
     return values.size();
 }
+
 int BinsModel::columnCount(const QModelIndex &) const
 {
     return ColumnCount;
 }
+
 QVariant BinsModel::data(const QModelIndex &index, int role) const
 {
     if (!index.isValid() || index.row() >= values.count())
@@ -125,10 +131,12 @@ void BinsModel::clearData()
         rz_heap_bin_free_64(item);
     }
 }
+
 RzList *BinsModel::getChunks(int index)
 {
     return values[index]->chunks;
 }
+
 QString BinsModel::getBinMessage(int index)
 {
     if (values[index]->message) {

--- a/src/dialogs/GlibcHeapBinsDialog.cpp
+++ b/src/dialogs/GlibcHeapBinsDialog.cpp
@@ -78,10 +78,8 @@ void GlibcHeapBinsDialog::showHeapInfoDialog()
         GlibcHeapInfoDialog dialog(offset, QString(), this);
         dialog.exec();
     }
-
-    // clear the lineEdit after showing dialog box
-    ui->lineEdit->clear();
 }
+
 void GlibcHeapBinsDialog::setGraphView(int index)
 {
     if (graphView) {

--- a/src/dialogs/GlibcHeapBinsDialog.cpp
+++ b/src/dialogs/GlibcHeapBinsDialog.cpp
@@ -18,6 +18,7 @@ GlibcHeapBinsDialog::GlibcHeapBinsDialog(RVA m_state, QWidget *parent)
             &GlibcHeapBinsDialog::onCurrentChanged);
 
     binsModel->reload();
+    ui->viewBins->resizeColumnsToContents();
 
     this->setWindowTitle(tr("Bins info for arena @ ") + RAddressString(m_state));
 }
@@ -119,15 +120,15 @@ QVariant BinsModel::headerData(int section, Qt::Orientation orientation, int rol
         case BinNumColumn:
             return tr("#");
         case FdColumn:
-            return tr("fd");
+            return tr("Fd");
         case BkColumn:
-            return tr("bk");
+            return tr("Bk");
         case TypeColumn:
-            return tr("type");
+            return tr("Type");
         case CountColumn:
-            return tr("chunks cnt");
+            return tr("Chunks count");
         case SizeColumn:
-            return tr("chunks size");
+            return tr("Chunks size");
         default:
             return QVariant();
         }

--- a/src/dialogs/GlibcHeapBinsDialog.cpp
+++ b/src/dialogs/GlibcHeapBinsDialog.cpp
@@ -77,13 +77,15 @@ QVariant BinsModel::data(const QModelIndex &index, int role) const
         case BinNumColumn:
             return item->bin_num;
         case FdColumn:
-            return RAddressString(item->fd);
+            return (item->fd == 0) ? tr("N/A") : RAddressString(item->fd);
         case BkColumn:
-            return RAddressString(item->bk);
+            return (item->bk == 0) ? tr("N/A") : RAddressString(item->bk);
         case TypeColumn:
             return QString(item->type);
         case CountColumn:
             return rz_list_length(item->chunks);
+        case SizeColumn:
+            return (item->size == 0) ? tr("N/A") : RHexString(item->size);
         default:
             return QVariant();
         }
@@ -106,7 +108,9 @@ QVariant BinsModel::headerData(int section, Qt::Orientation orientation, int rol
         case TypeColumn:
             return tr("type");
         case CountColumn:
-            return tr("#chunks");
+            return tr("chunks cnt");
+        case SizeColumn:
+            return tr("chunks size");
         default:
             return QVariant();
         }

--- a/src/dialogs/GlibcHeapBinsDialog.cpp
+++ b/src/dialogs/GlibcHeapBinsDialog.cpp
@@ -132,6 +132,24 @@ QVariant BinsModel::headerData(int section, Qt::Orientation orientation, int rol
         default:
             return QVariant();
         }
+
+    case Qt::ToolTipRole:
+        switch (section) {
+        case BinNumColumn:
+            return tr("Bin number in NBINS or fastbinsY array");
+        case FdColumn:
+            return tr("Pointer to first chunk of the bin");
+        case BkColumn:
+            return tr("Pointer to last chunk of the bin");
+        case TypeColumn:
+            return tr("Type of bin");
+        case CountColumn:
+            return tr("Number of chunks in the bin");
+        case SizeColumn:
+            return tr("Size of all chunks in the bin");
+        default:
+            return QVariant();
+        }
     default:
         return QVariant();
     }

--- a/src/dialogs/GlibcHeapBinsDialog.cpp
+++ b/src/dialogs/GlibcHeapBinsDialog.cpp
@@ -1,0 +1,135 @@
+#include "GlibcHeapBinsDialog.h"
+#include "ui_GlibcHeapBinsDialog.h"
+
+GlibcHeapBinsDialog::GlibcHeapBinsDialog(RVA m_state, QWidget *parent)
+    : QDialog(parent),
+      ui(new Ui::GlibcHeapBinsDialog),
+      m_state(m_state),
+      binsModel(new BinsModel(m_state, this))
+{
+    ui->setupUi(this);
+    ui->viewBins->setModel(binsModel);
+    ui->viewBins->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
+    ui->viewBins->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+    ui->viewBins->verticalHeader()->hide();
+    binsModel->reload();
+    ui->viewBins->resizeColumnsToContents();
+    this->setWindowTitle(tr("Bins info for arena @ ") + RAddressString(m_state));
+    connect(ui->viewBins->selectionModel(), &QItemSelectionModel::currentChanged, this,
+            &GlibcHeapBinsDialog::onCurrentChanged);
+}
+
+GlibcHeapBinsDialog::~GlibcHeapBinsDialog()
+{
+    delete ui;
+}
+
+void GlibcHeapBinsDialog::onCurrentChanged(const QModelIndex &current, const QModelIndex &prev)
+{
+    Q_UNUSED(current);
+    Q_UNUSED(prev);
+    auto currentIndex = ui->viewBins->selectionModel()->currentIndex();
+    setChainInfo(currentIndex.row());
+}
+void GlibcHeapBinsDialog::setChainInfo(int index)
+{
+    RzListIter *iter;
+    RzHeapChunkListItem *item;
+    RzList *chunks = binsModel->getChunks(index);
+    QString chainInfo;
+    CutterRListForeach(chunks, iter, RzHeapChunkListItem, item)
+    {
+        chainInfo += " → " + RAddressString(item->addr);
+    }
+    QString message = binsModel->getBinMessage(index);
+    if (!message.isEmpty()) {
+        chainInfo += " " + message;
+    }
+    ui->chainInfoEdit->setPlainText(chainInfo);
+}
+BinsModel::BinsModel(RVA arena_addr, QObject *parent)
+    : QAbstractTableModel(parent), arena_addr(arena_addr)
+{
+}
+void BinsModel::reload()
+{
+    beginResetModel();
+    clearData();
+    values = Core()->getHeapBins(arena_addr);
+    endResetModel();
+}
+int BinsModel::rowCount(const QModelIndex &) const
+{
+    return values.size();
+}
+int BinsModel::columnCount(const QModelIndex &) const
+{
+    return ColumnCount;
+}
+QVariant BinsModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() >= values.count())
+        return QVariant();
+    const auto &item = values.at(index.row());
+    switch (role) {
+    case Qt::DisplayRole:
+        switch (index.column()) {
+        case BinNumColumn:
+            return item->bin_num;
+        case FdColumn:
+            return RAddressString(item->fd);
+        case BkColumn:
+            return RAddressString(item->bk);
+        case TypeColumn:
+            return QString(item->type);
+        case CountColumn:
+            return rz_list_length(item->chunks);
+        default:
+            return QVariant();
+        }
+    default:
+        return QVariant();
+    }
+}
+QVariant BinsModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    Q_UNUSED(orientation);
+    switch (role) {
+    case Qt::DisplayRole:
+        switch (section) {
+        case BinNumColumn:
+            return tr("#");
+        case FdColumn:
+            return tr("fd");
+        case BkColumn:
+            return tr("bk");
+        case TypeColumn:
+            return tr("type");
+        case CountColumn:
+            return tr("#chunks");
+        default:
+            return QVariant();
+        }
+    default:
+        return QVariant();
+    }
+}
+
+void BinsModel::clearData()
+{
+    for (auto item : values) {
+        rz_heap_bin_free_64(item);
+    }
+}
+RzList *BinsModel::getChunks(int index)
+{
+    return values[index]->chunks;
+}
+QString BinsModel::getBinMessage(int index)
+{
+    if (values[index]->message) {
+        return QString(values[index]->message);
+    } else {
+        return QString();
+    }
+}

--- a/src/dialogs/GlibcHeapBinsDialog.cpp
+++ b/src/dialogs/GlibcHeapBinsDialog.cpp
@@ -1,3 +1,4 @@
+#include <HeapBinsGraphView.h>
 #include "GlibcHeapBinsDialog.h"
 #include "ui_GlibcHeapBinsDialog.h"
 #include "GlibcHeapInfoDialog.h"
@@ -22,6 +23,7 @@ GlibcHeapBinsDialog::GlibcHeapBinsDialog(RVA m_state, QWidget *parent)
 
     binsModel->reload();
     ui->viewBins->resizeColumnsToContents();
+    ui->horizontalLayout->addWidget(new HeapBinsGraphView(this, binsModel->values[1]));
 
     this->setWindowTitle(tr("Bins info for arena @ ") + RAddressString(m_state));
 }

--- a/src/dialogs/GlibcHeapBinsDialog.h
+++ b/src/dialogs/GlibcHeapBinsDialog.h
@@ -14,7 +14,15 @@ class BinsModel : public QAbstractTableModel
     Q_OBJECT
 public:
     explicit BinsModel(RVA arena_addr, QObject *parent = nullptr);
-    enum Column { TypeColumn = 0, BinNumColumn, FdColumn, BkColumn, CountColumn, ColumnCount };
+    enum Column {
+        TypeColumn = 0,
+        BinNumColumn,
+        FdColumn,
+        BkColumn,
+        CountColumn,
+        SizeColumn,
+        ColumnCount
+    };
     void reload();
     int rowCount(const QModelIndex &parent) const override;
     int columnCount(const QModelIndex &parent) const override;

--- a/src/dialogs/GlibcHeapBinsDialog.h
+++ b/src/dialogs/GlibcHeapBinsDialog.h
@@ -4,6 +4,8 @@
 #include <QDialog>
 #include <QAbstractTableModel>
 #include "core/Cutter.h"
+#include <MainWindow.h>
+#include <HeapBinsGraphView.h>
 
 namespace Ui {
 class GlibcHeapBinsDialog;
@@ -42,10 +44,11 @@ class GlibcHeapBinsDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit GlibcHeapBinsDialog(RVA m_state, QWidget *parent = nullptr);
+    explicit GlibcHeapBinsDialog(RVA i, MainWindow *main, QWidget *parent);
     ~GlibcHeapBinsDialog();
     void onCurrentChanged(const QModelIndex &current, const QModelIndex &prev);
     void setChainInfo(int index);
+    void setGraphView(int index);
 private slots:
     void showHeapInfoDialog();
 
@@ -53,6 +56,8 @@ private:
     Ui::GlibcHeapBinsDialog *ui;
     RVA m_state;
     BinsModel *binsModel {};
+    HeapBinsGraphView *graphView;
+    MainWindow *main;
 };
 
 #endif // GLIBCHEAPBINSDIALOG_H

--- a/src/dialogs/GlibcHeapBinsDialog.h
+++ b/src/dialogs/GlibcHeapBinsDialog.h
@@ -1,0 +1,48 @@
+#ifndef GLIBCHEAPBINSDIALOG_H
+#define GLIBCHEAPBINSDIALOG_H
+
+#include <QDialog>
+#include <QAbstractTableModel>
+#include "core/Cutter.h"
+
+namespace Ui {
+class GlibcHeapBinsDialog;
+}
+
+class BinsModel : public QAbstractTableModel
+{
+    Q_OBJECT
+public:
+    explicit BinsModel(RVA arena_addr, QObject *parent = nullptr);
+    enum Column { TypeColumn = 0, BinNumColumn, FdColumn, BkColumn, CountColumn, ColumnCount };
+    void reload();
+    int rowCount(const QModelIndex &parent) const override;
+    int columnCount(const QModelIndex &parent) const override;
+    void clearData();
+    QVariant data(const QModelIndex &index, int role) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+    RVA arena_addr = 0;
+    RzList *getChunks(int index);
+    QString getBinMessage(int index);
+
+private:
+    QVector<RzHeapBin *> values;
+};
+
+class GlibcHeapBinsDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit GlibcHeapBinsDialog(RVA m_state, QWidget *parent = nullptr);
+    ~GlibcHeapBinsDialog();
+    void onCurrentChanged(const QModelIndex &current, const QModelIndex &prev);
+    void setChainInfo(int index);
+
+private:
+    Ui::GlibcHeapBinsDialog *ui;
+    RVA m_state;
+    BinsModel *binsModel {};
+};
+
+#endif // GLIBCHEAPBINSDIALOG_H

--- a/src/dialogs/GlibcHeapBinsDialog.h
+++ b/src/dialogs/GlibcHeapBinsDialog.h
@@ -46,6 +46,8 @@ public:
     ~GlibcHeapBinsDialog();
     void onCurrentChanged(const QModelIndex &current, const QModelIndex &prev);
     void setChainInfo(int index);
+private slots:
+    void showHeapInfoDialog();
 
 private:
     Ui::GlibcHeapBinsDialog *ui;

--- a/src/dialogs/GlibcHeapBinsDialog.h
+++ b/src/dialogs/GlibcHeapBinsDialog.h
@@ -32,9 +32,9 @@ public:
     RVA arena_addr = 0;
     RzList *getChunks(int index);
     QString getBinMessage(int index);
+    QVector<RzHeapBin *> values;
 
 private:
-    QVector<RzHeapBin *> values;
 };
 
 class GlibcHeapBinsDialog : public QDialog

--- a/src/dialogs/GlibcHeapBinsDialog.ui
+++ b/src/dialogs/GlibcHeapBinsDialog.ui
@@ -6,8 +6,8 @@
             <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>400</width>
-                <height>300</height>
+                <width>613</width>
+                <height>402</height>
             </rect>
         </property>
         <property name="windowTitle">

--- a/src/dialogs/GlibcHeapBinsDialog.ui
+++ b/src/dialogs/GlibcHeapBinsDialog.ui
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+    <class>GlibcHeapBinsDialog</class>
+    <widget class="QDialog" name="GlibcHeapBinsDialog">
+        <property name="geometry">
+            <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>400</width>
+                <height>300</height>
+            </rect>
+        </property>
+        <property name="windowTitle">
+            <string>Dialog</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+            <item>
+                <widget class="QTableView" name="viewBins"/>
+            </item>
+            <item>
+                <widget class="QLabel" name="label">
+                    <property name="text">
+                        <string>Chain info:</string>
+                    </property>
+                </widget>
+            </item>
+            <item>
+                <widget class="QPlainTextEdit" name="chainInfoEdit"/>
+            </item>
+        </layout>
+    </widget>
+    <resources/>
+    <connections/>
+</ui>

--- a/src/dialogs/GlibcHeapBinsDialog.ui
+++ b/src/dialogs/GlibcHeapBinsDialog.ui
@@ -13,35 +13,39 @@
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
-    <widget class="QTableView" name="viewBins"/>
-   </item>
-   <item>
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Chain info:</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QPlainTextEdit" name="chainInfoEdit"/>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
      <item>
-      <widget class="QLabel" name="label_2">
+      <widget class="QTableView" name="viewBins"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
        <property name="text">
-        <string>Detailed chunk info:</string>
+        <string>Chain info:</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="lineEdit">
-       <property name="placeholderText">
-        <string>Enter chunk base address and press enter</string>
-       </property>
-      </widget>
+      <widget class="QPlainTextEdit" name="chainInfoEdit"/>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout3">
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Detailed chunk info:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="lineEdit">
+         <property name="placeholderText">
+          <string>Enter chunk base address and press enter</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>

--- a/src/dialogs/GlibcHeapBinsDialog.ui
+++ b/src/dialogs/GlibcHeapBinsDialog.ui
@@ -4,10 +4,10 @@
  <widget class="QDialog" name="GlibcHeapBinsDialog">
   <property name="geometry">
    <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>612</width>
-    <height>438</height>
+       <x>0</x>
+       <y>0</y>
+       <width>883</width>
+       <height>544</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/dialogs/GlibcHeapBinsDialog.ui
+++ b/src/dialogs/GlibcHeapBinsDialog.ui
@@ -1,34 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-    <class>GlibcHeapBinsDialog</class>
-    <widget class="QDialog" name="GlibcHeapBinsDialog">
-        <property name="geometry">
-            <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>613</width>
-                <height>402</height>
-            </rect>
-        </property>
-        <property name="windowTitle">
-            <string>Dialog</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-            <item>
-                <widget class="QTableView" name="viewBins"/>
-            </item>
-            <item>
-                <widget class="QLabel" name="label">
-                    <property name="text">
-                        <string>Chain info:</string>
-                    </property>
-                </widget>
-            </item>
-            <item>
-                <widget class="QPlainTextEdit" name="chainInfoEdit"/>
-            </item>
-        </layout>
+ <class>GlibcHeapBinsDialog</class>
+ <widget class="QDialog" name="GlibcHeapBinsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>612</width>
+    <height>438</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableView" name="viewBins"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Chain info:</string>
+     </property>
     </widget>
-    <resources/>
-    <connections/>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="chainInfoEdit"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Detailed chunk info:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineEdit">
+       <property name="placeholderText">
+        <string>Enter chunk base address and press enter</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
 </ui>

--- a/src/dialogs/GlibcHeapInfoDialog.cpp
+++ b/src/dialogs/GlibcHeapInfoDialog.cpp
@@ -13,8 +13,13 @@ GlibcHeapInfoDialog::GlibcHeapInfoDialog(RVA offset, QString status, QWidget *pa
     this->ui->rbNMA->setEnabled(false);
     this->ui->rbPI->setEnabled(false);
 
-    this->setWindowTitle(QString("Chunk @ ") + RAddressString(offset)
-                         + QString("(" + this->status + ")"));
+    // set window title
+    QString windowTitle = tr("Chunk @ ") + RAddressString(offset);
+    if (!this->status.isEmpty()) {
+        windowTitle += QString("(" + this->status + ")");
+    }
+    this->setWindowTitle(windowTitle);
+
     updateFields();
 }
 

--- a/src/widgets/GlibcHeapWidget.cpp
+++ b/src/widgets/GlibcHeapWidget.cpp
@@ -12,7 +12,8 @@ GlibcHeapWidget::GlibcHeapWidget(MainWindow *main, QWidget *parent)
       main(main)
 {
     ui->setupUi(this);
-
+    viewHeap = ui->tableView;
+    arenaSelectorView = ui->arenaSelector;
     viewHeap->setFont(Config()->getFont());
     viewHeap->setModel(modelHeap);
     viewHeap->verticalHeader()->hide();
@@ -38,6 +39,7 @@ GlibcHeapWidget::GlibcHeapWidget(MainWindow *main, QWidget *parent)
             &GlibcHeapWidget::onCurrentChanged);
     connect(chunkInfoAction, &QAction::triggered, this, &GlibcHeapWidget::viewChunkInfo);
     connect(binInfoAction, &QAction::triggered, this, &GlibcHeapWidget::viewBinInfo);
+    connect(ui->binsButton, &QPushButton::clicked, this, &GlibcHeapWidget::viewBinInfo);
 
     addressableItemContextMenu.addAction(chunkInfoAction);
     addressableItemContextMenu.addAction(binInfoAction);

--- a/src/widgets/GlibcHeapWidget.cpp
+++ b/src/widgets/GlibcHeapWidget.cpp
@@ -211,6 +211,6 @@ void GlibcHeapWidget::viewChunkInfo()
 
 void GlibcHeapWidget::viewBinInfo()
 {
-    GlibcHeapBinsDialog heapBinsDialog(modelHeap->arena_addr, this);
+    GlibcHeapBinsDialog heapBinsDialog(modelHeap->arena_addr, main, this);
     heapBinsDialog.exec();
 }

--- a/src/widgets/GlibcHeapWidget.cpp
+++ b/src/widgets/GlibcHeapWidget.cpp
@@ -1,3 +1,4 @@
+#include <dialogs/GlibcHeapBinsDialog.h>
 #include "GlibcHeapWidget.h"
 #include "ui_GlibcHeapWidget.h"
 #include "core/MainWindow.h"
@@ -18,10 +19,13 @@ GlibcHeapWidget::GlibcHeapWidget(MainWindow *main, QWidget *parent)
     // change the scroll mode to ScrollPerPixel
     viewHeap->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
     viewHeap->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+    viewHeap->setContextMenuPolicy(Qt::CustomContextMenu);
+
     ui->verticalLayout->addWidget(viewHeap);
     ui->verticalLayout->addWidget(arenaSelectorView);
+
     chunkInfoAction = new QAction(tr("Detailed Chunk Info"), this);
-    viewHeap->setContextMenuPolicy(Qt::CustomContextMenu);
+    binInfoAction = new QAction(tr("Bins Info"), this);
 
     connect(Core(), &CutterCore::refreshAll, this, &GlibcHeapWidget::updateContents);
     connect(Core(), &CutterCore::debugTaskStateChanged, this, &GlibcHeapWidget::updateContents);
@@ -33,8 +37,10 @@ GlibcHeapWidget::GlibcHeapWidget(MainWindow *main, QWidget *parent)
     connect(viewHeap->selectionModel(), &QItemSelectionModel::currentChanged, this,
             &GlibcHeapWidget::onCurrentChanged);
     connect(chunkInfoAction, &QAction::triggered, this, &GlibcHeapWidget::viewChunkInfo);
+    connect(binInfoAction, &QAction::triggered, this, &GlibcHeapWidget::viewBinInfo);
 
     addressableItemContextMenu.addAction(chunkInfoAction);
+    addressableItemContextMenu.addAction(binInfoAction);
     addActions(addressableItemContextMenu.actions());
 
     refreshDeferrer = dynamic_cast<CutterDockWidget *>(parent)->createRefreshDeferrer(
@@ -201,4 +207,10 @@ void GlibcHeapWidget::viewChunkInfo()
 
     GlibcHeapInfoDialog heapInfoDialog(Core()->math(offsetString), status, this);
     heapInfoDialog.exec();
+}
+
+void GlibcHeapWidget::viewBinInfo()
+{
+    GlibcHeapBinsDialog heapBinsDialog(modelHeap->arena_addr, this);
+    heapBinsDialog.exec();
 }

--- a/src/widgets/GlibcHeapWidget.cpp
+++ b/src/widgets/GlibcHeapWidget.cpp
@@ -14,6 +14,7 @@ GlibcHeapWidget::GlibcHeapWidget(MainWindow *main, QWidget *parent)
     ui->setupUi(this);
     viewHeap = ui->tableView;
     arenaSelectorView = ui->arenaSelector;
+
     viewHeap->setFont(Config()->getFont());
     viewHeap->setModel(modelHeap);
     viewHeap->verticalHeader()->hide();
@@ -21,9 +22,6 @@ GlibcHeapWidget::GlibcHeapWidget(MainWindow *main, QWidget *parent)
     viewHeap->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
     viewHeap->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     viewHeap->setContextMenuPolicy(Qt::CustomContextMenu);
-
-    ui->verticalLayout->addWidget(viewHeap);
-    ui->verticalLayout->addWidget(arenaSelectorView);
 
     chunkInfoAction = new QAction(tr("Detailed Chunk Info"), this);
     binInfoAction = new QAction(tr("Bins Info"), this);

--- a/src/widgets/GlibcHeapWidget.h
+++ b/src/widgets/GlibcHeapWidget.h
@@ -49,8 +49,8 @@ private:
     void updateArenas();
     void updateChunks();
     Ui::GlibcHeapWidget *ui;
-    QTableView *viewHeap = new QTableView(this);
-    QComboBox *arenaSelectorView = new QComboBox(this);
+    QTableView *viewHeap;
+    QComboBox *arenaSelectorView;
     GlibcHeapModel *modelHeap = new GlibcHeapModel(this);
     QVector<Arena> arenas;
     QAction *chunkInfoAction;

--- a/src/widgets/GlibcHeapWidget.h
+++ b/src/widgets/GlibcHeapWidget.h
@@ -43,6 +43,7 @@ private slots:
     void customMenuRequested(QPoint pos);
     void onCurrentChanged(const QModelIndex &current, const QModelIndex &previous);
     void viewChunkInfo();
+    void viewBinInfo();
 
 private:
     void updateArenas();
@@ -53,6 +54,7 @@ private:
     GlibcHeapModel *modelHeap = new GlibcHeapModel(this);
     QVector<Arena> arenas;
     QAction *chunkInfoAction;
+    QAction *binInfoAction;
     AddressableItemContextMenu addressableItemContextMenu;
     RefreshDeferrer *refreshDeferrer {};
     MainWindow *main;

--- a/src/widgets/GlibcHeapWidget.ui
+++ b/src/widgets/GlibcHeapWidget.ui
@@ -13,7 +13,34 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout"/>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableView" name="tableView"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QComboBox" name="arenaSelector"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="binsButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>View bins info for an arena</string>
+       </property>
+       <property name="text">
+        <string>Bins</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/src/widgets/HeapBinsGraphView.cpp
+++ b/src/widgets/HeapBinsGraphView.cpp
@@ -60,15 +60,18 @@ void HeapBinsGraphView::display_single_linked_list(QVector<GraphHeapChunk> chunk
         GraphLayout::GraphBlock gbChunk;
         gbChunk.entry = chunks[i].addr;
         gbChunk.edges.emplace_back(chunks[i].fd);
+
+        if (i == chunks.size() - 1 && heapBin->message) {
+            chunks[i].content += " " + QString(heapBin->message);
+        }
+
         addBlock(gbChunk, chunks[i].content);
     }
 
-    // add the END or message block
-    GraphLayout::GraphBlock gbEnd;
-    gbEnd.entry = 0;
-    if (heapBin->message) {
-        addBlock(gbEnd, heapBin->message);
-    } else {
+    // add the END block if no message
+    if (!heapBin->message) {
+        GraphLayout::GraphBlock gbEnd;
+        gbEnd.entry = 0;
         addBlock(gbEnd, "END");
     }
 }
@@ -91,13 +94,12 @@ void HeapBinsGraphView::display_double_linked_list(QVector<GraphHeapChunk> chunk
         gbChunk.entry = chunks[i].addr;
         gbChunk.edges.emplace_back(chunks[i].fd);
         gbChunk.edges.emplace_back(chunks[i].bk);
-        addBlock(gbChunk, chunks[i].content);
-    }
 
-    // add the block for the end message if any
-    if (heapBin->message) {
-        GraphLayout::GraphBlock gbEnd;
-        gbEnd.entry = -1;
-        addBlock(gbEnd, heapBin->message);
+        // if last chunk and there is message then show it in the chunk
+        if (i == chunks.size() - 1 && heapBin->message) {
+            chunks[i].content += " " + QString(heapBin->message);
+        }
+
+        addBlock(gbChunk, chunks[i].content);
     }
 }

--- a/src/widgets/HeapBinsGraphView.cpp
+++ b/src/widgets/HeapBinsGraphView.cpp
@@ -8,6 +8,7 @@
 HeapBinsGraphView::HeapBinsGraphView(QWidget *parent, RzHeapBin *bin, MainWindow *main)
     : SimpleTextGraphView(parent, main), heapBin(bin)
 {
+    enableAddresses(true);
 }
 
 void HeapBinsGraphView::loadCurrentGraph()
@@ -53,7 +54,8 @@ void HeapBinsGraphView::display_single_linked_list(QVector<GraphHeapChunk> chunk
     GraphLayout::GraphBlock gbBin;
     gbBin.entry = 1;
     gbBin.edges.emplace_back(heapBin->fd);
-    addBlock(gbBin, tr(heapBin->type) + tr("bin ") + QString::number(heapBin->bin_num));
+    QString content = tr(heapBin->type) + tr("bin ") + QString::number(heapBin->bin_num);
+    addBlock(gbBin, content);
 
     // add the blocks for the chunks
     for (int i = 0; i < chunks.size(); i++) {
@@ -65,14 +67,14 @@ void HeapBinsGraphView::display_single_linked_list(QVector<GraphHeapChunk> chunk
             chunks[i].content += " " + QString(heapBin->message);
         }
 
-        addBlock(gbChunk, chunks[i].content);
+        addBlock(gbChunk, chunks[i].content, chunks[i].addr);
     }
 
     // add the END block if no message
     if (!heapBin->message) {
         GraphLayout::GraphBlock gbEnd;
         gbEnd.entry = 0;
-        addBlock(gbEnd, "END");
+        addBlock(gbEnd, "END", 0);
     }
 }
 
@@ -83,10 +85,9 @@ void HeapBinsGraphView::display_double_linked_list(QVector<GraphHeapChunk> chunk
     gbBin.entry = heapBin->addr;
     gbBin.edges.emplace_back(heapBin->fd);
     gbBin.edges.emplace_back(heapBin->bk);
-
-    addBlock(gbBin,
-             tr(heapBin->type) + tr("bin ") + QString::number(heapBin->bin_num) + tr(" @ ")
-                     + RAddressString(heapBin->addr));
+    QString content = tr(heapBin->type) + tr("bin ") + QString::number(heapBin->bin_num) + tr(" @ ")
+            + RAddressString(heapBin->addr);
+    addBlock(gbBin, content, heapBin->addr);
 
     // add the blocks for the chunks
     for (int i = 0; i < chunks.size(); i++) {
@@ -100,6 +101,6 @@ void HeapBinsGraphView::display_double_linked_list(QVector<GraphHeapChunk> chunk
             chunks[i].content += " " + QString(heapBin->message);
         }
 
-        addBlock(gbChunk, chunks[i].content);
+        addBlock(gbChunk, chunks[i].content, chunks[i].addr);
     }
 }

--- a/src/widgets/HeapBinsGraphView.cpp
+++ b/src/widgets/HeapBinsGraphView.cpp
@@ -1,0 +1,41 @@
+//
+// Created by Pulak Malhotra on 29/06/21.
+//
+
+#include <Configuration.h>
+#include "HeapBinsGraphView.h"
+
+HeapBinsGraphView::HeapBinsGraphView(QWidget *parent, RzHeapBin *bin)
+    : CutterGraphView(parent), heapBin(bin)
+{
+}
+
+void HeapBinsGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block, bool interactive)
+{
+    qDebug() << "Drawing a block\n";
+    QRectF blockRect(block.x, block.y, block.width, block.height);
+    p.setPen(Qt::black);
+    p.setBrush(Qt::gray);
+    p.setFont(Config()->getFont());
+    p.drawRect(blockRect);
+}
+
+void HeapBinsGraphView::loadGraph()
+{
+    blocks.clear();
+    RzListIter *iter;
+    RzHeapChunkListItem *item;
+    CutterRListForeach(heapBin->chunks, iter, RzHeapChunkListItem, item)
+    {
+        GraphBlock gb;
+        gb.entry = item->addr;
+        addBlock(gb);
+    }
+}
+
+void HeapBinsGraphView::refreshView()
+{
+    qDebug() << "refreshing all";
+    CutterGraphView::refreshView();
+    loadGraph();
+}

--- a/src/widgets/HeapBinsGraphView.cpp
+++ b/src/widgets/HeapBinsGraphView.cpp
@@ -5,37 +5,99 @@
 #include <Configuration.h>
 #include "HeapBinsGraphView.h"
 
-HeapBinsGraphView::HeapBinsGraphView(QWidget *parent, RzHeapBin *bin)
-    : CutterGraphView(parent), heapBin(bin)
+HeapBinsGraphView::HeapBinsGraphView(QWidget *parent, RzHeapBin *bin, MainWindow *main)
+    : SimpleTextGraphView(parent, main), heapBin(bin)
 {
 }
 
-void HeapBinsGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block, bool interactive)
+void HeapBinsGraphView::loadCurrentGraph()
 {
-    qDebug() << "Drawing a block\n";
-    QRectF blockRect(block.x, block.y, block.width, block.height);
-    p.setPen(Qt::black);
-    p.setBrush(Qt::gray);
-    p.setFont(Config()->getFont());
-    p.drawRect(blockRect);
-}
-
-void HeapBinsGraphView::loadGraph()
-{
+    blockContent.clear();
     blocks.clear();
+
     RzListIter *iter;
     RzHeapChunkListItem *item;
+    QVector<GraphHeapChunk> chunks;
+
+    // store chunks in a vector from the list for easy access
     CutterRListForeach(heapBin->chunks, iter, RzHeapChunkListItem, item)
     {
-        GraphBlock gb;
-        gb.entry = item->addr;
-        addBlock(gb);
+        GraphHeapChunk graphHeapChunk;
+        graphHeapChunk.addr = item->addr;
+        RzHeapChunkSimple *chunkInfo = Core()->getHeapChunk(item->addr);
+        if (!chunkInfo) {
+            break;
+        }
+        QString content = "Base: " + RAddressString(chunkInfo->addr)
+                + " Size: " + RHexString(chunkInfo->size);
+        graphHeapChunk.fd = chunkInfo->fd;
+        graphHeapChunk.bk = chunkInfo->bk;
+        graphHeapChunk.content = content;
+        chunks.append(graphHeapChunk);
+        free(chunkInfo);
+    }
+
+    bool fast = QString(heapBin->type) == QString("Fast");
+    if (fast) {
+        display_single_linked_list(chunks);
+    } else {
+        display_double_linked_list(chunks);
+    }
+
+    cleanupEdges(blocks);
+    computeGraphPlacement();
+}
+
+void HeapBinsGraphView::display_single_linked_list(QVector<GraphHeapChunk> chunks)
+{
+    GraphLayout::GraphBlock gbBin;
+    gbBin.entry = 1;
+    gbBin.edges.emplace_back(heapBin->fd);
+    addBlock(gbBin, tr(heapBin->type) + tr("bin ") + QString::number(heapBin->bin_num));
+
+    // add the blocks for the chunks
+    for (int i = 0; i < chunks.size(); i++) {
+        GraphLayout::GraphBlock gbChunk;
+        gbChunk.entry = chunks[i].addr;
+        gbChunk.edges.emplace_back(chunks[i].fd);
+        addBlock(gbChunk, chunks[i].content);
+    }
+
+    // add the END or message block
+    GraphLayout::GraphBlock gbEnd;
+    gbEnd.entry = 0;
+    if (heapBin->message) {
+        addBlock(gbEnd, heapBin->message);
+    } else {
+        addBlock(gbEnd, "END");
     }
 }
 
-void HeapBinsGraphView::refreshView()
+void HeapBinsGraphView::display_double_linked_list(QVector<GraphHeapChunk> chunks)
 {
-    qDebug() << "refreshing all";
-    CutterGraphView::refreshView();
-    loadGraph();
+    // add the block for the bin
+    GraphLayout::GraphBlock gbBin;
+    gbBin.entry = heapBin->addr;
+    gbBin.edges.emplace_back(heapBin->fd);
+    gbBin.edges.emplace_back(heapBin->bk);
+
+    addBlock(gbBin,
+             tr(heapBin->type) + tr("bin ") + QString::number(heapBin->bin_num) + tr(" @ ")
+                     + RAddressString(heapBin->addr));
+
+    // add the blocks for the chunks
+    for (int i = 0; i < chunks.size(); i++) {
+        GraphLayout::GraphBlock gbChunk;
+        gbChunk.entry = chunks[i].addr;
+        gbChunk.edges.emplace_back(chunks[i].fd);
+        gbChunk.edges.emplace_back(chunks[i].bk);
+        addBlock(gbChunk, chunks[i].content);
+    }
+
+    // add the block for the end message if any
+    if (heapBin->message) {
+        GraphLayout::GraphBlock gbEnd;
+        gbEnd.entry = -1;
+        addBlock(gbEnd, heapBin->message);
+    }
 }

--- a/src/widgets/HeapBinsGraphView.cpp
+++ b/src/widgets/HeapBinsGraphView.cpp
@@ -5,7 +5,6 @@
 HeapBinsGraphView::HeapBinsGraphView(QWidget *parent, RzHeapBin *bin, MainWindow *main)
     : SimpleTextGraphView(parent, main), heapBin(bin)
 {
-
     chunkInfoAction = new QAction(tr("Detailed Chunk Info"), this);
     addressableItemContextMenu.addAction(chunkInfoAction);
     addAction(chunkInfoAction);

--- a/src/widgets/HeapBinsGraphView.cpp
+++ b/src/widgets/HeapBinsGraphView.cpp
@@ -1,7 +1,3 @@
-//
-// Created by Pulak Malhotra on 29/06/21.
-//
-
 #include <Configuration.h>
 #include "HeapBinsGraphView.h"
 

--- a/src/widgets/HeapBinsGraphView.h
+++ b/src/widgets/HeapBinsGraphView.h
@@ -22,6 +22,9 @@ public:
 
 protected:
     void loadCurrentGraph() override;
+    void drawBlock(QPainter &p, GraphView::GraphBlock &block, bool interactive) override;
+    void addBlock(GraphLayout::GraphBlock block, const QString &text,
+                  RVA address = RVA_INVALID) override;
 
 private:
     RzHeapBin *heapBin;

--- a/src/widgets/HeapBinsGraphView.h
+++ b/src/widgets/HeapBinsGraphView.h
@@ -21,11 +21,18 @@ protected:
     void drawBlock(QPainter &p, GraphView::GraphBlock &block, bool interactive) override;
     void addBlock(GraphLayout::GraphBlock block, const QString &text,
                   RVA address = RVA_INVALID) override;
+    void blockContextMenuRequested(GraphView::GraphBlock &block, QContextMenuEvent *event,
+                                   QPoint) override;
+
+private slots:
+    void viewChunkInfo();
 
 private:
     RzHeapBin *heapBin;
     void display_single_linked_list(QVector<GraphHeapChunk>);
     void display_double_linked_list(QVector<GraphHeapChunk>);
+    QAction *chunkInfoAction;
+    RVA selectedBlock;
 };
 
 #endif // CUTTER_HEAPBINSGRAPHVIEW_H

--- a/src/widgets/HeapBinsGraphView.h
+++ b/src/widgets/HeapBinsGraphView.h
@@ -4,19 +4,29 @@
 
 #ifndef CUTTER_HEAPBINSGRAPHVIEW_H
 #define CUTTER_HEAPBINSGRAPHVIEW_H
-#include "CutterGraphView.h"
+#include "SimpleTextGraphView.h"
 
-class HeapBinsGraphView : public CutterGraphView
+class HeapBinsGraphView : public SimpleTextGraphView
 {
     Q_OBJECT
+    struct GraphHeapChunk
+    {
+        QString content;
+        ut64 addr;
+        ut64 fd;
+        ut64 bk;
+    };
+
 public:
-    explicit HeapBinsGraphView(QWidget *parent, RzHeapBin *bin);
-    void drawBlock(QPainter &p, GraphView::GraphBlock &block, bool interactive) override;
-    void loadGraph();
-    void refreshView() override;
+    explicit HeapBinsGraphView(QWidget *parent, RzHeapBin *bin, MainWindow *main);
+
+protected:
+    void loadCurrentGraph() override;
 
 private:
     RzHeapBin *heapBin;
+    void display_single_linked_list(QVector<GraphHeapChunk>);
+    void display_double_linked_list(QVector<GraphHeapChunk>);
 };
 
 #endif // CUTTER_HEAPBINSGRAPHVIEW_H

--- a/src/widgets/HeapBinsGraphView.h
+++ b/src/widgets/HeapBinsGraphView.h
@@ -1,0 +1,22 @@
+//
+// Created by Pulak Malhotra on 29/06/21.
+//
+
+#ifndef CUTTER_HEAPBINSGRAPHVIEW_H
+#define CUTTER_HEAPBINSGRAPHVIEW_H
+#include "CutterGraphView.h"
+
+class HeapBinsGraphView : public CutterGraphView
+{
+    Q_OBJECT
+public:
+    explicit HeapBinsGraphView(QWidget *parent, RzHeapBin *bin);
+    void drawBlock(QPainter &p, GraphView::GraphBlock &block, bool interactive) override;
+    void loadGraph();
+    void refreshView() override;
+
+private:
+    RzHeapBin *heapBin;
+};
+
+#endif // CUTTER_HEAPBINSGRAPHVIEW_H

--- a/src/widgets/HeapBinsGraphView.h
+++ b/src/widgets/HeapBinsGraphView.h
@@ -1,7 +1,3 @@
-//
-// Created by Pulak Malhotra on 29/06/21.
-//
-
 #ifndef CUTTER_HEAPBINSGRAPHVIEW_H
 #define CUTTER_HEAPBINSGRAPHVIEW_H
 #include "SimpleTextGraphView.h"

--- a/src/widgets/SimpleTextGraphView.h
+++ b/src/widgets/SimpleTextGraphView.h
@@ -55,7 +55,8 @@ protected:
      * Needs to cleanup the old graph and use addBlock() to create new nodes.
      */
     virtual void loadCurrentGraph() = 0;
-    void addBlock(GraphLayout::GraphBlock block, const QString &content, RVA address = RVA_INVALID);
+    virtual void addBlock(GraphLayout::GraphBlock block, const QString &content,
+                          RVA address = RVA_INVALID);
     /**
      * @brief Enable or disable address interactions for nodes.
      * If enabled node addresses need to be specified when calling addBlock(). Adds address related


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Adding bins view to Glibc heap widget
How to:
- The bins view opens from the context menu by right clicking anywhere in the Glibc heap widget
 
Current functionality:
- See a list of non empty unsorted, small, large and fastbins
- Show the chain info for each bin
- Added view detailed info for chunk option
- Add a button next to arena selector for bins view if that is easier to find 


TODO:
- Make Bin name renders at top of Graph view


<img width="885" alt="Screenshot 2021-06-30 at 4 13 44 PM" src="https://user-images.githubusercontent.com/56169176/123947584-299b7680-d9be-11eb-9ae7-9990b01962f9.png">

### BUG: Bin name does not render at top for circular linked list
<img width="884" alt="Screenshot 2021-06-30 at 4 14 07 PM" src="https://user-images.githubusercontent.com/56169176/123947634-37e99280-d9be-11eb-9fd8-b496da76033d.png">
