### PR TITLE
Hexeditor: add option to write hex bytes

### DIFF
--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -754,19 +754,20 @@ void HexWidget::w_writeBytes()
     const int offset = bytes.startsWith("\\x") ? 2 : 0;
     const int incr = offset + 2;
     const int bytes_size = qMin(bytes.size() / incr, size);
-    if (ok && bytes_size) {
-        uint8_t *buf = (uint8_t *)malloc(static_cast<size_t>(bytes_size));
-        if (!buf) {
-            return;
-        }
-        for (int i = 0, j = 0, sz = bytes.size(); i < sz; i += incr, j++) {
-            buf[j] = static_cast<uint8_t>(bytes.mid(i + offset, 2).toInt(nullptr, 16));
-        }
-        RzCoreLocked core(Core());
-        rz_core_write_at(core, getLocationAddress(), buf, bytes_size);
-        free(buf);
-        refresh();
+    if (!ok || !bytes_size) {
+        return;
     }
+    uint8_t *buf = (uint8_t *)malloc(static_cast<size_t>(bytes_size));
+    if (!buf) {
+        return;
+    }
+    for (int i = 0, j = 0, sz = bytes.size(); i < sz; i += incr, j++) {
+        buf[j] = static_cast<uint8_t>(bytes.mid(i + offset, 2).toInt(nullptr, 16));
+    }
+    RzCoreLocked core(Core());
+    rz_core_write_at(core, getLocationAddress(), buf, bytes_size);
+    free(buf);
+    refresh();
 }
 
 void HexWidget::w_writeZeros()

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -315,6 +315,7 @@ private slots:
     // Write command slots
     void w_writeString();
     void w_increaseDecrease();
+	void w_writeBytes();
     void w_writeZeros();
     void w_write64();
     void w_writeRandom();


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**
Target widget for this feature: Hexdump. The purpose of this feature is to give user the ability to enter a string of hexadecimal bytes (using Hex Editors RMB context menu) in the form of either 'ff00fccdcd' or '\xff\x00\xfc\xcd\xcd' and that would be exactly what gets written. Although this seems to be quite a common operation, currently there is no way of doing this without using the console. Basically we just parse the string to select the pairs of chars, then convert them to integers with radix 16 and write to the selected location.

**Test plan (required)**
Try entering any number of hexadecimal bytes using RMB->Edit->Write Hex Bytes in Hexdump.
![hexedit_demo](https://user-images.githubusercontent.com/41104158/144399646-7a0f03c1-e158-44e0-a166-5e8197921c33.png)
The amount of bytes written respects the selected region (if any selection is performed). Any bytes past selection won't be overwritten.
In case, when bytes string is entered in the form of '\x00\x00', this is detected by checking only the first two bytes, so any mistakes in the input won't be corrected.
Incorrect input will result in zeros being written.
If the odd number of nibbles is entered, the last one will be ignored. 

