### PR TITLE
Extend blocksize to work around pdJ printing to few lines

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -219,6 +219,11 @@ void CutterCore::initialize(bool loadPlugins)
     // Otherwise Rizin may ask the user for input and Cutter would freeze
     setConfig("scr.interactive", false);
 
+    // Temporary workaround for https://github.com/rizinorg/rizin/issues/2741
+    // Otherwise sometimes disassembly is truncated.
+    // The blocksize here is a rather arbitrary value larger than the default 0x100.
+    rz_core_block_size(core, 0x400);
+
     // Initialize graph node highlighter
     bbHighlighter = new BasicBlockHighlighter();
 


### PR DESCRIPTION
see https://github.com/rizinorg/rizin/issues/2741
fixes this:
![Bildschirmfoto 2022-06-25 um 14 35 10](https://user-images.githubusercontent.com/1460997/175774759-08559e0a-b256-4cd8-93ed-ff1390be63c9.png)
