### PR TITLE
Fix wrong initialization order in ArenaInfoDialog

### DIFF
--- a/src/dialogs/ArenaInfoDialog.cpp
+++ b/src/dialogs/ArenaInfoDialog.cpp
@@ -2,7 +2,7 @@
 #include "ui_ArenaInfoDialog.h"
 
 ArenaInfoDialog::ArenaInfoDialog(Arena &arena, QWidget *parent)
-    : arena(arena), QDialog(parent), ui(new Ui::ArenaInfoDialog)
+    : QDialog(parent), ui(new Ui::ArenaInfoDialog), arena(arena)
 {
     ui->setupUi(this);
     setWindowTitle("Arena @ " + RzAddressString(arena.offset));


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

Fixes the following warning:
```
In file included from /home/akochkov/rizin/cutter/src/dialogs/ArenaInfoDialog.cpp:1:
/home/akochkov/rizin/cutter/src/dialogs/ArenaInfoDialog.h: In constructor ‘ArenaInfoDialog::ArenaInfoDialog(Arena&, QWidget*)’:
/home/akochkov/rizin/cutter/src/dialogs/ArenaInfoDialog.h:22:11: warning: ‘ArenaInfoDialog::arena’ will be initialized after [-Wreorder]
   22 |     Arena arena;
      |           ^~~~~
/home/akochkov/rizin/cutter/src/dialogs/ArenaInfoDialog.cpp:5:64: warning:   base ‘QDialog’ [-Wreorder]
    5 |     : arena(arena), QDialog(parent), ui(new Ui::ArenaInfoDialog)
      |                                                                ^
/home/akochkov/rizin/cutter/src/dialogs/ArenaInfoDialog.cpp:4:1: warning:   when initialized here [-Wreorder]
    4 | ArenaInfoDialog::ArenaInfoDialog(Arena &arena, QWidget *parent)
      | ^~~~~~~~~~~~~~~
```
**Test plan (required)**

CI is green (after https://github.com/rizinorg/cutter/pull/2772 is merged)