### PR TITLE
Small improvements for Widgets

### DIFF
--- a/src/common/AnalysisTask.cpp
+++ b/src/common/AnalysisTask.cpp
@@ -8,7 +8,7 @@
 
 AnalysisTask::AnalysisTask() : AsyncTask() {}
 
-AnalysisTask::~AnalysisTask() {}
+AnalysisTask::~AnalysisTask() = default;
 
 void AnalysisTask::interrupt()
 {

--- a/src/common/AnalysisTask.h
+++ b/src/common/AnalysisTask.h
@@ -13,9 +13,25 @@ class AnalysisTask : public AsyncTask
 {
     Q_OBJECT
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(AnalysisTask)                                                           \
+        AnalysisTask(const AnalysisTask &w) = delete;                                              \
+        AnalysisTask &operator=(const AnalysisTask &w) = delete;
+
+#    define Q_DISABLE_MOVE(AnalysisTask)                                                           \
+        AnalysisTask(AnalysisTask &&w) = delete;                                                   \
+        AnalysisTask &operator=(AnalysisTask &&w) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(AnalysisTask)                                                      \
+        Q_DISABLE_COPY(AnalysisTask)                                                               \
+        Q_DISABLE_MOVE(AnalysisTask)
+#endif
+
+    Q_DISABLE_COPY_MOVE(AnalysisTask)
+
 public:
     explicit AnalysisTask();
-    ~AnalysisTask();
+    ~AnalysisTask() override;
 
     QString getTitle() override;
 

--- a/src/common/Decompiler.cpp
+++ b/src/common/Decompiler.cpp
@@ -10,6 +10,8 @@ Decompiler::Decompiler(const QString &id, const QString &name, QObject *parent)
 {
 }
 
+Decompiler::~Decompiler() = default;
+
 RzAnnotatedCode *Decompiler::makeWarning(QString warningMessage)
 {
     std::string temporary = warningMessage.toStdString();
@@ -20,6 +22,8 @@ JSDecDecompiler::JSDecDecompiler(QObject *parent) : Decompiler("jsdec", "jsdec",
 {
     task = nullptr;
 }
+
+JSDecDecompiler::~JSDecDecompiler() = default;
 
 bool JSDecDecompiler::isAvailable()
 {

--- a/src/common/Decompiler.h
+++ b/src/common/Decompiler.h
@@ -21,7 +21,7 @@ private:
 
 public:
     Decompiler(const QString &id, const QString &name, QObject *parent = nullptr);
-    virtual ~Decompiler() = default;
+    ~Decompiler() override;
 
     static RzAnnotatedCode *makeWarning(QString warningMessage);
 
@@ -46,6 +46,8 @@ private:
 
 public:
     explicit JSDecDecompiler(QObject *parent = nullptr);
+    ~JSDecDecompiler() override;
+
     void decompileAt(RVA addr) override;
 
     bool isRunning() override { return task != nullptr; }

--- a/src/common/DecompilerHighlighter.cpp
+++ b/src/common/DecompilerHighlighter.cpp
@@ -13,6 +13,8 @@ DecompilerHighlighter::DecompilerHighlighter(QTextDocument *parent) : QSyntaxHig
     });
 }
 
+DecompilerHighlighter::~DecompilerHighlighter() = default;
+
 void DecompilerHighlighter::setAnnotations(RzAnnotatedCode *code)
 {
     this->code = code;

--- a/src/common/DecompilerHighlighter.h
+++ b/src/common/DecompilerHighlighter.h
@@ -16,9 +16,25 @@ class CUTTER_EXPORT DecompilerHighlighter : public QSyntaxHighlighter
 {
     Q_OBJECT
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(DecompilerHighlighter)                                                  \
+        DecompilerHighlighter(const DecompilerHighlighter &w) = delete;                            \
+        DecompilerHighlighter &operator=(const DecompilerHighlighter &w) = delete;
+
+#    define Q_DISABLE_MOVE(DecompilerHighlighter)                                                  \
+        DecompilerHighlighter(DecompilerHighlighter &&w) = delete;                                 \
+        DecompilerHighlighter &operator=(DecompilerHighlighter &&w) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(DecompilerHighlighter)                                             \
+        Q_DISABLE_COPY(DecompilerHighlighter)                                                      \
+        Q_DISABLE_MOVE(DecompilerHighlighter)
+#endif
+
+    Q_DISABLE_COPY_MOVE(DecompilerHighlighter)
+
 public:
     DecompilerHighlighter(QTextDocument *parent = nullptr);
-    virtual ~DecompilerHighlighter() = default;
+    ~DecompilerHighlighter() override;
 
     /**
      * @brief Set the code with annotations to be used for highlighting.

--- a/src/common/SettingsUpgrade.h
+++ b/src/common/SettingsUpgrade.h
@@ -7,7 +7,8 @@
 namespace Cutter {
 void initializeSettings();
 /**
- * @brief Check if Cutter should offer importing settings from version that can't be directly updated.
+ * @brief Check if Cutter should offer importing settings from version that can't be directly
+ * updated.
  * @return True if this is first time running Cutter and r2 based Cutter <= 1.12 settings exist.
  */
 bool shouldOfferSettingImport();

--- a/src/widgets/AddressableDockWidget.cpp
+++ b/src/widgets/AddressableDockWidget.cpp
@@ -21,6 +21,8 @@ AddressableDockWidget::AddressableDockWidget(MainWindow *parent)
     setContextMenuPolicy(Qt::ContextMenuPolicy::DefaultContextMenu);
 }
 
+AddressableDockWidget::~AddressableDockWidget() = default;
+
 QVariantMap AddressableDockWidget::serializeViewProprties()
 {
     auto result = CutterDockWidget::serializeViewProprties();

--- a/src/widgets/AddressableDockWidget.h
+++ b/src/widgets/AddressableDockWidget.h
@@ -11,9 +11,26 @@ class CutterSeekable;
 class AddressableDockWidget : public CutterDockWidget
 {
     Q_OBJECT
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(AddressableDockWidget)                                                  \
+        AddressableDockWidget(const AddressableDockWidget &m) = delete;                            \
+        AddressableDockWidget &operator=(const AddressableDockWidget &m) = delete;
+
+#    define Q_DISABLE_MOVE(AddressableDockWidget)                                                  \
+        AddressableDockWidget(AddressableDockWidget &&m) = delete;                                 \
+        AddressableDockWidget &operator=(AddressableDockWidget &&m) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(AddressableDockWidget)                                             \
+        Q_DISABLE_COPY(AddressableDockWidget)                                                      \
+        Q_DISABLE_MOVE(AddressableDockWidget)
+#endif
+
+    Q_DISABLE_COPY_MOVE(AddressableDockWidget)
+
 public:
     AddressableDockWidget(MainWindow *parent);
-    ~AddressableDockWidget() override {}
+    ~AddressableDockWidget() override;
 
     CutterSeekable *getSeekable() const;
 

--- a/src/widgets/BacktraceWidget.cpp
+++ b/src/widgets/BacktraceWidget.cpp
@@ -31,7 +31,7 @@ BacktraceWidget::BacktraceWidget(MainWindow *main)
     connect(Config(), &Configuration::fontsUpdated, this, &BacktraceWidget::fontsUpdatedSlot);
 }
 
-BacktraceWidget::~BacktraceWidget() {}
+BacktraceWidget::~BacktraceWidget() = default;
 
 void BacktraceWidget::updateContents()
 {

--- a/src/widgets/BacktraceWidget.h
+++ b/src/widgets/BacktraceWidget.h
@@ -18,9 +18,25 @@ class BacktraceWidget : public CutterDockWidget
 {
     Q_OBJECT
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(BacktraceWidget)                                                        \
+        BacktraceWidget(const BacktraceWidget &m) = delete;                                        \
+        BacktraceWidget &operator=(const BacktraceWidget &m) = delete;
+
+#    define Q_DISABLE_MOVE(BacktraceWidget)                                                        \
+        BacktraceWidget(BacktraceWidget &&m) = delete;                                             \
+        BacktraceWidget &operator=(BacktraceWidget &&m) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(BacktraceWidget)                                                   \
+        Q_DISABLE_COPY(BacktraceWidget)                                                            \
+        Q_DISABLE_MOVE(BacktraceWidget)
+#endif
+
+    Q_DISABLE_COPY_MOVE(BacktraceWidget)
+
 public:
     explicit BacktraceWidget(MainWindow *main);
-    ~BacktraceWidget();
+    ~BacktraceWidget() override;
 
 private slots:
     void updateContents();

--- a/src/widgets/BreakpointWidget.cpp
+++ b/src/widgets/BreakpointWidget.cpp
@@ -19,6 +19,8 @@ void BreakpointModel::refresh()
     endResetModel();
 }
 
+BreakpointModel::~BreakpointModel() = default;
+
 int BreakpointModel::rowCount(const QModelIndex &) const
 {
     return breakpoints.count();
@@ -176,6 +178,8 @@ BreakpointProxyModel::BreakpointProxyModel(BreakpointModel *sourceModel, QObject
     // Use numeric values instead of numbers converted to strings if available
     this->setSortRole(Qt::EditRole);
 }
+
+BreakpointProxyModel::~BreakpointProxyModel() = default;
 
 BreakpointWidget::BreakpointWidget(MainWindow *main)
     : CutterDockWidget(main), ui(new Ui::BreakpointWidget)

--- a/src/widgets/BreakpointWidget.h
+++ b/src/widgets/BreakpointWidget.h
@@ -24,6 +24,22 @@ class BreakpointModel : public AddressableItemModel<QAbstractListModel>
 {
     Q_OBJECT
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(BreakpointModel)                                                        \
+        BreakpointModel(const BreakpointModel &m) = delete;                                        \
+        BreakpointModel &operator=(const BreakpointModel &m) = delete;
+
+#    define Q_DISABLE_MOVE(BreakpointModel)                                                        \
+        BreakpointModel(BreakpointModel &&m) = delete;                                             \
+        BreakpointModel &operator=(BreakpointModel &&m) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(BreakpointModel)                                                   \
+        Q_DISABLE_COPY(BreakpointModel)                                                            \
+        Q_DISABLE_MOVE(BreakpointModel)
+#endif
+
+    Q_DISABLE_COPY_MOVE(BreakpointModel)
+
     friend BreakpointWidget;
 
 private:
@@ -42,6 +58,7 @@ public:
     enum Role { BreakpointDescriptionRole = Qt::UserRole };
 
     BreakpointModel(QObject *parent = nullptr);
+    ~BreakpointModel() override;
 
     void refresh();
 
@@ -61,17 +78,50 @@ class BreakpointProxyModel : public AddressableFilterProxyModel
 {
     Q_OBJECT
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(BreakpointProxyModel)                                                   \
+        BreakpointProxyModel(const BreakpointProxyModel &m) = delete;                              \
+        BreakpointProxyModel &operator=(const BreakpointProxyModel &m) = delete;
+
+#    define Q_DISABLE_MOVE(BreakpointProxyModel)                                                   \
+        BreakpointProxyModel(BreakpointProxyModel &&m) = delete;                                   \
+        BreakpointProxyModel &operator=(BreakpointProxyModel &&m) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(BreakpointProxyModel)                                              \
+        Q_DISABLE_COPY(BreakpointProxyModel)                                                       \
+        Q_DISABLE_MOVE(BreakpointProxyModel)
+#endif
+
+    Q_DISABLE_COPY_MOVE(BreakpointProxyModel)
+
 public:
     BreakpointProxyModel(BreakpointModel *sourceModel, QObject *parent = nullptr);
+    ~BreakpointProxyModel() override;
 };
 
 class BreakpointWidget : public CutterDockWidget
 {
     Q_OBJECT
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(BreakpointWidget)                                                       \
+        BreakpointWidget(const BreakpointWidget &w) = delete;                                      \
+        BreakpointWidget &operator=(const BreakpointWidget &w) = delete;
+
+#    define Q_DISABLE_MOVE(BreakpointWidget)                                                       \
+        BreakpointWidget(BreakpointWidget &&w) = delete;                                           \
+        BreakpointWidget &operator=(BreakpointWidget &&w) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(BreakpointWidget)                                                  \
+        Q_DISABLE_COPY(BreakpointWidget)                                                           \
+        Q_DISABLE_MOVE(BreakpointWidget)
+#endif
+
+    Q_DISABLE_COPY_MOVE(BreakpointWidget)
+
 public:
     explicit BreakpointWidget(MainWindow *main);
-    ~BreakpointWidget();
+    ~BreakpointWidget() override;
 
 private slots:
     void delBreakpoint();

--- a/src/widgets/CallGraph.cpp
+++ b/src/widgets/CallGraph.cpp
@@ -16,7 +16,7 @@ CallGraphWidget::CallGraphWidget(MainWindow *main, bool global)
     setWidget(graphView);
 }
 
-CallGraphWidget::~CallGraphWidget() {}
+CallGraphWidget::~CallGraphWidget() = default;
 
 QString CallGraphWidget::getWindowTitle() const
 {

--- a/src/widgets/CallGraph.h
+++ b/src/widgets/CallGraph.h
@@ -13,6 +13,23 @@ class MainWindow;
 class CallGraphView : public SimpleTextGraphView
 {
     Q_OBJECT
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(CallGraphView)                                                          \
+        CallGraphView(const CallGraphView &v) = delete;                                            \
+        CallGraphView &operator=(const CallGraphView &v) = delete;
+
+#    define Q_DISABLE_MOVE(CallGraphView)                                                          \
+        CallGraphView(CallGraphView &&v) = delete;                                                 \
+        CallGraphView &operator=(CallGraphView &&v) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(CallGraphView)                                                     \
+        Q_DISABLE_COPY(CallGraphView)                                                              \
+        Q_DISABLE_MOVE(CallGraphView)
+#endif
+
+    Q_DISABLE_COPY_MOVE(CallGraphView)
+
 public:
     CallGraphView(CutterDockWidget *parent, MainWindow *main, bool global);
     void showExportDialog() override;
@@ -35,9 +52,25 @@ class CallGraphWidget : public AddressableDockWidget
 {
     Q_OBJECT
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(CallGraphWidget)                                                        \
+        CallGraphWidget(const CallGraphWidget &w) = delete;                                        \
+        CallGraphWidget &operator=(const CallGraphWidget &w) = delete;
+
+#    define Q_DISABLE_MOVE(CallGraphWidget)                                                        \
+        CallGraphWidget(CallGraphWidget &&w) = delete;                                             \
+        CallGraphWidget &operator=(CallGraphWidget &&w) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(CallGraphWidget)                                                   \
+        Q_DISABLE_COPY(CallGraphWidget)                                                            \
+        Q_DISABLE_MOVE(CallGraphWidget)
+#endif
+
+    Q_DISABLE_COPY_MOVE(CallGraphWidget)
+
 public:
     explicit CallGraphWidget(MainWindow *main, bool global);
-    ~CallGraphWidget();
+    ~CallGraphWidget() override;
 
 protected:
     QString getWindowTitle() const override;

--- a/src/widgets/ClassesWidget.cpp
+++ b/src/widgets/ClassesWidget.cpp
@@ -221,6 +221,8 @@ AnalysisClassesModel::AnalysisClassesModel(CutterDockWidget *parent)
     refreshAll();
 }
 
+AnalysisClassesModel::~AnalysisClassesModel() = default;
+
 void AnalysisClassesModel::refreshAll()
 {
     if (!refreshDeferrer->attemptRefresh(nullptr)) {
@@ -522,6 +524,8 @@ ClassesSortFilterProxyModel::ClassesSortFilterProxyModel(QObject *parent)
 {
 }
 
+ClassesSortFilterProxyModel::~ClassesSortFilterProxyModel() = default;
+
 bool ClassesSortFilterProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) const
 {
     QModelIndex index = sourceModel()->index(row, 0, parent);
@@ -589,7 +593,7 @@ ClassesWidget::ClassesWidget(MainWindow *main) : CutterDockWidget(main), ui(new 
     refreshClasses();
 }
 
-ClassesWidget::~ClassesWidget() {}
+ClassesWidget::~ClassesWidget() = default;
 
 ClassesWidget::Source ClassesWidget::getSource()
 {

--- a/src/widgets/ClassesWidget.h
+++ b/src/widgets/ClassesWidget.h
@@ -62,6 +62,7 @@ public:
     static const int VTableRole = Qt::UserRole + 3;
 
     explicit ClassesModel(QObject *parent = nullptr) : QAbstractItemModel(parent) {}
+    ~ClassesModel() override = default;
 
     QVariant headerData(int section, Qt::Orientation orientation,
                         int role = Qt::DisplayRole) const override;
@@ -93,6 +94,22 @@ public:
 class AnalysisClassesModel : public ClassesModel
 {
     Q_OBJECT
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(AnalysisClassesModel)                                                   \
+        AnalysisClassesModel(const AnalysisClassesModel &m) = delete;                              \
+        AnalysisClassesModel &operator=(const AnalysisClassesModel &m) = delete;
+
+#    define Q_DISABLE_MOVE(AnalysisClassesModel)                                                   \
+        AnalysisClassesModel(AnalysisClassesModel &&m) = delete;                                   \
+        AnalysisClassesModel &operator=(AnalysisClassesModel &&m) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(AnalysisClassesModel)                                              \
+        Q_DISABLE_COPY(AnalysisClassesModel)                                                       \
+        Q_DISABLE_MOVE(AnalysisClassesModel)
+#endif
+
+    Q_DISABLE_COPY_MOVE(AnalysisClassesModel)
 
 private:
     /**
@@ -146,6 +163,7 @@ private:
 
 public:
     explicit AnalysisClassesModel(CutterDockWidget *parent);
+    ~AnalysisClassesModel() override;
 
 public slots:
     void refreshAll();
@@ -161,6 +179,7 @@ class ClassesSortFilterProxyModel : public QSortFilterProxyModel
 
 public:
     explicit ClassesSortFilterProxyModel(QObject *parent = nullptr);
+    ~ClassesSortFilterProxyModel() override;
 
 protected:
     bool filterAcceptsRow(int row, const QModelIndex &parent) const override;
@@ -172,9 +191,25 @@ class ClassesWidget : public CutterDockWidget
 {
     Q_OBJECT
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(ClassesWidget)                                                          \
+        ClassesWidget(const ClassesWidget &w) = delete;                                            \
+        ClassesWidget &operator=(const ClassesWidget &w) = delete;
+
+#    define Q_DISABLE_MOVE(ClassesWidget)                                                          \
+        ClassesWidget(ClassesWidget &&w) = delete;                                                 \
+        ClassesWidget &operator=(ClassesWidget &&w) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(ClassesWidget)                                                     \
+        Q_DISABLE_COPY(ClassesWidget)                                                              \
+        Q_DISABLE_MOVE(ClassesWidget)
+#endif
+
+    Q_DISABLE_COPY_MOVE(ClassesWidget)
+
 public:
     explicit ClassesWidget(MainWindow *main);
-    ~ClassesWidget();
+    ~ClassesWidget() override;
 
 private slots:
     void on_classesTreeView_doubleClicked(const QModelIndex &index);

--- a/src/widgets/ColorPicker.cpp
+++ b/src/widgets/ColorPicker.cpp
@@ -22,6 +22,8 @@ ColorPickArea::ColorPickArea(QWidget *parent) : ColorPickerWidget(parent)
     setMouseTracking(false);
 }
 
+ColorPickArea::~ColorPickArea() = default;
+
 void ColorPickArea::paintEvent(QPaintEvent *event)
 {
     QPainter p(this);
@@ -60,6 +62,8 @@ void ColorPickArea::setColor(const QColor &c)
 }
 
 ColorPickerWidget::ColorPickerWidget(QWidget *parent) : ColorPickWidgetAbstract(parent) {}
+
+ColorPickerWidget::~ColorPickerWidget() = default;
 
 void ColorPickerWidget::mouseReleaseEvent(QMouseEvent *event)
 {
@@ -357,6 +361,8 @@ void ColorPicker::stopPickingFromScreen()
 }
 
 ColorShowWidget::ColorShowWidget(QWidget *parent) : ColorPickWidgetAbstract(parent) {}
+
+ColorShowWidget::~ColorShowWidget() = default;
 
 void ColorShowWidget::setColor(const QColor &c)
 {

--- a/src/widgets/ColorPicker.h
+++ b/src/widgets/ColorPicker.h
@@ -11,9 +11,26 @@ namespace ColorPickerHelpers {
 class ColorPickWidgetAbstract : public QWidget
 {
     Q_OBJECT
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(ColorPickWidgetAbstract)                                                \
+        ColorPickWidgetAbstract(const ColorPickWidgetAbstract &m) = delete;                        \
+        ColorPickWidgetAbstract &operator=(const ColorPickWidgetAbstract &m) = delete;
+
+#    define Q_DISABLE_MOVE(ColorPickWidgetAbstract)                                                \
+        ColorPickWidgetAbstract(ColorPickWidgetAbstract &&m) = delete;                             \
+        ColorPickWidgetAbstract &operator=(ColorPickWidgetAbstract &&m) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(ColorPickWidgetAbstract)                                           \
+        Q_DISABLE_COPY(ColorPickWidgetAbstract)                                                    \
+        Q_DISABLE_MOVE(ColorPickWidgetAbstract)
+#endif
+
+    Q_DISABLE_COPY_MOVE(ColorPickWidgetAbstract)
+
 public:
     ColorPickWidgetAbstract(QWidget *parent = nullptr) : QWidget(parent) {}
-    virtual ~ColorPickWidgetAbstract() {}
+    ~ColorPickWidgetAbstract() override = default;
 
 signals:
     void colorChanged(const QColor &color);
@@ -37,9 +54,26 @@ class ColorPicker;
 class ColorPicker : public ColorPickerHelpers::ColorPickWidgetAbstract
 {
     Q_OBJECT
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(ColorPicker)                                                            \
+        ColorPicker(const ColorPicker &w) = delete;                                                \
+        ColorPicker &operator=(const ColorPicker &w) = delete;
+
+#    define Q_DISABLE_MOVE(ColorPicker)                                                            \
+        ColorPicker(ColorPicker &&w) = delete;                                                     \
+        ColorPicker &operator=(ColorPicker &&w) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(ColorPicker)                                                       \
+        Q_DISABLE_COPY(ColorPicker)                                                                \
+        Q_DISABLE_MOVE(ColorPicker)
+#endif
+
+    Q_DISABLE_COPY_MOVE(ColorPicker)
+
 public:
     explicit ColorPicker(QWidget *parent = nullptr);
-    ~ColorPicker();
+    ~ColorPicker() override;
 
     /**
      * @brief isPickingFromScreen returns true if color picker is picking from screen.
@@ -52,7 +86,7 @@ public slots:
     /**
      * @brief setColor sets displayed color to @a color and emits colorChanged signal.
      */
-    virtual void setColor(const QColor &color) override;
+    void setColor(const QColor &color) override;
 
     void colorChannelChanged();
 
@@ -95,8 +129,26 @@ namespace ColorPickerHelpers {
 class ColorPickerWidget : public ColorPickWidgetAbstract
 {
     Q_OBJECT
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(ColorPickerWidget)                                                      \
+        ColorPickerWidget(const ColorPickerWidget &w) = delete;                                    \
+        ColorPickerWidget &operator=(const ColorPickerWidget &w) = delete;
+
+#    define Q_DISABLE_MOVE(ColorPickerWidget)                                                      \
+        ColorPickerWidget(ColorPickerWidget &&w) = delete;                                         \
+        ColorPickerWidget &operator=(ColorPickerWidget &&w) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(ColorPickerWidget)                                                 \
+        Q_DISABLE_COPY(ColorPickerWidget)                                                          \
+        Q_DISABLE_MOVE(ColorPickerWidget)
+#endif
+
+    Q_DISABLE_COPY_MOVE(ColorPickerWidget)
+
 public:
     ColorPickerWidget(QWidget *parent = nullptr);
+    ~ColorPickerWidget() override;
 
 protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
@@ -119,8 +171,26 @@ protected:
 class ColorShowWidget : public ColorPickWidgetAbstract
 {
     Q_OBJECT
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(ColorShowWidget)                                                        \
+        ColorShowWidget(const ColorShowWidget &w) = delete;                                        \
+        ColorShowWidget &operator=(const ColorShowWidget &w) = delete;
+
+#    define Q_DISABLE_MOVE(ColorShowWidget)                                                        \
+        ColorShowWidget(ColorShowWidget &&w) = delete;                                             \
+        ColorShowWidget &operator=(ColorShowWidget &&w) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(ColorShowWidget)                                                   \
+        Q_DISABLE_COPY(ColorShowWidget)                                                            \
+        Q_DISABLE_MOVE(ColorShowWidget)
+#endif
+
+    Q_DISABLE_COPY_MOVE(ColorShowWidget)
+
 public:
     explicit ColorShowWidget(QWidget *parent = nullptr);
+    ~ColorShowWidget() override;
 
     void setColor(const QColor &c) override;
 
@@ -135,8 +205,26 @@ protected:
 class ColorPickArea : public ColorPickerWidget
 {
     Q_OBJECT
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(ColorPickArea)                                                          \
+        ColorPickArea(const ColorPickArea &w) = delete;                                            \
+        ColorPickArea &operator=(const ColorPickArea &w) = delete;
+
+#    define Q_DISABLE_MOVE(ColorPickArea)                                                          \
+        ColorPickArea(ColorPickArea &&w) = delete;                                                 \
+        ColorPickArea &operator=(ColorPickArea &&w) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(ColorPickArea)                                                     \
+        Q_DISABLE_COPY(ColorPickArea)                                                              \
+        Q_DISABLE_MOVE(ColorPickArea)
+#endif
+
+    Q_DISABLE_COPY_MOVE(ColorPickArea)
+
 public:
     explicit ColorPickArea(QWidget *parent = nullptr);
+    ~ColorPickArea() override;
 
     void setColor(const QColor &c) override;
 
@@ -152,8 +240,26 @@ private:
 class AlphaChannelBar : public ColorPickerWidget
 {
     Q_OBJECT
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(AlphaChannelBar)                                                        \
+        AlphaChannelBar(const AlphaChannelBar &w) = delete;                                        \
+        AlphaChannelBar &operator=(const AlphaChannelBar &w) = delete;
+
+#    define Q_DISABLE_MOVE(AlphaChannelBar)                                                        \
+        AlphaChannelBar(AlphaChannelBar &&w) = delete;                                             \
+        AlphaChannelBar &operator=(AlphaChannelBar &&w) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(AlphaChannelBar)                                                   \
+        Q_DISABLE_COPY(AlphaChannelBar)                                                            \
+        Q_DISABLE_MOVE(AlphaChannelBar)
+#endif
+
+    Q_DISABLE_COPY_MOVE(AlphaChannelBar)
+
 public:
     AlphaChannelBar(QWidget *parent = nullptr) : ColorPickerWidget(parent) {}
+    ~AlphaChannelBar() override = default;
 
     void setColor(const QColor &c) override;
 
@@ -173,8 +279,26 @@ private:
 class ColorValueBar : public ColorPickerWidget
 {
     Q_OBJECT
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(ColorValueBar)                                                          \
+        ColorValueBar(const ColorValueBar &w) = delete;                                            \
+        ColorValueBar &operator=(const ColorValueBar &w) = delete;
+
+#    define Q_DISABLE_MOVE(ColorValueBar)                                                          \
+        ColorValueBar(ColorValueBar &&w) = delete;                                                 \
+        ColorValueBar &operator=(ColorValueBar &&w) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(ColorValueBar)                                                     \
+        Q_DISABLE_COPY(ColorValueBar)                                                              \
+        Q_DISABLE_MOVE(ColorValueBar)
+#endif
+
+    Q_DISABLE_COPY_MOVE(ColorValueBar)
+
 public:
     ColorValueBar(QWidget *parent = nullptr) : ColorPickerWidget(parent) {}
+    ~ColorValueBar() override = default;
 
     void setColor(const QColor &c) override;
 

--- a/src/widgets/ColorThemeComboBox.cpp
+++ b/src/widgets/ColorThemeComboBox.cpp
@@ -12,6 +12,8 @@ ColorThemeComboBox::ColorThemeComboBox(QWidget *parent) : QComboBox(parent), sho
     updateFromConfig();
 }
 
+ColorThemeComboBox::~ColorThemeComboBox() = default;
+
 void ColorThemeComboBox::updateFromConfig(bool interfaceThemeChanged)
 {
     QSignalBlocker signalBlockerColorBox(this);
@@ -22,8 +24,7 @@ void ColorThemeComboBox::updateFromConfig(bool interfaceThemeChanged)
 
     clear();
     for (const QString &theme : themes) {
-        if (ThemeWorker().isCustomTheme(theme)
-            || !Configuration::relevantThemes[theme]
+        if (ThemeWorker().isCustomTheme(theme) || !Configuration::relevantThemes[theme]
             || (Configuration::cutterInterfaceThemesList()[curInterfaceThemeIndex].flag
                 & Configuration::relevantThemes[theme])) {
             addItem(theme);

--- a/src/widgets/ColorThemeComboBox.h
+++ b/src/widgets/ColorThemeComboBox.h
@@ -9,8 +9,26 @@
 class ColorThemeComboBox : public QComboBox
 {
     Q_OBJECT
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(ColorThemeComboBox)                                                     \
+        ColorThemeComboBox(const ColorThemeComboBox &m) = delete;                                  \
+        ColorThemeComboBox &operator=(const ColorThemeComboBox &m) = delete;
+
+#    define Q_DISABLE_MOVE(ColorThemeComboBox)                                                     \
+        ColorThemeComboBox(ColorThemeComboBox &&m) = delete;                                       \
+        ColorThemeComboBox &operator=(ColorThemeComboBox &&m) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(ColorThemeComboBox)                                                \
+        Q_DISABLE_COPY(ColorThemeComboBox)                                                         \
+        Q_DISABLE_MOVE(ColorThemeComboBox)
+#endif
+
+    Q_DISABLE_COPY_MOVE(ColorThemeComboBox)
+
 public:
     explicit ColorThemeComboBox(QWidget *parent = nullptr);
+    ~ColorThemeComboBox() override;
 
     /**
      * @brief setShowOnlyCustom sets whether or not combobox should contain only

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -38,6 +38,8 @@ ColorOptionDelegate::ColorOptionDelegate(QObject *parent) : QStyledItemDelegate(
     });
 }
 
+ColorOptionDelegate::~ColorOptionDelegate() = default;
+
 void ColorOptionDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
                                 const QModelIndex &index) const
 {
@@ -236,6 +238,8 @@ ColorThemeListView::ColorThemeListView(QWidget *parent) : QListView(parent)
     setMouseTracking(true);
 }
 
+ColorThemeListView::~ColorThemeListView() = default;
+
 void ColorThemeListView::currentChanged(const QModelIndex &current, const QModelIndex &previous)
 {
     ColorOption prev = previous.data(Qt::UserRole).value<ColorOption>();
@@ -324,6 +328,8 @@ void ColorThemeListView::blinkTimeout()
 }
 
 ColorSettingsModel::ColorSettingsModel(QObject *parent) : QAbstractListModel(parent) {}
+
+ColorSettingsModel::~ColorSettingsModel() = default;
 
 QVariant ColorSettingsModel::data(const QModelIndex &index, int role) const
 {

--- a/src/widgets/ColorThemeListView.h
+++ b/src/widgets/ColorThemeListView.h
@@ -20,9 +20,26 @@ class ColorSettingsModel;
 class ColorThemeListView : public QListView
 {
     Q_OBJECT
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(ColorThemeListView)                                                     \
+        ColorThemeListView(const ColorThemeListView &m) = delete;                                  \
+        ColorThemeListView &operator=(const ColorThemeListView &m) = delete;
+
+#    define Q_DISABLE_MOVE(ColorThemeListView)                                                     \
+        ColorThemeListView(ColorThemeListView &&m) = delete;                                       \
+        ColorThemeListView &operator=(ColorThemeListView &&m) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(ColorThemeListView)                                                \
+        Q_DISABLE_COPY(ColorThemeListView)                                                         \
+        Q_DISABLE_MOVE(ColorThemeListView)
+#endif
+
+    Q_DISABLE_COPY_MOVE(ColorThemeListView)
+
 public:
     ColorThemeListView(QWidget *parent = nullptr);
-    virtual ~ColorThemeListView() override {}
+    ~ColorThemeListView() override;
 
     ColorSettingsModel *colorSettingsModel() const;
 
@@ -56,9 +73,26 @@ private:
 class ColorSettingsModel : public QAbstractListModel
 {
     Q_OBJECT
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(ColorSettingsModel)                                                     \
+        ColorSettingsModel(const ColorSettingsModel &w) = delete;                                  \
+        ColorSettingsModel &operator=(const ColorSettingsModel &w) = delete;
+
+#    define Q_DISABLE_MOVE(ColorSettingsModel)                                                     \
+        ColorSettingsModel(ColorSettingsModel &&w) = delete;                                       \
+        ColorSettingsModel &operator=(ColorSettingsModel &&w) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(ColorSettingsModel)                                                \
+        Q_DISABLE_COPY(ColorSettingsModel)                                                         \
+        Q_DISABLE_MOVE(ColorSettingsModel)
+#endif
+
+    Q_DISABLE_COPY_MOVE(ColorSettingsModel)
+
 public:
     ColorSettingsModel(QObject *parent = nullptr);
-    virtual ~ColorSettingsModel() override {}
+    ~ColorSettingsModel() override;
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
@@ -81,9 +115,26 @@ private:
 class ColorOptionDelegate : public QStyledItemDelegate
 {
     Q_OBJECT
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_COPY(ColorOptionDelegate)                                                    \
+        ColorOptionDelegate(const ColorOptionDelegate &d) = delete;                                \
+        ColorOptionDelegate &operator=(const ColorOptionDelegate &d) = delete;
+
+#    define Q_DISABLE_MOVE(ColorOptionDelegate)                                                    \
+        ColorOptionDelegate(ColorOptionDelegate &&d) = delete;                                     \
+        ColorOptionDelegate &operator=(ColorOptionDelegate &&d) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(ColorOptionDelegate)                                               \
+        Q_DISABLE_COPY(ColorOptionDelegate)                                                        \
+        Q_DISABLE_MOVE(ColorOptionDelegate)
+#endif
+
+    Q_DISABLE_COPY_MOVE(ColorOptionDelegate)
+
 public:
     ColorOptionDelegate(QObject *parent = nullptr);
-    ~ColorOptionDelegate() override {}
+    ~ColorOptionDelegate() override;
 
     void paint(QPainter *painter, const QStyleOptionViewItem &option,
                const QModelIndex &index) const override;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Since `QObject`s aren't copyable or moveable, we explicity delete the relevant constructors so the compiler can perform further optimizations. Also, Qt versions that are < 5.13, don't have the `Q_DISABLE_COPY_MOVE()` macro so I define it like this:
```cpp
#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
#    define Q_DISABLE_COPY(AnalysisTask)                                                           \
        AnalysisTask(const AnalysisTask &w) = delete;                                              \
        AnalysisTask &operator=(const AnalysisTask &w) = delete;

#    define Q_DISABLE_MOVE(AnalysisTask)                                                           \
        AnalysisTask(AnalysisTask &&w) = delete;                                                   \
        AnalysisTask &operator=(AnalysisTask &&w) = delete;

#    define Q_DISABLE_COPY_MOVE(AnalysisTask)                                                      \
        Q_DISABLE_COPY(AnalysisTask)                                                               \
        Q_DISABLE_MOVE(AnalysisTask)
#endif

    Q_DISABLE_COPY_MOVE(AnalysisTask)
```

**Test plan (required)**

Nothing changed in the visual aspect of the widgets. Compile and run Cutter as usual.
