### PR TITLE
Use seek history API instead of command

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -585,7 +585,7 @@ QStringList CutterCore::autocomplete(const QString &cmd, RzLinePromptType prompt
 
 /**
  * @brief CutterCore::loadFile
- * Load initial file. TODO Maybe use the "o" commands?
+ * Load initial file.
  * @param path File path
  * @param baddr Base (RzBin) address
  * @param mapaddr Map address
@@ -2682,10 +2682,10 @@ QList<RVA> CutterCore::getSeekHistory()
 {
     CORE_LOCK();
     QList<RVA> ret;
-
-    QJsonArray jsonArray = cmdj("sj").array();
-    for (const QJsonValue &value : jsonArray)
-        ret << value.toVariant().toULongLong();
+    RzListIter *it;
+    RzCoreSeekItem *undo;
+    RzList *list = rz_core_seek_list(core);
+    CutterRListForeach(list, it, RzCoreSeekItem, undo) { ret << undo->offset; }
 
     return ret;
 }

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1127,14 +1127,25 @@ void MainWindow::updateHistoryMenu(QMenu *menu, bool redo)
     // not too short so that reasonable length c++ names can be seen most of the time
     const int MAX_NAME_LENGTH = 64;
 
-    auto hist = Core()->cmdj("sj");
+    RzListIter *it;
+    RzCoreSeekItem *undo;
+    RzList *list = rz_core_seek_list(Core()->core());
+
     bool history = true;
     QList<QAction *> actions;
-    for (auto item : Core()->cmdj("sj").array()) {
-        QJsonObject obj = item.toObject();
-        QString name = obj["name"].toString();
-        RVA offset = obj["offset"].toVariant().toULongLong();
-        bool current = obj["current"].toBool(false);
+    CutterRListForeach(list, it, RzCoreSeekItem, undo) {
+        RzFlagItem *f = rz_flag_get_at(Core()->core()->flags, undo->offset, true);
+        char *fname = NULL;
+        if (f) {
+            if (f->offset != undo->offset) {
+                fname = rz_str_newf("%s+%" PFMT64d, f->name, undo->offset - f->offset);
+            } else {
+                fname = strdup(f->name);
+            }
+        }
+        QString name = fname;
+        RVA offset = undo->offset;
+        bool current = undo->is_current;
         if (current) {
             history = false;
         }

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1129,12 +1129,13 @@ void MainWindow::updateHistoryMenu(QMenu *menu, bool redo)
 
     RzListIter *it;
     RzCoreSeekItem *undo;
-    RzList *list = rz_core_seek_list(Core()->core());
+    RzCoreLocked core(Core());
+    RzList *list = rz_core_seek_list(core);
 
     bool history = true;
     QList<QAction *> actions;
     CutterRListForeach(list, it, RzCoreSeekItem, undo) {
-        RzFlagItem *f = rz_flag_get_at(Core()->core()->flags, undo->offset, true);
+        RzFlagItem *f = rz_flag_get_at(core->flags, undo->offset, true);
         char *fname = NULL;
         if (f) {
             if (f->offset != undo->offset) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

Use the `rz_core_seek_list()` API instead of the "sj" (old) and "shj" (new) commands.

**Test plan (required)**

Open the history menu.

**Closing issues**

Closes https://github.com/rizinorg/cutter/issues/2750
