### PR TITLE
Enforce Cutter-local sleighhome on macOS only if Packaging is Enabled

### DIFF
--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -170,7 +170,7 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
     }
 #endif
 
-#ifdef Q_OS_MACOS
+#if defined(Q_OS_MACOS) && defined(CUTTER_ENABLE_PACKAGING)
     {
         auto rzprefix = QDir(QCoreApplication::applicationDirPath()); // Contents/MacOS
         rzprefix.cdUp(); // Contents


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Using rz-ghidra from Cutter was broken on macOS by default anywhere outside the dist package.

**Test plan (required)**

* With a local build of Cutter and rz-ghidra, make sure rz-ghidra works
* Download the packaged .dmg and make sure that it works there too and `ghidra.sleighhome` is set to the correct path inside the app bundle