### PR TITLE
Replace wcj and oj commands by API

### DIFF
--- a/src/common/IOModesController.cpp
+++ b/src/common/IOModesController.cpp
@@ -77,16 +77,12 @@ bool IOModesController::prepareForWriting()
 
 bool IOModesController::allChangesComitted()
 {
-    // Get a list of available write changes
-    CutterJson changes = Core()->cmdj("wcj");
-
-    // Check if there is a change which isn't written to the file
-    for (CutterJson changeObject : changes) {
-        if (!changeObject["written"].toBool()) {
+    RzCoreLocked core(Core());
+    for (auto c : CutterPVector<RzIOCache>(&core->io->cache)) {
+        if (!c->written) {
             return false;
         }
     }
-
     return true;
 }
 

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -4068,12 +4068,18 @@ void CutterCore::setWriteMode(bool enabled)
 
 bool CutterCore::isWriteModeEnabled()
 {
-    for (CutterJson v : cmdj("oj")) {
-        if (v["raised"].toBool()) {
-            return v["writable"].toBool();
+    CORE_LOCK();
+    RzListIter *it;
+    RzCoreFile *cf;
+    CutterRzListForeach (core->files, it, RzCoreFile, cf) {
+        RzIODesc *desc = rz_io_desc_get(core->io, cf->fd);
+        if (!desc) {
+            continue;
+        }
+        if (desc->perm & RZ_PERM_W) {
+            return true;
         }
     }
-
     return false;
 }
 

--- a/src/core/CutterCommon.h
+++ b/src/core/CutterCommon.h
@@ -25,6 +25,32 @@
              (char *)it != (char *)(vec)->a + ((vec)->len * (vec)->elem_size);                     \
              it = (type *)((char *)it + (vec)->elem_size))
 
+template<typename T> class CutterPVector
+{
+private:
+    const RzPVector * const vec;
+
+public:
+    class iterator : public std::iterator<std::input_iterator_tag, T *>
+    {
+    private:
+        T **p;
+
+    public:
+        iterator(T **p) : p(p) {}
+        iterator(const iterator &o) : p(o.p) {}
+        iterator &operator++() { p++; return *this; }
+        iterator operator++(int) { iterator tmp(*this); operator++(); return tmp; }
+        bool operator==(const iterator &rhs) const {return p == rhs.p;}
+        bool operator!=(const iterator &rhs) const {return p != rhs.p;}
+        T *operator*() { return *p; }
+    };
+
+    CutterPVector(const RzPVector *vec) : vec(vec) {}
+    iterator begin() const { return iterator(reinterpret_cast<T **>(vec->v.a)); }
+    iterator end() const { return iterator(reinterpret_cast<T **>(vec->v.a) + vec->v.len); }
+};
+
 // Global information for Cutter
 #define APPNAME "Cutter"
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

These commands have had changes in the current rizin dev, so now is a good time to remove their usages from here.

Partially addresses #2666