### PR TITLE
Move more common disassembly-previewing functionality to namaspace

### DIFF
--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -35,9 +35,6 @@ QString DisassemblyPreview::getToolTipStyleSheet()
 bool DisassemblyPreview::showDisasPreview(QWidget *parent, const QPoint &pointOfEvent,
                                           const RVA offsetFrom)
 {
-    QProcessEnvironment env;
-    QPoint point = pointOfEvent;
-
     QList<XrefDescription> refs = Core()->getXRefs(offsetFrom, false, false);
     if (refs.length()) {
         if (refs.length() > 1) {
@@ -75,10 +72,20 @@ bool DisassemblyPreview::showDisasPreview(QWidget *parent, const QPoint &pointOf
                                 .arg(qMax(8, fnt.pointSize() - 1))
                                 .arg(disasmPreview.join("<br>"));
 
-                QToolTip::showText(point, tooltip, parent, QRect {}, 3500);
+                QToolTip::showText(pointOfEvent, tooltip, parent, QRect {}, 3500);
                 return true;
             }
         }
     }
     return false;
+}
+
+RVA DisassemblyPreview::readDisassemblyOffset(QTextCursor tc)
+{
+    auto userData = getUserData(tc.block());
+    if (!userData) {
+        return RVA_INVALID;
+    }
+
+    return userData->line.offset;
 }

--- a/src/common/DisassemblyPreview.h
+++ b/src/common/DisassemblyPreview.h
@@ -31,8 +31,15 @@ QString getToolTipStyleSheet();
 
 /*!
  * @brief Show a QToolTip that previews the disassembly that is pointed to
+ * It works for GraphWidget and DisassemblyWidget
  * @return True if the tooltip is shown
  */
 bool showDisasPreview(QWidget *parent, const QPoint &pointOfEvent, const RVA offsetFrom);
+
+/*!
+ * @brief Reads the offset for the cursor position
+ * @return The disassembly offset of the hovered asm text
+ */
+RVA readDisassemblyOffset(QTextCursor tc);
 }
 #endif

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -997,13 +997,3 @@ bool DisassemblerGraphView::Instr::contains(ut64 addr) const
 {
     return this->addr <= addr && (addr - this->addr) < size;
 }
-
-RVA DisassemblerGraphView::readDisassemblyOffset(QTextCursor tc)
-{
-    auto userData = getUserData(tc.block());
-    if (!userData) {
-        return RVA_INVALID;
-    }
-
-    return userData->line.offset;
-}

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -178,7 +178,6 @@ private:
     DisassemblyBlock *blockForAddress(RVA addr);
     void seekLocal(RVA addr, bool update_viewport = true);
     void seekInstruction(bool previous_instr);
-    RVA readDisassemblyOffset(QTextCursor tc);
 
     CutterSeekable *seekable = nullptr;
     QList<QShortcut *> shortcuts;

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -83,7 +83,6 @@ private:
     RefreshDeferrer *disasmRefresh;
 
     RVA readCurrentDisassemblyOffset();
-    RVA readDisassemblyOffset(QTextCursor tc);
     bool eventFilter(QObject *obj, QEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
     QString getWindowTitle() const override;

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -2,6 +2,7 @@
 #include "ui_ListDockWidget.h"
 
 #include "core/MainWindow.h"
+#include "common/DisassemblyPreview.h"
 #include "common/Helpers.h"
 #include "common/FunctionsTask.h"
 #include "common/TempConfig.h"
@@ -635,10 +636,5 @@ void FunctionsWidget::onActionVerticalToggled(bool enable)
  */
 void FunctionsWidget::setTooltipStylesheet()
 {
-    setStyleSheet(QString("QToolTip { border-width: 1px; max-width: %1px;"
-                          "opacity: 230; background-color: %2;"
-                          "color: %3; border-color: %3;}")
-                          .arg(kMaxTooltipWidth)
-                          .arg(Config()->getColor("gui.tooltip.background").name())
-                          .arg(Config()->getColor("gui.tooltip.foreground").name()));
+    setStyleSheet(DisassemblyPreview::getToolTipStyleSheet());
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

In various spot inside the codebase there were functions about disassembly preview that were duplicated. Now they are inside the `DisassemblyPreview` namespace and defined only once.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

Compile and run Cutter like usual.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
