### PR TITLE
core: fixed missing field initializers

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -840,15 +840,18 @@ void CutterCore::removeString(RVA addr)
 QString CutterCore::getString(RVA addr)
 {
     CORE_LOCK();
-    char *s = (char *)returnAtSeek(
-            [&]() {
-                RzStrStringifyOpt opt = { 0 };
-                opt.buffer = core->block;
-                opt.length = core->blocksize;
-                opt.encoding = rz_str_guess_encoding_from_buffer(core->block, core->blocksize);
-                return rz_str_stringify_raw_buffer(&opt, NULL);
-            },
-            addr);
+    const auto function_op_on_seek = [&]() {
+        RzStrStringifyOpt opt = { core->block,
+                                  core->blocksize,
+                                  rz_str_guess_encoding_from_buffer(core->block, core->blocksize),
+                                  unsigned {},
+                                  bool {},
+                                  bool {},
+                                  bool {},
+                                  bool {} };
+        return rz_str_stringify_raw_buffer(&opt, NULL);
+    };
+    char *s = (char *)returnAtSeek(function_op_on_seek, addr);
     return fromOwnedCharPtr(s);
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

* When building the project from `clean`, compiler complains with:
```
    ./cutter/src/core/Cutter.cpp:845:45: warning: missing initializer for member ‘rz_str_stringify_opt_t::length’ [-Wmissing-field-initializers]
  845 |                 RzStrStringifyOpt opt = { 0 };
      |                                             ^                  
```
* This PR fixes said complaint by filling in the missing fields for the variable `opt` of datatype `RzStrStringifyOpt`.

**Test plan (required)**
* CI should pass and build with no problems.
  * Structurally, nothing has changed, only filled in missing data fields.

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

N/A

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
---