### PR TITLE
Fix missing dll in windows build

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -70,6 +70,7 @@ jobs:
         brew install pkg-config
     - name: py dependencies
       run: |
+        python3 -m pip install -U pip==21.3.1
         pip install meson
     - name: Prepare package id
       shell: bash

--- a/cmake/BundledRizin.cmake
+++ b/cmake/BundledRizin.cmake
@@ -48,7 +48,8 @@ endif()
 
 set (RZ_LIBS rz_core rz_config rz_cons rz_io rz_util rz_flag rz_asm rz_debug
         rz_hash rz_bin rz_lang rz_il rz_analysis rz_parse rz_bp rz_egg rz_reg
-        rz_search rz_syscall rz_socket rz_magic rz_crypto rz_type rz_diff rz_sign)
+        rz_search rz_syscall rz_socket rz_magic rz_crypto rz_type rz_diff rz_sign
+        rz_demangler)
 set (RZ_EXTRA_LIBS rz_main)
 set (RZ_BIN rz-agent rz-bin rizin rz-diff rz-find rz-gg rz-hash rz-run rz-asm rz-ax)
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

rz_demangler.dll wasn't included in the ZIP file that CUTTER_ENABLE_PACKAGING creates.

**Test plan (required)**

Check that the Windows CI artifact has rz_demangler.dll and that it doesn't crash on startup due to missing dependencies.
