### PR TITLE
Apply Q_DISABLE_COPY_MOVE macro in some widgets

### DIFF
--- a/src/core/CutterCommon.h
+++ b/src/core/CutterCommon.h
@@ -81,8 +81,8 @@ inline QString RzHexString(RVA size)
  */
 #if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
 #    define Q_DISABLE_MOVE(Class)                                                                  \
-        Class(Class &&w) = delete;                                                                 \
-        Class &operator=(Class &&w) = delete;
+        Class(Class &&) = delete;                                                                  \
+        Class &operator=(Class &&) = delete;
 
 #    define Q_DISABLE_COPY_MOVE(Class)                                                             \
         Q_DISABLE_COPY(Class)                                                                      \

--- a/src/core/CutterCommon.h
+++ b/src/core/CutterCommon.h
@@ -15,11 +15,11 @@
 #endif // Q_OS_WIN
 
 // Rizin list iteration macros
-#define CutterRzListForeach(list, it, type, x)                                                      \
+#define CutterRzListForeach(list, it, type, x)                                                     \
     if (list)                                                                                      \
         for (it = list->head; it && ((x = static_cast<type *>(it->data))); it = it->n)
 
-#define CutterRzVectorForeach(vec, it, type)                                                        \
+#define CutterRzVectorForeach(vec, it, type)                                                       \
     if ((vec) && (vec)->a)                                                                         \
         for (it = (type *)(vec)->a;                                                                \
              (char *)it != (char *)(vec)->a + ((vec)->len * (vec)->elem_size);                     \
@@ -72,6 +72,21 @@ inline QString RzHexString(RVA size)
 #endif
 #if !defined(CUTTER_DEPRECATED)
 #    define CUTTER_DEPRECATED(msg)
+#endif
+
+/**
+ * @brief Since Qt versions < 5.13 don't define the Q_DISABLE_COPY_MOVE
+ * macro, we define it here. This check and this macro definition  will
+ * be deprecated when Cutter moves to a greater than 5.13.0 Qt version.
+ */
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#    define Q_DISABLE_MOVE(Class)                                                                  \
+        Class(Class &&w) = delete;                                                                 \
+        Class &operator=(Class &&w) = delete;
+
+#    define Q_DISABLE_COPY_MOVE(Class)                                                             \
+        Q_DISABLE_COPY(Class)                                                                      \
+        Q_DISABLE_MOVE(Class)
 #endif
 
 #endif // CUTTERCORE_H

--- a/src/widgets/AddressableDockWidget.h
+++ b/src/widgets/AddressableDockWidget.h
@@ -11,6 +11,8 @@ class CutterSeekable;
 class AddressableDockWidget : public CutterDockWidget
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(AddressableDockWidget)
+
 public:
     AddressableDockWidget(MainWindow *parent);
     ~AddressableDockWidget() override {}

--- a/src/widgets/BacktraceWidget.h
+++ b/src/widgets/BacktraceWidget.h
@@ -17,6 +17,7 @@ class BacktraceWidget;
 class BacktraceWidget : public CutterDockWidget
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(BacktraceWidget)
 
 public:
     explicit BacktraceWidget(MainWindow *main);

--- a/src/widgets/BoolToggleDelegate.h
+++ b/src/widgets/BoolToggleDelegate.h
@@ -7,6 +7,9 @@
 
 class CUTTER_EXPORT BoolTogggleDelegate : public QStyledItemDelegate
 {
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(BoolTogggleDelegate)
+
 public:
     BoolTogggleDelegate(QObject *parent = nullptr);
 

--- a/src/widgets/BreakpointWidget.h
+++ b/src/widgets/BreakpointWidget.h
@@ -23,6 +23,7 @@ class BreakpointWidget;
 class BreakpointModel : public AddressableItemModel<QAbstractListModel>
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(BreakpointModel)
 
     friend BreakpointWidget;
 
@@ -60,6 +61,7 @@ public:
 class BreakpointProxyModel : public AddressableFilterProxyModel
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(BreakpointProxyModel)
 
 public:
     BreakpointProxyModel(BreakpointModel *sourceModel, QObject *parent = nullptr);
@@ -68,6 +70,7 @@ public:
 class BreakpointWidget : public CutterDockWidget
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(BreakpointWidget)
 
 public:
     explicit BreakpointWidget(MainWindow *main);

--- a/src/widgets/CallGraph.h
+++ b/src/widgets/CallGraph.h
@@ -13,6 +13,8 @@ class MainWindow;
 class CallGraphView : public SimpleTextGraphView
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(CallGraphView)
+
 public:
     CallGraphView(CutterDockWidget *parent, MainWindow *main, bool global);
     void showExportDialog() override;

--- a/src/widgets/ClassesWidget.h
+++ b/src/widgets/ClassesWidget.h
@@ -23,6 +23,9 @@ class ClassesWidget;
  */
 class ClassesModel : public QAbstractItemModel
 {
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(ClassesModel)
+
 public:
     enum Columns { NAME = 0, TYPE, OFFSET, VTABLE, COUNT };
 
@@ -72,6 +75,7 @@ Q_DECLARE_METATYPE(ClassesModel::RowType)
 class BinClassesModel : public ClassesModel
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(BinClassesModel)
 
 private:
     QList<BinClassDescription> classes;
@@ -93,6 +97,7 @@ public:
 class AnalysisClassesModel : public ClassesModel
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(AnalysisClassesModel)
 
 private:
     /**

--- a/src/widgets/ColorPicker.h
+++ b/src/widgets/ColorPicker.h
@@ -11,7 +11,6 @@ namespace ColorPickerHelpers {
 class ColorPickWidgetAbstract : public QWidget
 {
     Q_OBJECT
-    Q_DISABLE_COPY_MOVE(ColorPickWidgetAbstract)
 
 public:
     ColorPickWidgetAbstract(QWidget *parent = nullptr) : QWidget(parent) {}
@@ -39,7 +38,6 @@ class ColorPicker;
 class ColorPicker : public ColorPickerHelpers::ColorPickWidgetAbstract
 {
     Q_OBJECT
-    Q_DISABLE_COPY_MOVE(ColorPicker)
 
 public:
     explicit ColorPicker(QWidget *parent = nullptr);
@@ -99,7 +97,6 @@ namespace ColorPickerHelpers {
 class ColorPickerWidget : public ColorPickWidgetAbstract
 {
     Q_OBJECT
-    Q_DISABLE_COPY_MOVE(ColorPickerWidget)
 
 public:
     ColorPickerWidget(QWidget *parent = nullptr);
@@ -125,7 +122,6 @@ protected:
 class ColorShowWidget : public ColorPickWidgetAbstract
 {
     Q_OBJECT
-    Q_DISABLE_COPY_MOVE(ColorShowWidget)
 
 public:
     explicit ColorShowWidget(QWidget *parent = nullptr);
@@ -143,7 +139,6 @@ protected:
 class ColorPickArea : public ColorPickerWidget
 {
     Q_OBJECT
-    Q_DISABLE_COPY_MOVE(ColorPickArea)
 
 public:
     explicit ColorPickArea(QWidget *parent = nullptr);
@@ -162,7 +157,6 @@ private:
 class AlphaChannelBar : public ColorPickerWidget
 {
     Q_OBJECT
-    Q_DISABLE_COPY_MOVE(AlphaChannelBar)
 
 public:
     AlphaChannelBar(QWidget *parent = nullptr) : ColorPickerWidget(parent) {}
@@ -185,7 +179,6 @@ private:
 class ColorValueBar : public ColorPickerWidget
 {
     Q_OBJECT
-    Q_DISABLE_COPY_MOVE(ColorValueBar)
 
 public:
     ColorValueBar(QWidget *parent = nullptr) : ColorPickerWidget(parent) {}

--- a/src/widgets/ColorPicker.h
+++ b/src/widgets/ColorPicker.h
@@ -99,6 +99,8 @@ namespace ColorPickerHelpers {
 class ColorPickerWidget : public ColorPickWidgetAbstract
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(ColorPickerWidget)
+
 public:
     ColorPickerWidget(QWidget *parent = nullptr);
 
@@ -123,6 +125,8 @@ protected:
 class ColorShowWidget : public ColorPickWidgetAbstract
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(ColorShowWidget)
+
 public:
     explicit ColorShowWidget(QWidget *parent = nullptr);
 
@@ -139,6 +143,8 @@ protected:
 class ColorPickArea : public ColorPickerWidget
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(ColorPickArea)
+
 public:
     explicit ColorPickArea(QWidget *parent = nullptr);
 
@@ -156,6 +162,8 @@ private:
 class AlphaChannelBar : public ColorPickerWidget
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(AlphaChannelBar)
+
 public:
     AlphaChannelBar(QWidget *parent = nullptr) : ColorPickerWidget(parent) {}
 
@@ -177,6 +185,8 @@ private:
 class ColorValueBar : public ColorPickerWidget
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(ColorValueBar)
+
 public:
     ColorValueBar(QWidget *parent = nullptr) : ColorPickerWidget(parent) {}
 

--- a/src/widgets/ColorPicker.h
+++ b/src/widgets/ColorPicker.h
@@ -11,6 +11,8 @@ namespace ColorPickerHelpers {
 class ColorPickWidgetAbstract : public QWidget
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(ColorPickWidgetAbstract)
+
 public:
     ColorPickWidgetAbstract(QWidget *parent = nullptr) : QWidget(parent) {}
     virtual ~ColorPickWidgetAbstract() {}
@@ -37,6 +39,8 @@ class ColorPicker;
 class ColorPicker : public ColorPickerHelpers::ColorPickWidgetAbstract
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(ColorPicker)
+
 public:
     explicit ColorPicker(QWidget *parent = nullptr);
     ~ColorPicker();

--- a/src/widgets/ColorThemeComboBox.h
+++ b/src/widgets/ColorThemeComboBox.h
@@ -9,7 +9,6 @@
 class ColorThemeComboBox : public QComboBox
 {
     Q_OBJECT
-    Q_DISABLE_COPY_MOVE(ColorThemeComboBox)
 
 public:
     explicit ColorThemeComboBox(QWidget *parent = nullptr);

--- a/src/widgets/ColorThemeComboBox.h
+++ b/src/widgets/ColorThemeComboBox.h
@@ -9,6 +9,8 @@
 class ColorThemeComboBox : public QComboBox
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(ColorThemeComboBox)
+
 public:
     explicit ColorThemeComboBox(QWidget *parent = nullptr);
 

--- a/src/widgets/ColorThemeListView.h
+++ b/src/widgets/ColorThemeListView.h
@@ -20,6 +20,8 @@ class ColorSettingsModel;
 class ColorThemeListView : public QListView
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(ColorThemeListView)
+
 public:
     ColorThemeListView(QWidget *parent = nullptr);
     virtual ~ColorThemeListView() override {}
@@ -56,6 +58,8 @@ private:
 class ColorSettingsModel : public QAbstractListModel
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(ColorSettingsModel)
+
 public:
     ColorSettingsModel(QObject *parent = nullptr);
     virtual ~ColorSettingsModel() override {}
@@ -81,6 +85,8 @@ private:
 class ColorOptionDelegate : public QStyledItemDelegate
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(ColorOptionDelegate)
+
 public:
     ColorOptionDelegate(QObject *parent = nullptr);
     ~ColorOptionDelegate() override {}

--- a/src/widgets/ComboQuickFilterView.h
+++ b/src/widgets/ComboQuickFilterView.h
@@ -13,6 +13,7 @@ class ComboQuickFilterView;
 class CUTTER_EXPORT ComboQuickFilterView : public QWidget
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(ComboQuickFilterView)
 
 public:
     explicit ComboQuickFilterView(QWidget *parent = nullptr);

--- a/src/widgets/CommentsWidget.h
+++ b/src/widgets/CommentsWidget.h
@@ -25,6 +25,7 @@ struct CommentGroup
 class CommentsModel : public AddressableItemModel<>
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(CommentsModel)
 
     friend CommentsWidget;
 
@@ -61,6 +62,7 @@ public:
 class CommentsProxyModel : public AddressableFilterProxyModel
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(CommentsProxyModel)
 
 public:
     CommentsProxyModel(CommentsModel *sourceModel, QObject *parent = nullptr);
@@ -73,6 +75,7 @@ protected:
 class CommentsWidget : public ListDockWidget
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(CommentsWidget)
 
 public:
     explicit CommentsWidget(MainWindow *main);

--- a/src/widgets/ConsoleWidget.h
+++ b/src/widgets/ConsoleWidget.h
@@ -22,6 +22,7 @@ class ConsoleWidget;
 class ConsoleWidget : public CutterDockWidget
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(ConsoleWidget)
 
 public:
     explicit ConsoleWidget(MainWindow *main);

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -11,6 +11,7 @@ class MainWindow;
 class CUTTER_EXPORT CutterDockWidget : public QDockWidget
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(CutterDockWidget)
 
 public:
     CUTTER_DEPRECATED("Action will be ignored. Use CutterDockWidget(MainWindow*) instead.")

--- a/src/widgets/CutterGraphView.h
+++ b/src/widgets/CutterGraphView.h
@@ -17,6 +17,8 @@
 class CutterGraphView : public GraphView
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(CutterGraphView)
+
 public:
     CutterGraphView(QWidget *parent);
     virtual bool event(QEvent *event) override;

--- a/src/widgets/CutterTreeView.h
+++ b/src/widgets/CutterTreeView.h
@@ -14,6 +14,7 @@ class CutterTreeView;
 class CUTTER_EXPORT CutterTreeView : public QTreeView
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(CutterTreeView)
 
 public:
     explicit CutterTreeView(QWidget *parent = nullptr);

--- a/src/widgets/CutterTreeWidget.h
+++ b/src/widgets/CutterTreeWidget.h
@@ -10,8 +10,8 @@ class MainWindow;
 
 class CUTTER_EXPORT CutterTreeWidget : public QObject
 {
-
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(CutterTreeWidget)
 
 public:
     explicit CutterTreeWidget(QObject *parent = nullptr);

--- a/src/widgets/SdbWidget.h
+++ b/src/widgets/SdbWidget.h
@@ -15,21 +15,6 @@ class SdbWidget;
 class SdbWidget : public CutterDockWidget
 {
     Q_OBJECT
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
-#    define Q_DISABLE_COPY(SdbWidget)                                                              \
-        SdbWidget(const SdbWidget &s) = delete;                                                    \
-        SdbWidget &operator=(const SdbWidget &s) = delete;
-
-#    define Q_DISABLE_MOVE(SdbWidget)                                                              \
-        SdbWidget(SdbWidget &&s) = delete;                                                         \
-        SdbWidget &operator=(SdbWidget &&s) = delete;
-
-#    define Q_DISABLE_COPY_MOVE(SdbWidget)                                                         \
-        Q_DISABLE_COPY(SdbWidget)                                                                  \
-        Q_DISABLE_MOVE(SdbWidget)
-#endif
-
     Q_DISABLE_COPY_MOVE(SdbWidget)
 
 public:


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This PR applies the Q_DISABLE_COPY_MOVE macro in order to delete the copy and move constructors of some widgets. 

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

No visual or other changes. Just compile and use Cutter normally.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

