### PR TITLE
Add option to disable the preview when hovering over the assembly

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -774,6 +774,16 @@ bool Configuration::getOutputRedirectionEnabled() const
     return outputRedirectEnabled;
 }
 
+void Configuration::setPreviewValue( bool checked )
+{
+    s.setValue("asm.preview", checked);
+}
+
+bool Configuration::getPreviewValue() const
+{
+    return s.value("asm.preview").toBool();
+}
+
 bool Configuration::getGraphBlockEntryOffset()
 {
     return s.value("graphBlockEntryOffset", true).value<bool>();

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -201,6 +201,9 @@ public:
     void setOutputRedirectionEnabled(bool enabled);
     bool getOutputRedirectionEnabled() const;
 
+    void setPreviewValue(bool checked);
+    bool getPreviewValue() const;
+
     /**
      * @brief Recently opened binaries, as shown in NewFileDialog.
      */

--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -134,6 +134,10 @@ void AsmOptionsWidget::updateAsmOptionsFromVars()
     ui->asmTabsOffSpinBox->setValue(Config()->getConfigInt("asm.tabs.off"));
     ui->asmTabsOffSpinBox->blockSignals(false);
 
+    ui->previewCheckBox->blockSignals(true);
+    ui->previewCheckBox->setChecked(Config()->getPreviewValue());
+    ui->previewCheckBox->blockSignals(false);
+
     QList<ConfigCheckbox>::iterator confCheckbox;
 
     // Set the value for each checkbox in "checkboxes" as it exists in the configuration
@@ -235,6 +239,12 @@ void AsmOptionsWidget::on_varsubCheckBox_toggled(bool checked)
 {
     Config()->setConfig("asm.sub.var", checked);
     ui->varsubOnlyCheckBox->setEnabled(checked);
+    triggerAsmOptionsChanged();
+}
+
+void AsmOptionsWidget::on_previewCheckBox_toggled( bool checked )
+{
+    Config()->setPreviewValue(checked);
     triggerAsmOptionsChanged();
 }
 

--- a/src/dialogs/preferences/AsmOptionsWidget.h
+++ b/src/dialogs/preferences/AsmOptionsWidget.h
@@ -48,6 +48,7 @@ private slots:
 
     void on_bytesCheckBox_toggled(bool checked);
     void on_varsubCheckBox_toggled(bool checked);
+    void on_previewCheckBox_toggled(bool checked);
 
     void on_buttonBox_clicked(QAbstractButton *button);
 

--- a/src/dialogs/preferences/AsmOptionsWidget.ui
+++ b/src/dialogs/preferences/AsmOptionsWidget.ui
@@ -48,8 +48,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>583</width>
-              <height>668</height>
+              <width>582</width>
+              <height>766</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -65,10 +65,34 @@
                 <string>Disassembly</string>
                </property>
                <layout class="QGridLayout" name="gridLayout">
-                <item row="11" column="1">
-                 <widget class="QCheckBox" name="bytesCheckBox">
+                <item row="12" column="2">
+                 <widget class="QSpinBox" name="nbytesSpinBox">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item row="17" column="2">
+                 <widget class="QSpinBox" name="asmTabsOffSpinBox">
+                  <property name="maximum">
+                   <number>100</number>
+                  </property>
+                  <property name="singleStep">
+                   <number>5</number>
+                  </property>
+                 </widget>
+                </item>
+                <item row="19" column="1" colspan="2">
+                 <widget class="QCheckBox" name="lbytesCheckBox">
                   <property name="text">
-                   <string>Display the bytes of each instruction (asm.bytes)</string>
+                   <string>Align bytes to the left (asm.lbytes)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="15" column="1">
+                 <widget class="QCheckBox" name="previewCheckBox">
+                  <property name="text">
+                   <string>Show preview when hovering (asm.preview)</string>
                   </property>
                  </widget>
                 </item>
@@ -82,66 +106,10 @@
                   </property>
                  </widget>
                 </item>
-                <item row="16" column="2">
-                 <widget class="QSpinBox" name="asmTabsOffSpinBox">
-                  <property name="maximum">
-                   <number>100</number>
-                  </property>
-                  <property name="singleStep">
-                   <number>5</number>
-                  </property>
-                 </widget>
-                </item>
-                <item row="3" column="1">
-                 <widget class="QLabel" name="label">
+                <item row="8" column="2">
+                 <widget class="QCheckBox" name="relOffFlagsCheckBox">
                   <property name="text">
-                   <string>Show Disassembly as:</string>
-                  </property>
-                  <property name="textInteractionFlags">
-                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-                  </property>
-                 </widget>
-                </item>
-                <item row="12" column="1">
-                 <widget class="QLabel" name="nbytesLabel">
-                  <property name="enabled">
-                   <bool>true</bool>
-                  </property>
-                  <property name="text">
-                   <string>Number of bytes to display (asm.nbytes):</string>
-                  </property>
-                  <property name="textInteractionFlags">
-                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-                  </property>
-                 </widget>
-                </item>
-                <item row="17" column="1" colspan="2">
-                 <widget class="QCheckBox" name="indentCheckBox">
-                  <property name="text">
-                   <string>Indent disassembly based on reflines depth (asm.indent)</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="1" colspan="2">
-                 <spacer name="verticalSpacer_3">
-                  <property name="orientation">
-                   <enum>Qt::Vertical</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Fixed</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>20</width>
-                    <height>10</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item row="12" column="2">
-                 <widget class="QSpinBox" name="nbytesSpinBox">
-                  <property name="enabled">
-                   <bool>true</bool>
+                   <string>Flags (asm.reloff.flags)</string>
                   </property>
                  </widget>
                 </item>
@@ -171,7 +139,7 @@
                   </property>
                  </widget>
                 </item>
-                <item row="16" column="1">
+                <item row="17" column="1">
                  <widget class="QLabel" name="asmTabsOffLabel">
                   <property name="text">
                    <string>Tabs before assembly (asm.tabs.off):</string>
@@ -181,13 +149,40 @@
                   </property>
                  </widget>
                 </item>
-                <item row="4" column="2">
-                 <widget class="QComboBox" name="syntaxComboBox"/>
-                </item>
-                <item row="14" column="1" colspan="2">
-                 <widget class="QCheckBox" name="bblineCheckBox">
+                <item row="12" column="1">
+                 <widget class="QLabel" name="nbytesLabel">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
                   <property name="text">
-                   <string>Show empty line after every basic block (asm.bb.line)</string>
+                   <string>Number of bytes to display (asm.nbytes):</string>
+                  </property>
+                  <property name="textInteractionFlags">
+                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="20" column="1" colspan="2">
+                 <widget class="QCheckBox" name="bytespaceCheckBox">
+                  <property name="text">
+                   <string>Separate bytes with whitespace (asm.bytes.space)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="16" column="2">
+                 <widget class="QSpinBox" name="asmTabsSpinBox">
+                  <property name="maximum">
+                   <number>100</number>
+                  </property>
+                  <property name="singleStep">
+                   <number>5</number>
+                  </property>
+                 </widget>
+                </item>
+                <item row="11" column="1">
+                 <widget class="QCheckBox" name="bytesCheckBox">
+                  <property name="text">
+                   <string>Display the bytes of each instruction (asm.bytes)</string>
                   </property>
                  </widget>
                 </item>
@@ -210,44 +205,10 @@
                   </item>
                  </widget>
                 </item>
-                <item row="18" column="1" colspan="2">
-                 <widget class="QCheckBox" name="lbytesCheckBox">
+                <item row="14" column="1" colspan="2">
+                 <widget class="QCheckBox" name="bblineCheckBox">
                   <property name="text">
-                   <string>Align bytes to the left (asm.lbytes)</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="19" column="1" colspan="2">
-                 <widget class="QCheckBox" name="bytespaceCheckBox">
-                  <property name="text">
-                   <string>Separate bytes with whitespace (asm.bytes.space)</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="13" column="1">
-                 <widget class="QCheckBox" name="realnameCheckBox">
-                  <property name="text">
-                   <string>Display flags' real name (asm.flags.real)</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="15" column="1">
-                 <widget class="QLabel" name="asmTabsLabel">
-                  <property name="text">
-                   <string>Tabs in assembly (asm.tabs):</string>
-                  </property>
-                  <property name="textInteractionFlags">
-                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-                  </property>
-                 </widget>
-                </item>
-                <item row="15" column="2">
-                 <widget class="QSpinBox" name="asmTabsSpinBox">
-                  <property name="maximum">
-                   <number>100</number>
-                  </property>
-                  <property name="singleStep">
-                   <number>5</number>
+                   <string>Show empty line after every basic block (asm.bb.line)</string>
                   </property>
                  </widget>
                 </item>
@@ -269,10 +230,56 @@
                   </item>
                  </layout>
                 </item>
-                <item row="8" column="2">
-                 <widget class="QCheckBox" name="relOffFlagsCheckBox">
+                <item row="4" column="2">
+                 <widget class="QComboBox" name="syntaxComboBox"/>
+                </item>
+                <item row="0" column="1" colspan="2">
+                 <spacer name="verticalSpacer_3">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>10</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item row="3" column="1">
+                 <widget class="QLabel" name="label">
                   <property name="text">
-                   <string>Flags (asm.reloff.flags)</string>
+                   <string>Show Disassembly as:</string>
+                  </property>
+                  <property name="textInteractionFlags">
+                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="16" column="1">
+                 <widget class="QLabel" name="asmTabsLabel">
+                  <property name="text">
+                   <string>Tabs in assembly (asm.tabs):</string>
+                  </property>
+                  <property name="textInteractionFlags">
+                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="18" column="1" colspan="2">
+                 <widget class="QCheckBox" name="indentCheckBox">
+                  <property name="text">
+                   <string>Indent disassembly based on reflines depth (asm.indent)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="13" column="1">
+                 <widget class="QCheckBox" name="realnameCheckBox">
+                  <property name="text">
+                   <string>Display flags' real name (asm.flags.real)</string>
                   </property>
                  </widget>
                 </item>
@@ -408,8 +415,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>581</width>
-              <height>302</height>
+              <width>454</width>
+              <height>286</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_6">

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -654,7 +654,9 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
         jumpToOffsetUnderCursor(cursor);
 
         return true;
-    } else if (event->type() == QEvent::ToolTip && obj == mDisasTextEdit->viewport()) {
+    } else if (Config()->getPreviewValue()
+            && event->type() == QEvent::ToolTip
+            && obj == mDisasTextEdit->viewport()) {
         QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
 
         auto cursorForWord = mDisasTextEdit->cursorForPosition(helpEvent->pos());


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Some people might find that a tool-tip jumping here and there when they read/browse/hover the code, might be intrusive. This PR provides a simple checkbox to disable this functionality.

I was forced to create setter/getter inside the `Configuration` class like this:
```cpp
void Configuration::setPreviewValue( bool checked )
{
    s.setValue("asm.preview", checked);
}
```
I tried to use `Config()->setConfig("asm.preview", checked);` but while this worked, I couldn't *read* the saved value with `Config()->getConfigBool("asm.preview")` by no means. I was getting an "`rz_config_set: variable 'asm.preview' not found `" error, so I abandoned this idea.

**Test plan (required)**

One should just open the Preferences and toggle the relevant checkbox in the Disassembly category.
![Screenshot_20211004_011246](https://user-images.githubusercontent.com/18561627/135773134-c3263055-ced1-4f0f-a488-dbaec9b9336c.png)

<!-- **Code formatting**
I formated the code with clang-format but this reformated code that I hadn't touched. I thought I should ask for explicit permission before doing unrelated changes here.

**Closing issues**

Closes #2497
