### PR TITLE
Fixed an invalid index check

### DIFF
--- a/src/widgets/GlibcHeapWidget.cpp
+++ b/src/widgets/GlibcHeapWidget.cpp
@@ -71,7 +71,7 @@ void GlibcHeapWidget::updateArenas()
     }
 
     // check if arenas reduced or invalid index and restore the previously selected arena
-    if (arenaSelectorView->count() < currentIndex || currentIndex == -1) {
+    if (arenaSelectorView->count() <= currentIndex || currentIndex == -1) {
         currentIndex = 0;
     }
     arenaSelectorView->setCurrentIndex(currentIndex);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

    void GlibcHeapWidget::updateArenas()
    {
        ...
        int currentIndex = arenaSelectorView->currentIndex();
        arenaSelectorView->clear();

        // add the new arenas to the arena selector
        for (auto &arena : arenas) {
            arenaSelectorView->addItem(...);
        }
        ...
    }

As `QComboBox` uses zero based indexing, an issue will arise when `currentIndex` is equal to the last index of `arenaSelectorView` and count of items in `arenaSelectorView` decreases by one after the for loop.

    if (arenaSelectorView->count() < currentIndex || currentIndex == -1) {
        currentIndex = 0;
    }
    arenaSelectorView->setCurrentIndex(currentIndex);

So, `arenaSelectorView->count() < currentIndex` evaluates to false and `setCurrentIndex` gets called with `currentIndex` being equal to `arenaSelectorView->count()` which is also equal to `arenas.size()`

    connect<void (QComboBox::*)(int)>(arenaSelectorView, &QComboBox::currentIndexChanged, 
                                     this, &GlibcHeapWidget::onArenaSelected);


As `QComboBox::setCurrentIndex` emits the signal `QComboBox::currentIndexChanged` and because of the above connection,  `GlibcHeapWidget::onArenaSelected` gets called with the same index.

    void GlibcHeapWidget::onArenaSelected(int index)
    {
        if (index == -1) {
            modelHeap->arena_addr = 0;
        } else {
            modelHeap->arena_addr = arenas[index].offset;
        }
        
        ...
    }

As `index == currentIndex == arenaSelectorView->count() == arenas.size()` holds true, `arenas[index]` will be an out of bounds access, causing undefined behavior.