### PR TITLE
Fix CutterCore::getBinPluginDescriptions() args

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -2731,28 +2731,32 @@ QStringList CutterCore::getAnalysisPluginNames()
     return ret;
 }
 
-QList<RzBinPluginDescription> CutterCore::getRBinPluginDescriptions(const QString &type)
+QList<RzBinPluginDescription> CutterCore::getBinPluginDescriptions(bool bin, bool xtr)
 {
     CORE_LOCK();
     QList<RzBinPluginDescription> ret;
     RzListIter *it;
-    RzBinPlugin *bp;
-    CutterRzListForeach (core->bin->plugins, it, RzBinPlugin, bp) {
-        RzBinPluginDescription desc;
-        desc.name = bp->name ? bp->name : "";
-        desc.description = bp->desc ? bp->desc : "";
-        desc.license = bp->license ? bp->license : "";
-        desc.type = "bin";
-        ret.append(desc);
+    if (bin) {
+        RzBinPlugin *bp;
+        CutterRzListForeach (core->bin->plugins, it, RzBinPlugin, bp) {
+            RzBinPluginDescription desc;
+            desc.name = bp->name ? bp->name : "";
+            desc.description = bp->desc ? bp->desc : "";
+            desc.license = bp->license ? bp->license : "";
+            desc.type = "bin";
+            ret.append(desc);
+        }
     }
-    RzBinXtrPlugin *bx;
-    CutterRzListForeach (core->bin->binxtrs, it, RzBinXtrPlugin, bx) {
-        RzBinPluginDescription desc;
-        desc.name = bx->name ? bx->name : "";
-        desc.description = bx->desc ? bx->desc : "";
-        desc.license = bx->license ? bx->license : "";
-        desc.type = "xtr";
-        ret.append(desc);
+    if (xtr) {
+        RzBinXtrPlugin *bx;
+        CutterRzListForeach (core->bin->binxtrs, it, RzBinXtrPlugin, bx) {
+            RzBinPluginDescription desc;
+            desc.name = bx->name ? bx->name : "";
+            desc.description = bx->desc ? bx->desc : "";
+            desc.license = bx->license ? bx->license : "";
+            desc.type = "xtr";
+            ret.append(desc);
+        }
     }
     return ret;
 }

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -534,7 +534,7 @@ public:
     QStringList getAnalysisPluginNames();
 
     /* Widgets */
-    QList<RzBinPluginDescription> getRBinPluginDescriptions(const QString &type = QString());
+    QList<RzBinPluginDescription> getBinPluginDescriptions(bool bin = true, bool xtr = true);
     QList<RzIOPluginDescription> getRIOPluginDescriptions();
     QList<RzCorePluginDescription> getRCorePluginDescriptions();
     QList<RzAsmPluginDescription> getRAsmPluginDescriptions();

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -47,7 +47,7 @@ InitialOptionsDialog::InitialOptionsDialog(MainWindow *main)
     setTooltipWithConfigHelp(ui->kernelComboBox, "asm.os");
     setTooltipWithConfigHelp(ui->bitsComboBox, "asm.bits");
 
-    for (const auto &plugin : core->getRBinPluginDescriptions("bin")) {
+    for (const auto &plugin : core->getBinPluginDescriptions(true, false)) {
         ui->formatComboBox->addItem(plugin.name, QVariant::fromValue(plugin));
     }
 

--- a/src/dialogs/RizinPluginsDialog.cpp
+++ b/src/dialogs/RizinPluginsDialog.cpp
@@ -10,7 +10,7 @@ RizinPluginsDialog::RizinPluginsDialog(QWidget *parent)
 {
     ui->setupUi(this);
 
-    for (const auto &plugin : Core()->getRBinPluginDescriptions()) {
+    for (const auto &plugin : Core()->getBinPluginDescriptions()) {
         QTreeWidgetItem *item = new QTreeWidgetItem();
         item->setText(0, plugin.name);
         item->setText(1, plugin.description);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Test plan (required)**

* In the InitialOptionsDialog, check that the "Format" combo box shows all bin plugins, but none starting with `xtr.`
* In the Rizin Plugins Dialog, check that both regular bin and xtr plugins are shown in the bin tab.