### PR TITLE
Fix #2657 - Set cutter executable as WINDOWS subsystem

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -426,6 +426,7 @@ endif()
 
 if (WIN32)
     set(PLATFORM_RESOURCES "img/cutter.rc")
+    set(OPTIONS WIN32)
 else()
     set(PLATFORM_RESOURCES "")
 endif()
@@ -437,7 +438,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
 endif()
 
 
-add_executable(Cutter ${UI_FILES} ${QRC_FILES} ${PLATFORM_RESOURCES} ${SOURCES} ${HEADER_FILES} ${BINDINGS_SOURCE})
+add_executable(Cutter ${OPTIONS} ${UI_FILES} ${QRC_FILES} ${PLATFORM_RESOURCES} ${SOURCES} ${HEADER_FILES} ${BINDINGS_SOURCE})
 set_target_properties(Cutter PROPERTIES
         OUTPUT_NAME cutter
         RUNTIME_OUTPUT_DIRECTORY ..


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Set cutter as a GUI application so it doesn't launch a console on open. 

**Test plan (required)**

* Open cutter by double-clicking
* Open cutter through console

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #2657