### PR TITLE
Search button disabled and button text changed while search is occurring

### DIFF
--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -195,14 +195,18 @@ SearchWidget::SearchWidget(MainWindow *main) : CutterDockWidget(main), ui(new Ui
 
     QShortcut *enter_press = new QShortcut(QKeySequence(Qt::Key_Return), this);
     connect(enter_press, &QShortcut::activated, this, [this]() {
+        disableSearch();
         refreshSearch();
         checkSearchResultEmpty();
+        enableSearch();
     });
     enter_press->setContext(Qt::WidgetWithChildrenShortcut);
 
     connect(ui->searchButton, &QAbstractButton::clicked, this, [this]() {
+        disableSearch();
         refreshSearch();
         checkSearchResultEmpty();
+        enableSearch();
     });
 
     connect(ui->searchspaceCombo,
@@ -309,4 +313,17 @@ void SearchWidget::updatePlaceholderText(int index)
     default:
         ui->filterLineEdit->setPlaceholderText("jmp rax");
     }
+}
+
+void SearchWidget::disableSearch()
+{
+    ui->searchButton->setEnabled(false);
+    ui->searchButton->setText("Searching...");
+    qApp->processEvents();
+}
+
+void SearchWidget::enableSearch()
+{
+    ui->searchButton->setEnabled(true);
+    ui->searchButton->setText("Search");
 }

--- a/src/widgets/SearchWidget.h
+++ b/src/widgets/SearchWidget.h
@@ -77,6 +77,8 @@ private:
 
     void refreshSearch();
     void checkSearchResultEmpty();
+    void enableSearch();
+    void disableSearch();
     void setScrollMode();
     void updatePlaceholderText(int index);
 };


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
Contributes to issue #2161 
This implements the suggestion posed by @ITAYC0HEN. When a search is initiated, the button text is changed to "Searching..." and the button is disabled. Once the search is complete, the button returns to normal. To this end, two functions, enableSearch() and disableSearch() are implemented. The UI is also manually updated via a call to qApp->processEvents().
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**
The search function should work similarly to how it worked before, but while a search is being conducted, the button will be disabled and the text will be replaced with "Searching...". Once the search is completed, it should return to normal.
<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**
closes #2161 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
