### PR TITLE
‘memDisp’ may be used uninitialized

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -489,7 +489,7 @@ void DisassemblyContextMenu::aboutToShowSlot()
 
     // Create structure offset menu if it makes sense
     QString memBaseReg; // Base register
-    st64 memDisp; // Displacement
+    st64 memDisp = 0; // Displacement
 
     // Loop through both the operands of the instruction
     for (const CutterJson operand : instObject["opex"]["operands"]) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

resolves the following warning
```
cutter/src/menus/DisassemblyContextMenu.cpp: In member function ‘void DisassemblyContextMenu::aboutToShowSlot()’:
cutter/src/menus/DisassemblyContextMenu.cpp:515:68: warning: ‘memDisp’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  515 |         QStringList ret = Core()->cmdList("ahts " + QString::number(memDisp));
      |                                                     ~~~~~~~~~~~~~~~^~~~~~~~~
```