### PR TITLE
Fix compilation with KF 5.92

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -7,9 +7,9 @@
 #include <QApplication>
 
 #ifdef CUTTER_ENABLE_KSYNTAXHIGHLIGHTING
-#    include <KSyntaxHighlighting/repository.h>
-#    include <KSyntaxHighlighting/theme.h>
-#    include <KSyntaxHighlighting/definition.h>
+#    include <KSyntaxHighlighting/Repository>
+#    include <KSyntaxHighlighting/Theme>
+#    include <KSyntaxHighlighting/Definition>
 #endif
 
 #include "common/ColorThemeWorker.h"

--- a/src/common/SyntaxHighlighter.cpp
+++ b/src/common/SyntaxHighlighter.cpp
@@ -5,7 +5,7 @@
 
 #    include "Configuration.h"
 
-#    include <KSyntaxHighlighting/theme.h>
+#    include <KSyntaxHighlighting/Theme>
 
 SyntaxHighlighter::SyntaxHighlighter(QTextDocument *document)
     : KSyntaxHighlighting::SyntaxHighlighter(document)

--- a/src/common/SyntaxHighlighter.h
+++ b/src/common/SyntaxHighlighter.h
@@ -10,7 +10,7 @@
 
 #ifdef CUTTER_ENABLE_KSYNTAXHIGHLIGHTING
 
-#    include <KSyntaxHighlighting/syntaxhighlighter.h>
+#    include <KSyntaxHighlighting/SyntaxHighlighter>
 
 class SyntaxHighlighter : public KSyntaxHighlighting::SyntaxHighlighter
 {


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

With KF5.92 headers `KSyntaxHighlighting/{header}.h` copied to `KSyntaxHighlighting/ksyntaxhighlighting/{header}.h`. Headers `KSyntaxHighlighting/{Header}`  now include `ksyntaxhighlighting/{header}.h` instead of `{header}.h`. Than on some distros like ArchLinux headers `KSyntaxHighlighting/{header}.h` removed, because it copies of `KSyntaxHighlighting/ksyntaxhighlighting/{header}.h` and because `KSyntaxHighlighting/{Header}` now include `ksyntaxhighlighting/{header}.h`.

Without `KSyntaxHighlighting/{header}.h` compilation of cutter is failed.

This PR replaces headers `KSyntaxHighlighting/{header}.h` to `KSyntaxHighlighting/{Header}`. E.g. `KSyntaxHighlighting/syntaxhighlighter.h` replaced to `KSyntaxHighlighting/SyntaxHighlighter`

**Test plan (required)**

- Install KSyntaxHighlighting from tag KF5.92
- Remove headers `KSyntaxHighlighting/{header}.h` (or just use package from ArchLinux)
- Try to compile cutter with KSyntaxHighlighting
- 