### PR TITLE
Fix crash on Windows when starting from a console

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -22,14 +22,19 @@ static void connectToConsole()
         return;
     }
 
-    // Avoid reconfiguring stderr/stdout if one of them is already connected to a stream.
+    // Avoid reconfiguring stdin/stderr/stdout if one of them is already connected to a stream.
     // This can happen when running with stdout/stderr redirected to a file.
-    if (0 > fileno(stdout)) {
-        // Overwrite FD 1 and 2 for the benefit of any code that uses the FDs
+	if (0 > fileno(stdin)) {
+        // Overwrite FD 0, FD 1 and 2 for the benefit of any code that uses the FDs
         // directly.  This is safe because the CRT allocates FDs 0, 1 and
         // 2 at startup even if they don't have valid underlying Windows
         // handles.  This means we won't be overwriting an FD created by
         // _open() after startup.
+        _close(0);
+
+        freopen("CONIN$", "r+", stdin);
+    }
+    if (0 > fileno(stdout)) {
         _close(1);
 
         if (freopen("CONOUT$", "a+", stdout)) {

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -24,7 +24,7 @@ static void connectToConsole()
 
     // Avoid reconfiguring stdin/stderr/stdout if one of them is already connected to a stream.
     // This can happen when running with stdout/stderr redirected to a file.
-	if (0 > fileno(stdin)) {
+    if (0 > fileno(stdin)) {
         // Overwrite FD 0, FD 1 and 2 for the benefit of any code that uses the FDs
         // directly.  This is safe because the CRT allocates FDs 0, 1 and
         // 2 at startup even if they don't have valid underlying Windows


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
See https://github.com/rizinorg/cutter/issues/2877#issuecomment-1020275956

> You crash here https://github.com/rizinorg/cutter/blob/91d99ba2190f4796da268be376d9f06e3c7f31bc/src/widgets/ConsoleWidget.cpp#L454
> Because `fileno(stdin)` is `-2` as cutter is built with `/SUBSYSTEM:WINDOWS` and hasn't set `stdin` to anything after calling `AttachConsole`. Honestly, you should be able to redirect them even when cutter is not attached to a console by just setting them to `NUL` or something else appropriate if you want the `fdopen` for saving the orig handles to not fail, or even just acknowledge that there are no original handles.
>
> And of course, any such stdio init should be done before anything that grabs/uses stdio itself, such as Python init, or rizin itself.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->
Manually started cutter on Windows from a console, it doesn't crash after the change.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->
(This is so small, that I haven't bothered, but let me know if needed)

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
Closes #2877
