### PR TITLE
Fix Versions in Info.plist (Fix #2679)

### DIFF
--- a/dist/macos/Info.plist.in
+++ b/dist/macos/Info.plist.in
@@ -7,9 +7,9 @@
 	<key>CFBundleExecutable</key>
 	<string>cutter</string>
 	<key>CFBundleVersion</key>
-	<string>@FULL_VERSION@</string>
+	<string>@CUTTER_VERSION_FULL@</string>
 	<key>CFBundleShortVersionString</key>
-	<string>@FULL_VERSION@</string>
+	<string>@CUTTER_VERSION_FULL@</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Licensed under the GPLv3 by the Cutter developers.</string>
 	<key>CFBundleIconFile</key>


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

The `FULL_VERSION` did not exist. `CUTTER_VERSION_FULL` is the right one.

**Test Plan**

Download the generated .dmg for macOS and check if the versions in the contained `Info.plist` are present.

**Fixes**

Fix #2679