### PR TITLE
Remove unused stats query

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -2653,32 +2653,6 @@ QList<MemoryMapDescription> CutterCore::getMemoryMap()
     return ret;
 }
 
-QStringList CutterCore::getStats()
-{
-    QStringList stats;
-    cmdRaw("fs functions");
-
-    // The cmd coomand is frequently used in this function because
-    // cmdRaw would not work with grep
-    stats << cmd("f~?").trimmed();
-
-    QString imps = cmd("ii~?").trimmed();
-    stats << imps;
-
-    cmdRaw("fs symbols");
-    stats << cmd("f~?").trimmed();
-    cmdRaw("fs strings");
-    stats << cmd("f~?").trimmed();
-    cmdRaw("fs relocs");
-    stats << cmd("f~?").trimmed();
-    cmdRaw("fs sections");
-    stats << cmd("f~?").trimmed();
-    cmdRaw("fs *");
-    stats << cmd("f~?").trimmed();
-
-    return stats;
-}
-
 void CutterCore::setGraphEmpty(bool empty)
 {
     emptyGraph = empty;

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -559,7 +559,6 @@ public:
     CutterJson getFileInfo();
     CutterJson getSignatureInfo();
     CutterJson getFileVersionInfo();
-    QStringList getStats();
     void setGraphEmpty(bool empty);
     bool isGraphEmpty();
 

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -151,9 +151,6 @@ void Dashboard::updateContents()
     QSpacerItem *spacer = new QSpacerItem(1, 1, QSizePolicy::Fixed, QSizePolicy::Expanding);
     ui->verticalLayout_2->addSpacerItem(spacer);
 
-    // Get stats for the graphs
-    QStringList stats = Core()->getStats();
-
     // Check if signature info and version info available
     if (!Core()->getSignatureInfo().size()) {
         ui->certificateButton->setEnabled(false);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

The views showing this info have been removed in the past, so it was
unused. This also fixes some errors with latest rizin where
zero-argument f does not exist anymore (it's now fl).
