### PR TITLE
Fix pdj call in nextOpAddr for disasm scrolling

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -991,7 +991,7 @@ RVA CutterCore::nextOpAddr(RVA startAddr, int count)
     CORE_LOCK();
 
     QJsonArray array =
-            Core()->cmdj("pdj " + QString::number(count + 1) + "@" + QString::number(startAddr))
+            Core()->cmdj("pdj " + QString::number(count + 1) + " @ " + QString::number(startAddr))
                     .array();
     if (array.isEmpty()) {
         return startAddr + 1;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Converting this to API unfortunately is not easily possible since there is a lot involved in the disasm process that isn't exposed at all.

**Test plan (required)**

Scroll down in the disasm widget. You should not see any errors in the console.