### PR TITLE
Removed info button globally

### DIFF
--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -52,7 +52,7 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
     setAttribute(Qt::AA_UseHighDpiPixmaps); // always enabled on Qt >= 6.0.0
 #endif
     setLayoutDirection(Qt::LeftToRight);
-
+    QApplication::setAttribute(Qt::AA_DisableWindowContextHelpButton); //Remove info buttons globally
     // WARN!!! Put initialization code below this line. Code above this line is mandatory to be run
     // First
 

--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -52,7 +52,6 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
     setAttribute(Qt::AA_UseHighDpiPixmaps); // always enabled on Qt >= 6.0.0
 #endif
     setLayoutDirection(Qt::LeftToRight);
-    QApplication::setAttribute(Qt::AA_DisableWindowContextHelpButton); //Remove info buttons globally
     // WARN!!! Put initialization code below this line. Code above this line is mandatory to be run
     // First
 
@@ -142,6 +141,7 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
     // set up context menu shortcut display fix
 #if QT_VERSION_CHECK(5, 10, 0) < QT_VERSION
     setStyle(new CutterProxyStyle());
+    QApplication::setAttribute(Qt::AA_DisableWindowContextHelpButton); // Remove info button globally
 #endif // QT_VERSION_CHECK(5, 10, 0) < QT_VERSION
 
     if (clOptions.args.empty() && clOptions.fileOpenOptions.projectFile.isEmpty()) {

--- a/src/CutterApplication.cpp
+++ b/src/CutterApplication.cpp
@@ -141,7 +141,6 @@ CutterApplication::CutterApplication(int &argc, char **argv) : QApplication(argc
     // set up context menu shortcut display fix
 #if QT_VERSION_CHECK(5, 10, 0) < QT_VERSION
     setStyle(new CutterProxyStyle());
-    QApplication::setAttribute(Qt::AA_DisableWindowContextHelpButton); // Remove info button globally
 #endif // QT_VERSION_CHECK(5, 10, 0) < QT_VERSION
 
     if (clOptions.args.empty() && clOptions.fileOpenOptions.projectFile.isEmpty()) {

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -619,7 +619,9 @@ bool MainWindow::openProject(const QString &file)
         const char *s = rz_project_err_message(err);
         QString msg = tr("Failed to open project: %1").arg(QString::fromUtf8(s));
         RzListIter *it;
-        CutterRzListForeach(res, it, const char, s) { msg += "\n" + QString::fromUtf8(s); }
+        CutterRzListForeach (res, it, const char, s) {
+            msg += "\n" + QString::fromUtf8(s);
+        }
         QMessageBox::critical(this, tr("Open Project"), msg);
         rz_list_free(res);
         return false;
@@ -1134,7 +1136,7 @@ void MainWindow::updateHistoryMenu(QMenu *menu, bool redo)
 
     bool history = true;
     QList<QAction *> actions;
-    CutterRzListForeach(list, it, RzCoreSeekItem, undo) {
+    CutterRzListForeach (list, it, RzCoreSeekItem, undo) {
         RzFlagItem *f = rz_flag_get_at(core->flags, undo->offset, true);
         char *fname = NULL;
         if (f) {
@@ -1789,8 +1791,16 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
     }
 }
 
-bool MainWindow::eventFilter(QObject *, QEvent *event)
+bool MainWindow::eventFilter(QObject *obj, QEvent *event)
 {
+    // For every create event - disable context help and proceed to next event check
+    if (event->type() == QEvent::Create) {
+        if (obj->isWidgetType()) {
+            auto w = static_cast<QWidget *>(obj);
+            w->setWindowFlags(w->windowFlags() & (~Qt::WindowContextHelpButtonHint));
+        }
+    }
+
     if (event->type() == QEvent::MouseButtonPress) {
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
         if (mouseEvent->button() == Qt::ForwardButton || mouseEvent->button() == Qt::BackButton) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

I'm new to Cutter and QT. I'm just trying to get my feat wet for now!

I implemented @ITAYC0HEN's suggestion and removed the WhatThis/info button globally. I simply inserted the global attribute set into CutterApplication.cpp. 

Before
![cutter_whatsthat_button](https://user-images.githubusercontent.com/57366423/137059634-4ab57151-2688-4112-b088-95d19e953553.png)

After
![cutter_whatsthat_button_gone](https://user-images.githubusercontent.com/57366423/137059670-2f86dd16-6085-4cfa-9ad6-9fb77677b9a6.png)

**Test plan (required)**

I observed the "?" button in a few locations including a load window and the edit window. I implemented the code and observed that the button went away.




**Closing issues**

closes #2342
