### PR TITLE
Fix EditVariablesDialog parenting

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -875,7 +875,7 @@ void DisassemblyContextMenu::on_actionSetFunctionVarTypes_triggered()
         return;
     }
 
-    EditVariablesDialog dialog(fcn->addr, curHighlightedWord, this);
+    EditVariablesDialog dialog(fcn->addr, curHighlightedWord, this->mainWindow);
     if (dialog.empty()) { // don't show the dialog if there are no variables
         return;
     }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

This fixes the dialog being placed weirdly when using the 'Y' shortcut
because it was parented to the DisassemblyContextMenu, which itself
might not be shown at all.

**Test plan (required)**

Open a file, do NOT right-click anywhere, select a var and press y.
The dialog should show in the center of the mainwindow (or whatever is the standard on your platform) and no warnings from qt should be printed.