### PR TITLE
Solved the bug of missing NX and PIC bits in Dashboard.

### DIFF
--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -64,28 +64,27 @@ void Dashboard::updateContents()
 
     setPlainText(this->ui->baddrEdit, RzAddressString(item2["baddr"].toRVA()));
 
-    // set booleans
-    //remove to use API directly
-//    setBool(this->ui->vaEdit, item2, "va");
-//    setBool(this->ui->canaryEdit, item2, "canary");
-//    setBool(this->ui->cryptoEdit, item2, "crypto");
-//    setBool(this->ui->nxEdit, item, "nx");
-//    setBool(this->ui->picEdit, item, "pic");
-    setBool(this->ui->staticEdit, item2, "static");
-    setBool(this->ui->strippedEdit, item2, "stripped");
-    setBool(this->ui->relocsEdit, item2, "relocs");
-
     // Add file hashes, analysis info and libraries
     RzCoreLocked core(Core());
 
-    // using API directly to get NX and PIC/PIE
+    // using API directly to get boolean values in dashboard
     RzBinInfo *binInfo = rz_bin_get_info(core->bin);
+
+    //setting boolean values
+    setBoolvalues(binInfo);
+
+    //setting the value of "static"
+    int static_value = rz_bin_is_static(core->bin);
+    setPlainText(ui->staticEdit, tr(intToText(static_value)));
+
+    //setting the value of relocs and stripped
+    bool relocs_value = RZ_BIN_DBG_RELOCS & binInfo->dbg_info;
+    bool stripped_value = RZ_BIN_DBG_STRIPPED & binInfo->dbg_info;
+    setPlainText(this->ui->strippedEdit, intToText(stripped_value));
+    setPlainText(this->ui->relocsEdit, intToText(relocs_value));
 
     RzBinFile *bf = rz_bin_cur(core->bin);
     RzList *hashes = rz_bin_file_compute_hashes(core->bin, bf, UT64_MAX);
-
-    //setting nx and PIC text
-    setNxPIC(binInfo);
 
 
     // Delete hashesWidget if it isn't null to avoid duplicate components
@@ -249,11 +248,11 @@ void Dashboard::setBool(QLineEdit *textBox, const CutterJson &jsonObject, const 
 }
 
 /**
- * @brief Set NX bit and PIC bit text according to parsed value from API
+ * @brief Setting boolean values text according to parsed value from API
  * @param RzBinInfo
  */
 
