### PR TITLE
Port Sections information to the Rizin API

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3121,28 +3121,44 @@ QList<SectionDescription> CutterCore::getAllSections()
     CORE_LOCK();
     QList<SectionDescription> sections;
 
-    QJsonDocument sectionsDoc = cmdj("iSj entropy");
-    QJsonObject sectionsObj = sectionsDoc.object();
-    QJsonArray sectionsArray = sectionsObj[RJsonKey::sections].toArray();
+    RzBinObject *o = rz_bin_cur_object(core->bin);
+    if (!o) {
+        return sections;
+    }
 
-    for (const QJsonValue &value : sectionsArray) {
-        QJsonObject sectionObject = value.toObject();
-
-        QString name = sectionObject[RJsonKey::name].toString();
-        if (name.isEmpty())
+    RzList *sects = rz_bin_object_get_sections(o);
+    if (!sects) {
+        return sections;
+    }
+    RzList *hashnames = rz_list_newf(free);
+    if (!hashnames) {
+        return sections;
+    }
+    rz_list_push(hashnames, rz_str_new("entropy"));
+    RzListIter *it;
+    RzBinSection *sect;
+    CutterRzListForeach (sects, it, RzBinSection, sect) {
+        if (RZ_STR_ISEMPTY(sect->name))
             continue;
 
         SectionDescription section;
-        section.name = name;
-        section.vaddr = sectionObject[RJsonKey::vaddr].toVariant().toULongLong();
-        section.vsize = sectionObject[RJsonKey::vsize].toVariant().toULongLong();
-        section.paddr = sectionObject[RJsonKey::paddr].toVariant().toULongLong();
-        section.size = sectionObject[RJsonKey::size].toVariant().toULongLong();
-        section.perm = sectionObject[RJsonKey::perm].toString();
-        section.entropy = sectionObject[RJsonKey::entropy].toString();
+        section.name = sect->name;
+        section.vaddr = sect->vaddr;
+        section.vsize = sect->vsize;
+        section.paddr = sect->paddr;
+        section.size = sect->size;
+        section.perm = rz_str_rwx_i(sect->perm);
+        HtPP *digests = rz_core_bin_section_digests(core, sect, hashnames);
+        if (!digests) {
+            continue;
+        }
+        const char *entropy = (const char*)ht_pp_find(digests, "entropy", NULL);
+        section.entropy = rz_str_get(entropy);
+        ht_pp_free(digests);
 
         sections << section;
     }
+    rz_list_free(sects);
     return sections;
 }
 
@@ -3151,9 +3167,19 @@ QStringList CutterCore::getSectionList()
     CORE_LOCK();
     QStringList ret;
 
-    QJsonArray sectionsArray = cmdj("iSj").array();
-    for (const QJsonValue &value : sectionsArray) {
-        ret << value.toObject()[RJsonKey::name].toString();
+    RzBinObject *o = rz_bin_cur_object(core->bin);
+    if (!o) {
+        return ret;
+    }
+
+    RzList *sects = rz_bin_object_get_sections(o);
+    if (!sects) {
+        return ret;
+    }
+    RzListIter *it;
+    RzBinSection *sect;
+    CutterRzListForeach (sects, it, RzBinSection, sect) {
+        ret << sect->name;
     }
     return ret;
 }


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Ported the sections information to use the Rizin API.

**Test plan (required)**

Open any ELF or PE or MachO file, choose "Windows -> Info ->Sections", it should match the Rizin's `iS` output.

**Closing issues**

Closes https://github.com/rizinorg/cutter/issues/2784
