### PR TITLE
Created adding comments option inside Hexdump.

### DIFF
--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -634,6 +634,16 @@ void HexWidget::contextMenuEvent(QContextMenuEvent *event)
         actionCopyAddress->setDisabled(disable);
     };
 
+    QString comment = Core()->getCommentAt(cursor.address);
+
+    if (comment.isNull() || comment.isEmpty()) {
+        actionDeleteComment->setVisible(false);
+        actionComment->setText(tr("Add Comment"));
+    } else {
+        actionDeleteComment->setVisible(true);
+        actionComment->setText(tr("Edit Comment"));
+    }
+
     QMenu *menu = new QMenu();
     QMenu *sizeMenu = menu->addMenu(tr("Item size:"));
     sizeMenu->addActions(actionsItemSize);

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -2,6 +2,7 @@
 #include "Cutter.h"
 #include "Configuration.h"
 #include "dialogs/WriteCommandsDialogs.h"
+#include "dialogs/CommentsDialog.h"
 
 #include <QPainter>
 #include <QPaintEvent>
@@ -119,6 +120,19 @@ HexWidget::HexWidget(QWidget *parent)
     actionCopyAddress->setShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_C);
     connect(actionCopyAddress, &QAction::triggered, this, &HexWidget::copyAddress);
     addAction(actionCopyAddress);
+
+    // Add comment option
+    actionComment = new QAction(tr("Add Comment"), this);
+    actionComment->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+    actionComment->setShortcut(Qt::Key_Semicolon);
+    connect(actionComment, &QAction::triggered, this, &HexWidget::on_actionAddComment_triggered);
+    addAction(actionComment);
+
+    // delete comment option
+    actionDeleteComment = new QAction(tr("Delete Comment"), this);
+    actionDeleteComment->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+    connect(actionDeleteComment, &QAction::triggered, this, &HexWidget::on_actionDeleteComment_triggered);
+    addAction(actionDeleteComment);
 
     actionSelectRange = new QAction(tr("Select range"), this);
     connect(actionSelectRange, &QAction::triggered, this,
@@ -687,6 +701,20 @@ void HexWidget::copyAddress()
     }
     QClipboard *clipboard = QApplication::clipboard();
     clipboard->setText(RzAddressString(addr));
+}
+
+//slot for add comment action
+void HexWidget::on_actionAddComment_triggered()
+{
+    uint64_t addr = cursor.address;
+    CommentsDialog::addOrEditComment(addr, this);
+}
+
+//slot for deleting comment action
+void HexWidget::on_actionDeleteComment_triggered()
+{
+    uint64_t addr = cursor.address;
+    Core()->delComment(addr);
 }
 
 void HexWidget::onRangeDialogAccepted()

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -311,6 +311,8 @@ private slots:
     void copy();
     void copyAddress();
     void onRangeDialogAccepted();
+    void on_actionAddComment_triggered();
+    void on_actionDeleteComment_triggered();
 
     // Write command slots
     void w_writeString();
@@ -475,6 +477,9 @@ private:
     QAction *actionHexPairs;
     QAction *actionCopy;
     QAction *actionCopyAddress;
+    QAction *actionComment;
+    QAction *actionDeleteComment;
+    QAction *actionSetFlag;
     QAction *actionSelectRange;
     QList<QAction *> actionsWriteString;
     QList<QAction *> actionsWriteOther;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
This pull request adds the feature of adding comments for certain addresses inside the Hexdump widget. The implementation is nearly the same as adding comments in disassembly window. The pull request solves this issue #1070 as now adding, editing, and deleting comments in Hexdump menu is available. 

**Implementation:**
1 - Added (actionComment) action to the context menu.
`actionComment = new QAction(tr("Add Comment"), this);`
2 - Added (actionDeleteComment) action to context menu.
`actionDeleteComment = new QAction(tr("Delete Comment"), this); `
3 - Connected the created actions to the slots

`
connect(actionComment, &QAction::triggered, this, &HexWidget::on_actionAddComment_triggered);
`
`
connect(actionDeleteComment, &QAction::triggered, this, &HexWidget::on_actionDeleteComment_triggered);
`

4 - Used the same called and implemented functions in disassembly context menu inside the created slots.
5 - Check every time right click is done on the same part where comment is made to see whether there is a comment or not:
-if there is a comment then hide ("Add comment") and display ("Edit comment") and ("delete comment") instead.
This is implemeted through adding the following code inside (contextMenuEvent) function inside "HexWidget.cpp")

```
QString comment = Core()->getCommentAt(cursor.address);
    if (comment.isNull() || comment.isEmpty()) {
        actionDeleteComment->setVisible(false);
        actionComment->setText(tr("Add Comment"));
    } else {
        actionDeleteComment->setVisible(true);
        actionComment->setText(tr("Edit Comment"));
    }
```

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->
I uploaded the video on drive:
https://drive.google.com/file/d/1xwL1g-4_yPxsDztIfiGd2HmfacFSQuji/view?usp=sharing


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #1070
