### PR TITLE
Fix #2958 - Add checkbox to fill remaining bytes with nops.

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -758,10 +758,14 @@ QString CutterCore::getInstructionOpcode(RVA addr)
     return fromOwnedCharPtr(ret);
 }
 
-void CutterCore::editInstruction(RVA addr, const QString &inst)
+void CutterCore::editInstruction(RVA addr, const QString &inst, bool fillWithNops)
 {
     CORE_LOCK();
-    rz_core_write_assembly(core, addr, inst.trimmed().toStdString().c_str());
+    if (fillWithNops) {
+        rz_core_write_assembly_fill(core, addr, inst.trimmed().toStdString().c_str());
+    } else {
+        rz_core_write_assembly(core, addr, inst.trimmed().toStdString().c_str());
+    }
     emit instructionChanged(addr);
 }
 

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -259,7 +259,7 @@ public:
     /* Edition functions */
     QString getInstructionBytes(RVA addr);
     QString getInstructionOpcode(RVA addr);
-    void editInstruction(RVA addr, const QString &inst);
+    void editInstruction(RVA addr, const QString &inst, bool fillWithNops = false);
     void nopInstruction(RVA addr);
     void jmpReverse(RVA addr);
     void editBytes(RVA addr, const QString &inst);

--- a/src/dialogs/EditInstructionDialog.cpp
+++ b/src/dialogs/EditInstructionDialog.cpp
@@ -2,12 +2,20 @@
 #include "ui_EditInstructionDialog.h"
 #include "core/Cutter.h"
 
+#include <QCheckBox>
+
 EditInstructionDialog::EditInstructionDialog(InstructionEditMode editMode, QWidget *parent)
     : QDialog(parent), ui(new Ui::EditInstructionDialog), editMode(editMode)
 {
     ui->setupUi(this);
     ui->lineEdit->setMinimumWidth(400);
     ui->instructionLabel->setWordWrap(true);
+    if (editMode == EDIT_TEXT) {
+        ui->fillWithNops->setVisible(true);
+        ui->fillWithNops->setCheckState(Qt::Checked);
+    } else {
+        ui->fillWithNops->setVisible(false);
+    }
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
 
     connect(ui->lineEdit, &QLineEdit::textEdited, this, &EditInstructionDialog::updatePreview);
@@ -20,6 +28,15 @@ void EditInstructionDialog::on_buttonBox_accepted() {}
 void EditInstructionDialog::on_buttonBox_rejected()
 {
     close();
+}
+
+bool EditInstructionDialog::needsNops() const
+{
+    if (editMode != EDIT_TEXT) {
+        return false;
+    }
+
+    return ui->fillWithNops->checkState() == Qt::Checked;
 }
 
 QString EditInstructionDialog::getInstruction() const

--- a/src/dialogs/EditInstructionDialog.h
+++ b/src/dialogs/EditInstructionDialog.h
@@ -20,18 +20,18 @@ public:
 
     QString getInstruction() const;
     void setInstruction(const QString &instruction);
+    bool needsNops() const;
 
 private slots:
     void on_buttonBox_accepted();
-
     void on_buttonBox_rejected();
 
     void updatePreview(const QString &input);
 
 private:
     std::unique_ptr<Ui::EditInstructionDialog> ui;
-    InstructionEditMode
-            editMode; // true if editing intruction **bytes**; false if editing instruction **text**
+    // defines if the user is editing bytes or asm
+    InstructionEditMode editMode;
 };
 
 #endif // EDITINSTRUCTIONDIALOG_H

--- a/src/dialogs/EditInstructionDialog.ui
+++ b/src/dialogs/EditInstructionDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>118</height>
+    <height>151</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,6 +37,18 @@
    </property>
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="leftMargin">
+      <number>5</number>
+     </property>
+     <property name="topMargin">
+      <number>5</number>
+     </property>
+     <property name="rightMargin">
+      <number>5</number>
+     </property>
+     <property name="bottomMargin">
+      <number>5</number>
+     </property>
      <item>
       <spacer name="verticalSpacer">
        <property name="orientation">
@@ -81,6 +93,16 @@
         </widget>
        </item>
       </layout>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="fillWithNops">
+       <property name="text">
+        <string>Fill all remaining bytes with NOP opcodes</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
      </item>
      <item>
       <spacer name="verticalSpacer_1">

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -708,9 +708,10 @@ void DisassemblyContextMenu::on_actionEditInstruction_triggered()
     e.setInstruction(oldInstructionOpcode);
 
     if (e.exec()) {
+        bool fillWithNops = e.needsNops();
         QString userInstructionOpcode = e.getInstruction();
         if (userInstructionOpcode != oldInstructionOpcode) {
-            Core()->editInstruction(offset, userInstructionOpcode);
+            Core()->editInstruction(offset, userInstructionOpcode, fillWithNops);
         }
     }
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Adds a checkbox to allow auto-filling remaining bytes with nops (this is only available when in EDIT_TEXT mode).

![image](https://user-images.githubusercontent.com/561184/174772877-03c0b148-0ef0-41d8-bff4-b22d2042084b.png)
![image](https://user-images.githubusercontent.com/561184/174773012-2150c241-4fae-41f2-940d-d15ef964d595.png)

Fix #2958 