### PR TITLE
Build jsdec with -Djsc_folder option to embed the javascript code

### DIFF
--- a/dist/bundle_jsdec.ps1
+++ b/dist/bundle_jsdec.ps1
@@ -2,9 +2,9 @@ $dist = $args[0]
 $python = Split-Path((Get-Command python.exe).Path)
 
 if (-not (Test-Path -Path 'jsdec' -PathType Container)) {
-    git clone https://github.com/rizinorg/jsdec.git --depth 1 --branch v0.3.0
+    git clone https://github.com/rizinorg/jsdec.git --depth 1 --branch v0.3.1
 }
 cd jsdec
-& meson.exe --buildtype=release -Dc_args=-DDUK_USE_DATE_NOW_WINDOWS --prefix=$dist --libdir=lib\plugins --datadir=lib\plugins p build
+& meson.exe --buildtype=release -Dc_args=-DDUK_USE_DATE_NOW_WINDOWS -Djsc_folder="." -Drizin_plugdir=lib\plugins -prefix=$dist --libdir=lib\plugins --datadir=lib\plugins p build
 ninja -C build install
 Remove-Item -Recurse -Force $dist\lib\plugins\core_pdd.lib

--- a/scripts/jsdec.sh
+++ b/scripts/jsdec.sh
@@ -7,13 +7,13 @@ SCRIPTPATH=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 cd "$SCRIPTPATH/.."
 
 if [[ ! -d jsdec ]]; then
-	git clone https://github.com/rizinorg/jsdec.git --depth 1 --branch v0.3.0
+	git clone https://github.com/rizinorg/jsdec.git --depth 1 --branch v0.3.1
 fi
 
 cd jsdec
 rm -rf build
 mkdir build && cd build
-meson --buildtype=release --libdir=share/rizin/plugins --datadir=share/rizin/plugins "$@" ../p
+meson --buildtype=release -Drizin_plugdir=share/rizin/plugins -Djsc_folder="../" --libdir=share/rizin/plugins --datadir=share/rizin/plugins "$@" ../p
 ninja
 ninja install
 

--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -184,21 +184,11 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
         sleighHome.cd(
                 "share/rizin/plugins/rz_ghidra_sleigh"); // Contents/Resources/rz/share/rizin/plugins/rz_ghidra_sleigh
         Core()->setConfig("ghidra.sleighhome", sleighHome.absolutePath());
-
-#    ifdef CUTTER_BUNDLE_JSDEC
-        auto jsdecHome = rzprefix;
-        jsdecHome.cd(
-                "share/rizin/plugins/jsdec"); // Contents/Resources/rz/share/rizin/plugins/jsdec
-        qputenv("JSDEC_HOME", jsdecHome.absolutePath().toLocal8Bit());
-#    endif
     }
 #endif
 
 #if defined(Q_OS_WIN) && defined(CUTTER_ENABLE_PACKAGING)
     {
-#    ifdef CUTTER_BUNDLE_JSDEC
-        qputenv("JSDEC_HOME", "lib\\plugins\\jsdec");
-#    endif
         auto sleighHome = QDir(QCoreApplication::applicationDirPath());
         sleighHome.cd("lib/plugins/rz_ghidra_sleigh");
         Core()->setConfig("ghidra.sleighhome", sleighHome.absolutePath());


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

This embeds jsdec into one shared library