### PR TITLE
Colorize the preview tooltip in the DisassemblyWidget according to th…

### DIFF
--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -22,6 +22,8 @@
 #include <algorithm>
 #include <cmath>
 
+static const int kMaxTooltipWidth = 400;
+
 class DisassemblyTextBlockUserData : public QTextBlockUserData
 {
 public:
@@ -768,7 +770,7 @@ void DisassemblyWidget::setupColors()
     setStyleSheet(QString{"QToolTip { border-width: 1px; max-width: %1px;"
                               "opacity: 230; background-color: %2;"
                               "color: %3; border-color: %3;}"}
-                              .arg(400)
+                              .arg(kMaxTooltipWidth)
                               .arg(Config()->getColor("gui.tooltip.background").name())
                               .arg(Config()->getColor("gui.tooltip.foreground").name()));
 }


### PR DESCRIPTION
…e overall colors of the window

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Until now the preview tooltips were dark (due to them considered inactive windows). This PR solves this issue as it now reads the colors from the selected style-sheet, colorizing the tooltip in a way that matches the rest of Cutter's environment.

Unlike the #2797 PR, I didn't create a separate function for handling this. I found that `DisassemblyWidget::setupColors()` can contain this code and has a `connect`ion already established.

**Test plan (required)**

Compile and run Cutter. Then in the Disassembly widget move the cursor to preview an address.

![graph7Screenshot_20211007_190708](https://user-images.githubusercontent.com/18561627/136426068-7b12b274-7aeb-4071-9c66-35946e70dd2c.png)

