### PR TITLE
Fixed issue #2726

### DIFF
--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -96,6 +96,16 @@ void AsmOptionsWidget::updateAsmOptionsFromVars()
     bool varsubEnabled = Config()->getConfigBool("asm.sub.var");
     ui->varsubOnlyCheckBox->setEnabled(varsubEnabled);
 
+    ui->asmComboBox->blockSignals(true);
+    if (Config()->getConfigBool("asm.esil")) {
+        ui->asmComboBox->setCurrentIndex(1);
+    } else if (Config()->getConfigBool("asm.pseudo")) {
+        ui->asmComboBox->setCurrentIndex(2);
+    } else {
+        ui->asmComboBox->setCurrentIndex(0);
+    }
+    ui->asmComboBox->blockSignals(false);
+
     QString currentSyntax = Config()->getConfigString("asm.syntax");
     for (int i = 0; i < ui->syntaxComboBox->count(); i++) {
         if (ui->syntaxComboBox->itemData(i) == currentSyntax) {


### PR DESCRIPTION
**Detailed description**
Added restoring value for `Show Disassembly as` preference from config `asm.esil` and `asm.pseudo`.

**Test plan**

1. Open project with x86 binary
2. Open preferences widget (`Edit` ->` Preferences`)
3. Select `Pseudocode` or `ESIL` from preference labeled `Show Disassembly as`
4. Click `Ok` button to close preference dialog
5. Notice that assembly in Disassembly widget has changed to pseudocode/esil
6. Open preferences widget (`Edit` ->` Preferences`)
7. Notice that preference labeled `Show Disassembly as` is set to `Pseudocode` or `ESIL` and corresponds to the one selected in step 3

**Closing issues**

closes #2726
