### PR TITLE
Fix null deref in strings loading without any file

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -542,10 +542,7 @@ CutterJson CutterCore::cmdjTask(const QString &str)
     RizinCmdTask task(str);
     task.startTask();
     task.joinTask();
-    const char *res = task.getResultRaw();
-    char *copy = static_cast<char *>(rz_mem_alloc(strlen(res) + 1));
-    strcpy(copy, res);
-    return parseJson(copy, str);
+    return task.getResultJson();
 }
 
 CutterJson CutterCore::parseJson(char *res, const char *cmd)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

see title

**Test plan (required)**

Open Cutter without any file -> should not segfault and show empty strings widget
Open Cutter with a file -> should show strings