### PR TITLE
Remove additional 0x prefix in the registers widget

### DIFF
--- a/src/widgets/RegistersWidget.cpp
+++ b/src/widgets/RegistersWidget.cpp
@@ -51,7 +51,7 @@ void RegistersWidget::setRegisterGrid()
 
     registerLen = registerRefs.size();
     for (auto &reg : registerRefs) {
-        regValue = "0x" + reg.value;
+        regValue = reg.value;
         // check if we already filled this grid space with label/value
         if (!registerLayout->itemAtPosition(i, col)) {
             registerLabel = new QLabel;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

The `value` field in `drj`(which is used by [CutterCore::getRegisterValues](https://github.com/rizinorg/cutter/blob/dev/src/core/Cutter.cpp#L1778)) is now prefixed with `0x` so it's no longer necessary to add it for display in [RegistersWidget::setRegisterGrid](https://github.com/rizinorg/cutter/blob/dev/src/widgets/RegistersWidget.cpp#L43).

**Test plan (required)**

See that the registers widget shows valid addresses that can be shown in the disassembly window by right clicking on the value and selecting "Show in->Disassembly"

