### PR TITLE
Fixed issue #2672

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -21,10 +21,17 @@
  * and for light - only light ones.
  */
 const QHash<QString, ColorFlags> Configuration::relevantThemes = {
-    { "ayu", DarkFlag },     { "consonance", DarkFlag }, { "darkda", DarkFlag },
-    { "onedark", DarkFlag }, { "solarized", DarkFlag },  { "zenburn", DarkFlag },
-    { "cutter", LightFlag }, { "dark", LightFlag },      { "matrix", LightFlag },
-    { "tango", LightFlag },  { "white", LightFlag }
+    { "ayu", DarkFlag },    { "basic", DarkFlag },  { "behelit", DarkFlag },
+    { "bold", DarkFlag },   { "bright", DarkFlag }, { "consonance", DarkFlag },
+    { "darkda", DarkFlag }, { "defragger", DarkFlag },  { "focus", DarkFlag },
+    { "gentoo", DarkFlag }, { "lima", DarkFlag },   { "monokai", DarkFlag },
+    { "ogray", DarkFlag },  { "onedark", DarkFlag },    { "pink", DarkFlag },
+    { "rasta", DarkFlag },  { "sepia", DarkFlag },  { "smyck", DarkFlag },
+    { "solarized", DarkFlag },  { "twilight", DarkFlag },   { "white2", DarkFlag },
+    { "xvilka", DarkFlag }, { "zenburn", DarkFlag },
+    { "cga", LightFlag },   { "cutter", LightFlag },    { "dark", LightFlag },
+    { "gb", LightFlag },    { "matrix", LightFlag },    { "tango", LightFlag },
+    { "white", LightFlag }
 };
 static const QString DEFAULT_LIGHT_COLOR_THEME = "cutter";
 static const QString DEFAULT_DARK_COLOR_THEME = "ayu";

--- a/src/widgets/ColorThemeComboBox.cpp
+++ b/src/widgets/ColorThemeComboBox.cpp
@@ -23,6 +23,7 @@ void ColorThemeComboBox::updateFromConfig(bool interfaceThemeChanged)
     clear();
     for (const QString &theme : themes) {
         if (ThemeWorker().isCustomTheme(theme)
+            || !Configuration::relevantThemes[theme]
             || (Configuration::cutterInterfaceThemesList()[curInterfaceThemeIndex].flag
                 & Configuration::relevantThemes[theme])) {
             addItem(theme);


### PR DESCRIPTION
**Detailed description**
Added known themes to dark or light list (added corresponding flag). Added unknown themes in both lists.

**Test plan**
1. Go to Preferences/Appearance
2. Note all the color themes when light interface is chosen
3. Note all the color themes when dark interface is chosen
4. Type ecoj in console widget to list all the included themes
We can see that light list + dark list = ecoj list

**Screenshots**
![222](https://user-images.githubusercontent.com/32013101/133140876-b51c5dc2-8b8b-4a18-adae-68061b60d951.jpg)
![11111](https://user-images.githubusercontent.com/32013101/133140883-29f21293-e840-4105-a88c-dc07745353d8.jpg)



**Closing issues**
closes #2672
