### PR TITLE
Fix jsdec build on windows

### DIFF
--- a/dist/bundle_jsdec.ps1
+++ b/dist/bundle_jsdec.ps1
@@ -7,4 +7,10 @@ if (-not (Test-Path -Path 'jsdec' -PathType Container)) {
 cd jsdec
 & meson.exe --buildtype=release -Dc_args=-DDUK_USE_DATE_NOW_WINDOWS -Djsc_folder="." -Drizin_plugdir=lib\plugins --prefix=$dist --libdir=lib\plugins --datadir=lib\plugins p build
 ninja -C build install
+$ErrorActionPreference = 'Stop'
+$pathdll = "$dist\lib\plugins\core_pdd.dll"
+if(![System.IO.File]::Exists($pathdll)) {
+    type build\meson-logs\meson-log.txt
+    throw (New-Object System.IO.FileNotFoundException("File not found: $pathdll", $pathdll))
+}
 Remove-Item -Recurse -Force $dist\lib\plugins\core_pdd.lib

--- a/dist/bundle_jsdec.ps1
+++ b/dist/bundle_jsdec.ps1
@@ -5,7 +5,7 @@ if (-not (Test-Path -Path 'jsdec' -PathType Container)) {
     git clone https://github.com/rizinorg/jsdec.git --depth 1 --branch v0.3.1
 }
 cd jsdec
-& meson.exe --buildtype=release -Dc_args=-DDUK_USE_DATE_NOW_WINDOWS -Djsc_folder="." -Drizin_plugdir=lib\plugins --prefix=$dist --libdir=lib\plugins --datadir=lib\plugins p build
+& meson.exe --buildtype=release -Dc_args=-DDUK_USE_DATE_NOW_WINDOWS -Djsc_folder=".." -Drizin_plugdir=lib\plugins --prefix=$dist --libdir=lib\plugins --datadir=lib\plugins p build
 ninja -C build install
 $ErrorActionPreference = 'Stop'
 $pathdll = "$dist\lib\plugins\core_pdd.dll"

--- a/dist/bundle_jsdec.ps1
+++ b/dist/bundle_jsdec.ps1
@@ -5,6 +5,6 @@ if (-not (Test-Path -Path 'jsdec' -PathType Container)) {
     git clone https://github.com/rizinorg/jsdec.git --depth 1 --branch v0.3.1
 }
 cd jsdec
-& meson.exe --buildtype=release -Dc_args=-DDUK_USE_DATE_NOW_WINDOWS -Djsc_folder="." -Drizin_plugdir=lib\plugins -prefix=$dist --libdir=lib\plugins --datadir=lib\plugins p build
+& meson.exe --buildtype=release -Dc_args=-DDUK_USE_DATE_NOW_WINDOWS -Djsc_folder="." -Drizin_plugdir=lib\plugins --prefix=$dist --libdir=lib\plugins --datadir=lib\plugins p build
 ninja -C build install
 Remove-Item -Recurse -Force $dist\lib\plugins\core_pdd.lib


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Fixes the following error:
```
usage: meson [-h]
             {setup,configure,dist,install,introspect,init,test,wrap,subprojects,help,rewrite,compile,devenv}
             ...
meson: error: unrecognized arguments: -prefix=$dist
ninja: fatal: chdir to 'build' - No such file or directory
ninja: Entering directory `build'
Remove-Item : Cannot find path 'D:\a\cutter\cutter\build\_CPack_Packages\win64\ZIP\cutter-git-2021-11-17-8bab611c7fae0c
45bc98098bb196f400e4caeec7-x64.Windows\lib\plugins\core_pdd.lib' because it does not exist.
At D:\a\cutter\cutter\dist\bundle_jsdec.ps1:10 char:1
+ Remove-Item -Recurse -Force $dist\lib\plugins\core_pdd.lib
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (D:\a\cutter\cut...ns\core_pdd.lib:String) [Remove-Item], ItemNotFoundEx 
   ception
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.RemoveItemCommand
```