-void Dashboard::setNxPIC(RzBinInfo *binInfo)
+void Dashboard::setBoolvalues(RzBinInfo *binInfo)
 {
     int nx = binInfo->has_nx;
     int pic = binInfo->has_pi;

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -21,7 +21,6 @@
 #include <QDialog>
 #include <QTreeWidget>
 
-
 Dashboard::Dashboard(MainWindow *main) : CutterDockWidget(main), ui(new Ui::Dashboard)
 {
     ui->setupUi(this);

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -20,10 +20,6 @@
 #include <QMessageBox>
 #include <QDialog>
 #include <QTreeWidget>
-#include <string>
-#include <string.h>
-#include <cstring>
-
 
 
 Dashboard::Dashboard(MainWindow *main) : CutterDockWidget(main), ui(new Ui::Dashboard)

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -65,10 +65,10 @@ void Dashboard::updateContents()
     setPlainText(this->ui->baddrEdit, RzAddressString(item2["baddr"].toRVA()));
 
     // set booleans
-    setBool(this->ui->vaEdit, item2, "va");
-    setBool(this->ui->canaryEdit, item2, "canary");
-    setBool(this->ui->cryptoEdit, item2, "crypto");
     //remove to use API directly
+//    setBool(this->ui->vaEdit, item2, "va");
+//    setBool(this->ui->canaryEdit, item2, "canary");
+//    setBool(this->ui->cryptoEdit, item2, "crypto");
 //    setBool(this->ui->nxEdit, item, "nx");
 //    setBool(this->ui->picEdit, item, "pic");
     setBool(this->ui->staticEdit, item2, "static");
@@ -255,9 +255,16 @@ void Dashboard::setBool(QLineEdit *textBox, const CutterJson &jsonObject, const 
 
 void Dashboard::setNxPIC(RzBinInfo *binInfo)
 {
-    //setting text
     int nx = binInfo->has_nx;
     int pic = binInfo->has_pi;
+    int va = binInfo->has_va;
+    int canary = binInfo->has_canary;
+    int crypto = binInfo->has_crypto;
+
+    //setting text
+    setPlainText(ui->vaEdit, tr(intToText(va)));
+    setPlainText(ui->canaryEdit, tr(intToText(canary)));
+    setPlainText(ui->cryptoEdit, tr(intToText(crypto)));
     setPlainText(ui->nxEdit, tr(intToText(nx)));
     setPlainText(ui->picEdit, tr(intToText(pic)));
 }

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -266,8 +266,8 @@ void Dashboard::setBoolvalues(RzBinInfo *binInfo)
     // Setting the value of "relocs" and "stripped"
     bool relocs_value = RZ_BIN_DBG_RELOCS & binInfo->dbg_info;
     bool stripped_value = RZ_BIN_DBG_STRIPPED & binInfo->dbg_info;
-    setPlainText(this->ui->strippedEdit, intToText(stripped_value));
-    setPlainText(this->ui->relocsEdit, intToText(relocs_value));
+    setPlainText(this->ui->strippedEdit,QVariant(stripped_value).toString());
+    setPlainText(this->ui->relocsEdit,QVariant(relocs_value).toString());
 }
 
 /**

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -52,23 +52,23 @@ void Dashboard::updateContents()
     RzBinFile *bf = rz_bin_cur(core->bin);
     RzBinInfo *binInfo = rz_bin_get_info(core->bin);
 
-    setPlainText(this->ui->fileEdit, binInfo->file);
-    setPlainText(this->ui->formatEdit, binInfo->rclass);
-    setPlainText(this->ui->typeEdit, binInfo->type);
-    setPlainText(this->ui->archEdit, binInfo->arch);
-    setPlainText(this->ui->langEdit, binInfo->lang);
-    setPlainText(this->ui->classEdit, binInfo->bclass);
-    setPlainText(this->ui->machineEdit, binInfo->machine);
-    setPlainText(this->ui->osEdit, binInfo->os);
-    setPlainText(this->ui->subsysEdit, binInfo->subsystem);
-    setPlainText(this->ui->compilerEdit, binInfo->compiler);
-    setPlainText(this->ui->bitsEdit, QString::number(binInfo->bits));
-    setPlainText(this->ui->baddrEdit, RzAddressString(rz_bin_file_get_baddr(bf)));
-    setPlainText(this->ui->sizeEdit, qhelpers::formatBytecount(bf->size));
-    setPlainText(this->ui->fdEdit, QString::number(bf->fd));
+    setPlainText(ui->fileEdit, binInfo ? binInfo->file : "");
+    setPlainText(ui->formatEdit, binInfo ? binInfo->rclass : "");
+    setPlainText(ui->typeEdit, binInfo ? binInfo->type : "");
+    setPlainText(ui->archEdit, binInfo ? binInfo->arch : "");
+    setPlainText(ui->langEdit, binInfo ? binInfo->lang : "");
+    setPlainText(ui->classEdit, binInfo ? binInfo->bclass : "");
+    setPlainText(ui->machineEdit, binInfo ? binInfo->machine : "");
+    setPlainText(ui->osEdit, binInfo ? binInfo->os : "");
+    setPlainText(ui->subsysEdit, binInfo ? binInfo->subsystem : "");
+    setPlainText(ui->compilerEdit, binInfo ? binInfo->compiler : "");
+    setPlainText(ui->bitsEdit, binInfo ? QString::number(binInfo->bits) : "");
+    setPlainText(ui->baddrEdit, binInfo ? RzAddressString(rz_bin_file_get_baddr(bf)) : "");
+    setPlainText(ui->sizeEdit, binInfo ? qhelpers::formatBytecount(bf->size) : "");
+    setPlainText(ui->fdEdit, binInfo ? QString::number(bf->fd) : "");
 
     // Setting the value of "Endianness"
-    const char *endian = binInfo->big_endian ? "BE" : "LE";
+    const char *endian = binInfo ? (binInfo->big_endian ? "BE" : "LE") : "";
     setPlainText(this->ui->endianEdit, endian);
 
     // Setting boolean values
@@ -223,47 +223,19 @@ void Dashboard::setPlainText(QLineEdit *textBox, const QString &text)
 }
 
 /**
- * @brief Set the text of a QLineEdit as True, False or N/A if it does not exist
- * @param textBox
- * @param isTrue
- */
-void Dashboard::setBool(QLineEdit *textBox, const CutterJson &jsonObject, const char *key)
-{
-    if (jsonObject[key].valid()) {
-        if (jsonObject[key].toBool()) {
-            setPlainText(textBox, tr("True"));
-        } else {
-            setPlainText(textBox, tr("False"));
-        }
-    } else {
-        setPlainText(textBox, tr("N/A"));
-    }
-}
-
-/**
  * @brief Setting boolean values of binary information in dashboard
  * @param RzBinInfo
  */
 void Dashboard::setRzBinInfo(RzBinInfo *binInfo)
 {
-    int nx = binInfo->has_nx;
-    int pic = binInfo->has_pi;
-    int va = binInfo->has_va;
-    int canary = binInfo->has_canary;
-    int crypto = binInfo->has_crypto;
-
-    // Setting text
-    setPlainText(ui->vaEdit, tr(setBoolText(va)));
-    setPlainText(ui->canaryEdit, tr(setBoolText(canary)));
-    setPlainText(ui->cryptoEdit, tr(setBoolText(crypto)));
-    setPlainText(ui->nxEdit, tr(setBoolText(nx)));
-    setPlainText(ui->picEdit, tr(setBoolText(pic)));
-
-    // Setting the value of "relocs" and "stripped"
-    bool relocs_value = RZ_BIN_DBG_RELOCS & binInfo->dbg_info;
-    bool stripped_value = RZ_BIN_DBG_STRIPPED & binInfo->dbg_info;
-    setPlainText(this->ui->strippedEdit, setBoolText(stripped_value));
-    setPlainText(this->ui->relocsEdit, setBoolText(relocs_value));
+    setPlainText(ui->vaEdit, binInfo ? setBoolText(binInfo->has_va) : "");
+    setPlainText(ui->canaryEdit, binInfo ? setBoolText(binInfo->has_canary) : "");
+    setPlainText(ui->cryptoEdit, binInfo ? setBoolText(binInfo->has_crypto) : "");
+    setPlainText(ui->nxEdit, binInfo ? setBoolText(binInfo->has_nx) : "");
+    setPlainText(ui->picEdit, binInfo ? setBoolText(binInfo->has_pi) : "");
+    setPlainText(ui->strippedEdit,
+                 binInfo ? setBoolText(RZ_BIN_DBG_STRIPPED & binInfo->dbg_info) : "");
+    setPlainText(ui->relocsEdit, binInfo ? setBoolText(RZ_BIN_DBG_RELOCS & binInfo->dbg_info) : "");
 }
 
 /**

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -49,23 +49,20 @@ void Dashboard::updateContents()
 
     // Add file hashes, analysis info and libraries
     RzCoreLocked core(Core());
-
-    // Using API directly to get values in dashboard
     RzBinFile *bf = rz_bin_cur(core->bin);
     RzBinInfo *binInfo = rz_bin_get_info(core->bin);
 
-    // Setting text values from the API
-    setPlainText(this->ui->fileEdit,binInfo->file);
-    setPlainText(this->ui->formatEdit,binInfo->rclass);
-    setPlainText(this->ui->typeEdit,binInfo->type);
-    setPlainText(this->ui->archEdit,binInfo->arch);
+    setPlainText(this->ui->fileEdit, binInfo->file);
+    setPlainText(this->ui->formatEdit, binInfo->rclass);
+    setPlainText(this->ui->typeEdit, binInfo->type);
+    setPlainText(this->ui->archEdit, binInfo->arch);
     setPlainText(this->ui->langEdit, binInfo->lang);
-    setPlainText(this->ui->classEdit,binInfo->bclass);
-    setPlainText(this->ui->machineEdit,binInfo->machine);
-    setPlainText(this->ui->osEdit,binInfo->os);
-    setPlainText(this->ui->subsysEdit,binInfo->subsystem);
-    setPlainText(this->ui->compilerEdit,binInfo->compiler);
-    setPlainText(this->ui->bitsEdit,QString::number(binInfo->bits));
+    setPlainText(this->ui->classEdit, binInfo->bclass);
+    setPlainText(this->ui->machineEdit, binInfo->machine);
+    setPlainText(this->ui->osEdit, binInfo->os);
+    setPlainText(this->ui->subsysEdit, binInfo->subsystem);
+    setPlainText(this->ui->compilerEdit, binInfo->compiler);
+    setPlainText(this->ui->bitsEdit, QString::number(binInfo->bits));
     setPlainText(this->ui->baddrEdit, RzAddressString(rz_bin_file_get_baddr(bf)));
     setPlainText(this->ui->sizeEdit, qhelpers::formatBytecount(bf->size));
     setPlainText(this->ui->fdEdit, QString::number(bf->fd));
@@ -79,7 +76,7 @@ void Dashboard::updateContents()
 
     // Setting the value of "static"
     int static_value = rz_bin_is_static(core->bin);
-    setPlainText(ui->staticEdit, tr(intToText(static_value)));
+    setPlainText(ui->staticEdit, tr(setBoolText(static_value)));
 
     RzList *hashes = rz_bin_file_compute_hashes(core->bin, bf, UT64_MAX);
 
@@ -244,10 +241,9 @@ void Dashboard::setBool(QLineEdit *textBox, const CutterJson &jsonObject, const 
 }
 
 /**
- * @brief Setting boolean values text according to parsed value from API
+ * @brief Setting boolean values of binary information in dashboard
  * @param RzBinInfo
  */
-
 void Dashboard::setBoolvalues(RzBinInfo *binInfo)
 {
     int nx = binInfo->has_nx;
@@ -257,29 +253,24 @@ void Dashboard::setBoolvalues(RzBinInfo *binInfo)
     int crypto = binInfo->has_crypto;
 
     // Setting text
-    setPlainText(ui->vaEdit, tr(intToText(va)));
-    setPlainText(ui->canaryEdit, tr(intToText(canary)));
-    setPlainText(ui->cryptoEdit, tr(intToText(crypto)));
-    setPlainText(ui->nxEdit, tr(intToText(nx)));
-    setPlainText(ui->picEdit, tr(intToText(pic)));
+    setPlainText(ui->vaEdit, tr(setBoolText(va)));
+    setPlainText(ui->canaryEdit, tr(setBoolText(canary)));
+    setPlainText(ui->cryptoEdit, tr(setBoolText(crypto)));
+    setPlainText(ui->nxEdit, tr(setBoolText(nx)));
+    setPlainText(ui->picEdit, tr(setBoolText(pic)));
 
     // Setting the value of "relocs" and "stripped"
     bool relocs_value = RZ_BIN_DBG_RELOCS & binInfo->dbg_info;
     bool stripped_value = RZ_BIN_DBG_STRIPPED & binInfo->dbg_info;
-    setPlainText(this->ui->strippedEdit,QVariant(stripped_value).toString());
-    setPlainText(this->ui->relocsEdit,QVariant(relocs_value).toString());
+    setPlainText(this->ui->strippedEdit, setBoolText(stripped_value));
+    setPlainText(this->ui->relocsEdit, setBoolText(relocs_value));
 }
 
 /**
- * @brief Set the text of a QLineEdit as True, False according to the integer value
- * @param integer value
+ * @brief Set the text of a QLineEdit as True, False
+ * @param boolean value
  */
-
-char* Dashboard::intToText(int value){
-    if (value){
-        return "True";
-    }
-    else if (!value){
-        return "False";
-    }
+const char *Dashboard::setBoolText(bool value)
+{
+    return value ? "True" : "False";
 }

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -72,7 +72,7 @@ void Dashboard::updateContents()
     setPlainText(this->ui->endianEdit, endian);
 
     // Setting boolean values
-    setBoolvalues(binInfo);
+    setRzBinInfo(binInfo);
 
     // Setting the value of "static"
     int static_value = rz_bin_is_static(core->bin);
@@ -244,7 +244,7 @@ void Dashboard::setBool(QLineEdit *textBox, const CutterJson &jsonObject, const 
  * @brief Setting boolean values of binary information in dashboard
  * @param RzBinInfo
  */
-void Dashboard::setBoolvalues(RzBinInfo *binInfo)
+void Dashboard::setRzBinInfo(RzBinInfo *binInfo)
 {
     int nx = binInfo->has_nx;
     int pic = binInfo->has_pi;

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -20,6 +20,11 @@
 #include <QMessageBox>
 #include <QDialog>
 #include <QTreeWidget>
+#include <string>
+#include <string.h>
+#include <cstring>
+
+
 
 Dashboard::Dashboard(MainWindow *main) : CutterDockWidget(main), ui(new Ui::Dashboard)
 {
@@ -68,16 +73,25 @@ void Dashboard::updateContents()
     setBool(this->ui->vaEdit, item2, "va");
     setBool(this->ui->canaryEdit, item2, "canary");
     setBool(this->ui->cryptoEdit, item2, "crypto");
-    setBool(this->ui->nxEdit, item2, "nx");
-    setBool(this->ui->picEdit, item2, "pic");
+    //remove to use API directly
+//    setBool(this->ui->nxEdit, item, "nx");
+//    setBool(this->ui->picEdit, item, "pic");
     setBool(this->ui->staticEdit, item2, "static");
     setBool(this->ui->strippedEdit, item2, "stripped");
     setBool(this->ui->relocsEdit, item2, "relocs");
 
     // Add file hashes, analysis info and libraries
     RzCoreLocked core(Core());
+
+    // using API directly to get NX and PIC/PIE
+    RzBinInfo *binInfo = rz_bin_get_info(core->bin);
+
     RzBinFile *bf = rz_bin_cur(core->bin);
     RzList *hashes = rz_bin_file_compute_hashes(core->bin, bf, UT64_MAX);
+
+    //setting nx and PIC text
+    setNxPIC(binInfo);
+
 
     // Delete hashesWidget if it isn't null to avoid duplicate components
     if (hashesWidget) {
@@ -238,3 +252,35 @@ void Dashboard::setBool(QLineEdit *textBox, const CutterJson &jsonObject, const 
         setPlainText(textBox, tr("N/A"));
     }
 }
+
+/**
+ * @brief Set NX bit and PIC bit text according to parsed value from API
+ * @param RzBinInfo
+ */
+
+void Dashboard::setNxPIC(RzBinInfo *binInfo)
+{
+    //setting text
+    int nx = binInfo->has_nx;
+    int pic = binInfo->has_pi;
+    setPlainText(ui->nxEdit, tr(intToText(nx)));
+    setPlainText(ui->picEdit, tr(intToText(pic)));
+}
+
+/**
+ * @brief Set the text of a QLineEdit as True, False or N/A if it does not exist according to the integer value
+ * @param integer value
+ */
+
+char* Dashboard::intToText(int value){
+    if (value){
+        return "True";
+    }
+    else if (!value){
+        return "False";
+    }
+    else{
+        return "N/A";
+    }
+}
+

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -264,7 +264,7 @@ void Dashboard::setNxPIC(RzBinInfo *binInfo)
 }
 
 /**
- * @brief Set the text of a QLineEdit as True, False or N/A if it does not exist according to the integer value
+ * @brief Set the text of a QLineEdit as True, False according to the integer value
  * @param integer value
  */
 
@@ -274,9 +274,6 @@ char* Dashboard::intToText(int value){
     }
     else if (!value){
         return "False";
-    }
-    else{
-        return "N/A";
     }
 }
 

--- a/src/widgets/Dashboard.h
+++ b/src/widgets/Dashboard.h
@@ -34,6 +34,8 @@ private:
     std::unique_ptr<Ui::Dashboard> ui;
     void setPlainText(QLineEdit *textBox, const QString &text);
     void setBool(QLineEdit *textBox, const CutterJson &jsonObject, const char *key);
+    void setNxPIC(RzBinInfo *binInfo);
+    char* intToText(int value);
 
     QWidget *hashesWidget = nullptr;
 };

--- a/src/widgets/Dashboard.h
+++ b/src/widgets/Dashboard.h
@@ -35,7 +35,7 @@ private:
     void setPlainText(QLineEdit *textBox, const QString &text);
     void setBool(QLineEdit *textBox, const CutterJson &jsonObject, const char *key);
     void setBoolvalues(RzBinInfo *binInfo);
-    char* intToText(int value);
+    const char* setBoolText(bool value);
 
     QWidget *hashesWidget = nullptr;
 };

--- a/src/widgets/Dashboard.h
+++ b/src/widgets/Dashboard.h
@@ -33,7 +33,6 @@ private slots:
 private:
     std::unique_ptr<Ui::Dashboard> ui;
     void setPlainText(QLineEdit *textBox, const QString &text);
-    void setBool(QLineEdit *textBox, const CutterJson &jsonObject, const char *key);
     void setRzBinInfo(RzBinInfo *binInfo);
     const char *setBoolText(bool value);
 

--- a/src/widgets/Dashboard.h
+++ b/src/widgets/Dashboard.h
@@ -34,8 +34,8 @@ private:
     std::unique_ptr<Ui::Dashboard> ui;
     void setPlainText(QLineEdit *textBox, const QString &text);
     void setBool(QLineEdit *textBox, const CutterJson &jsonObject, const char *key);
-    void setBoolvalues(RzBinInfo *binInfo);
-    const char* setBoolText(bool value);
+    void setRzBinInfo(RzBinInfo *binInfo);
+    const char *setBoolText(bool value);
 
     QWidget *hashesWidget = nullptr;
 };

--- a/src/widgets/Dashboard.h
+++ b/src/widgets/Dashboard.h
@@ -34,7 +34,7 @@ private:
     std::unique_ptr<Ui::Dashboard> ui;
     void setPlainText(QLineEdit *textBox, const QString &text);
     void setBool(QLineEdit *textBox, const CutterJson &jsonObject, const char *key);
-    void setNxPIC(RzBinInfo *binInfo);
+    void setBoolvalues(RzBinInfo *binInfo);
     char* intToText(int value);
 
     QWidget *hashesWidget = nullptr;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This PR solves the problem of missing NX bit and PIC protections. The solution is to use rizin API directly.
Implementation:
1 - Remove using `setBool(this->ui->nxEdit, item, "nx");` and `setBool(this->ui->nxEdit, item, "pic");` 
2- Using the API directly by calling `RzBinInfo *binInfo = rz_bin_get_info(core->bin);` as this function returns a struct containing the correct values of NX bit and PIC bit: `has_nx` and `has_pi`
3 - calling the function `setNxPIC` that sets the linedit with the correct values:
```
void Dashboard::setNxPIC(RzBinInfo *binInfo)
{
    //setting text
    int nx = binInfo->has_nx;
    int pic = binInfo->has_pi;
    setPlainText(ui->nxEdit, tr(intToText(nx)));
    setPlainText(ui->picEdit, tr(intToText(pic)));
}
```
**This solution follows the trend of using the API directly inside the cutter #2666. This solution can be generalized to all the boolean values inside the dashboard**


**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->
1- open new file using cutter 
2- check the values of NX bit and PIC bit
3- you can confirm the correctness of the values using the command `$ rz-bin -I filename` or using `$ checksec --file=filename`



<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #2895
