### PR TITLE
Join Debug Task on Suspend to avoid races

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -2005,6 +2005,7 @@ void CutterCore::attachDebug(int pid)
 void CutterCore::suspendDebug()
 {
     debugTask->breakTask();
+    debugTask->joinTask();
 }
 
 void CutterCore::stopDebug()


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

This is somewhat a workaround for a potential null deref when stopping a running process on Windows.
It is still more deterministic to join the task before doing anything else with it, so this change is also good independent of the crash.

**Test plan (required)**

On Windows:
* Start debugging a program
* click continue until the program runs and is **not** suspended
* press the stop button

repeat this multiple times, before this change it may crash.