### PR TITLE
Fixed issue #2829

### DIFF
--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -297,6 +297,9 @@ void DebugActions::attachRemoteDebugger()
 
 void DebugActions::onAttachedRemoteDebugger(bool successfully)
 {
+    if(remoteDialog == nullptr)
+        return;
+    
     if (!successfully) {
         QMessageBox msgBox;
         msgBox.setText(tr("Error connecting."));

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -297,7 +297,8 @@ void DebugActions::attachRemoteDebugger()
 
 void DebugActions::onAttachedRemoteDebugger(bool successfully)
 {
-    if(remoteDialog == nullptr)
+    // TODO(#2829): Investigate why this is happening
+    if (remoteDialog == nullptr)
         return;
     
     if (!successfully) {


### PR DESCRIPTION
Fixed issue where member `remoteDialog` of class `DebugActions` was null and caused crash after closing remote debugger dialog.