### PR TITLE
Replace eco Command with API (Fix #2751)

### DIFF
--- a/src/common/ColorThemeWorker.cpp
+++ b/src/common/ColorThemeWorker.cpp
@@ -131,9 +131,10 @@ QJsonDocument ColorThemeWorker::getTheme(const QString &themeName) const
     QString curr = Config()->getColorTheme();
 
     if (themeName != curr) {
-        Core()->cmdRaw(QString("eco %1").arg(themeName));
+        RzCoreLocked core(Core());
+        rz_core_load_theme(core, themeName.toUtf8().constData());
         theme = Core()->cmdj("ecj").object().toVariantMap();
-        Core()->cmdRaw(QString("eco %1").arg(curr));
+        rz_core_load_theme(core, curr.toUtf8().constData());
     } else {
         theme = Core()->cmdj("ecj").object().toVariantMap();
     }

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -522,7 +522,7 @@ void Configuration::setColorTheme(const QString &theme)
         Core()->cmdRaw("ecd");
         s.setValue("theme", "default");
     } else {
-        Core()->cmdRaw(QStringLiteral("eco %1").arg(theme));
+        rz_core_load_theme(Core()->core(), theme.toUtf8().constData());
         s.setValue("theme", theme);
     }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

`ec` were converted to newshell, so `cmdRaw()` does not work on it anymore.
Regarding API, see also #2666

Requires https://github.com/rizinorg/rizin/pull/1680 to be merged and cherry-picked into stable, then the submodule updated here.

**Test plan (required)**

* Open Cutter, notice that the user-set color theme is loaded
* Switch to another color theme from Preferences, it should change
* Open the color theme editor and inside the editor, switch to another theme to edit. The editor should update accordingly.

**Closing issues**

Fix #2751