### PR TITLE
Various Fixes for Haiku

### DIFF
--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -424,7 +424,9 @@ void ConsoleWidget::processQueuedOutput()
     while (pipeSocket->canReadLine()) {
         QString output = QString(pipeSocket->readLine());
 
-        fprintf(origStderr, "%s", output.toStdString().c_str());
+        if (origStderr) {
+            fprintf(origStderr, "%s", output.toStdString().c_str());
+        }
 
         // Get the last segment that wasn't overwritten by carriage return
         output = output.trimmed();
@@ -449,7 +451,7 @@ void ConsoleWidget::redirectOutput()
 
     pipeSocket = new QLocalSocket(this);
 
-    origStdin = fdopen(dup(fileno(stderr)), "r");
+    origStdin = fdopen(dup(fileno(stdin)), "r");
     origStderr = fdopen(dup(fileno(stderr)), "a");
     origStdout = fdopen(dup(fileno(stdout)), "a");
 #ifdef Q_OS_WIN

--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -25,6 +25,8 @@ VisualNavbar::VisualNavbar(MainWindow *main, QWidget *parent)
 {
     Q_UNUSED(parent);
 
+    blockTooltip = false;
+
     setObjectName("visualNavbar");
     setWindowTitle(tr("Visual navigation bar"));
     //    setMovable(false);
@@ -240,11 +242,17 @@ void VisualNavbar::on_seekChanged(RVA addr)
 
 void VisualNavbar::mousePressEvent(QMouseEvent *event)
 {
+    if (blockTooltip) {
+        return;
+    }
     qreal x = qhelpers::mouseEventPos(event).x();
     RVA address = localXToAddress(x);
     if (address != RVA_INVALID) {
         auto tooltipPos = qhelpers::mouseEventGlobalPos(event);
+        blockTooltip = true; // on Haiku, the below call sometimes triggers another mouseMoveEvent,
+                             // causing infinite recursion
         QToolTip::showText(tooltipPos, toolTipForAddress(address), this, this->rect());
+        blockTooltip = false;
         if (event->buttons() & Qt::LeftButton) {
             event->accept();
             Core()->seek(address);

--- a/src/widgets/VisualNavbar.h
+++ b/src/widgets/VisualNavbar.h
@@ -48,6 +48,7 @@ private:
     unsigned int previousWidth = 0;
 
     QList<XToAddress> xToAddress;
+    bool blockTooltip;
 
     RVA localXToAddress(double x);
     double addressToLocalX(RVA address);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

This prevents the crash from https://github.com/haikuports/haikuports/issues/6215. Maybe there is also a way to actually get redirection working in this case, but I have not figured out the reason for the `B_NOT_ALLOWED` yet.
In any case, `fdopen()` is an operation that may fail in any environment so it should be checked anyway.

The second commit fixes another crash that can happen in combination with Qt's Haiku integration.

**Test plan (required)**

Make sure stdout/stderr redirection still works

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->