### PR TITLE
Remove direct download from update check

### DIFF
--- a/src/common/UpdateWorker.h
+++ b/src/common/UpdateWorker.h
@@ -23,8 +23,7 @@ class QNetworkReply;
 
 /**
  * @class UpdateWorker
- * @brief The UpdateWorker class is a class providing API to check for current Cutter version
- *        and download specific version of one.
+ * @brief The UpdateWorker class is a class providing API to check for current Cutter version.
  */
 
 class UpdateWorker : public QObject
@@ -48,22 +47,11 @@ public:
     void checkCurrentVersion(time_t timeoutMs);
 
     /**
-     * @fn void UpdateWorker::download(QDir downloadPath, QString version)
-     *
-     * @brief Downloads provided @a version of Cutter into @a downloadDir.
-     *
-     * @sa downloadProcess(size_t bytesReceived, size_t bytesTotal)
-     */
-    void download(QString filename, QString version);
-
-    /**
      * @fn void UpdateWorker::showUpdateDialog()
      *
-     * Shows dialog that allows user to either download latest version of Cutter from website
-     * or download it by clicking on a button. This dialog also has "Don't check for updates"
-     * button which disables on-start update checks if @a showDontCheckForUpdatesButton is true.
-     *
-     * @sa downloadProcess(size_t bytesReceived, size_t bytesTotal)
+     * Shows dialog that allows user to download latest version of Cutter from website.
+     * This dialog also has "Don't check for updates" button which disables on-start update
+     * checks if @a showDontCheckForUpdatesButton is true.
      */
     void showUpdateDialog(bool showDontCheckForUpdatesButton);
 
@@ -72,18 +60,6 @@ public:
      * CUTTER_VERSION_MINOR and CUTTER_VERSION_PATCH.
      */
     static QVersionNumber currentVersionNumber();
-
-public slots:
-    /**
-     * @fn void UpdateWorker::abortDownload()
-     *
-     * @brief Stops current process of downloading.
-     *
-     * @note UpdateWorker::downloadFinished(QString filename) is not send after this function.
-     *
-     * @sa download(QDir downloadDir, QString version)
-     */
-    void abortDownload();
 
 signals:
     /**
@@ -95,46 +71,14 @@ signals:
      */
     void checkComplete(const QVersionNumber &currVerson, const QString &errorMsg);
 
-    /**
-     * @fn UpdateWorker::downloadProcess(size_t bytesReceived, size_t bytesTotal)
-     *
-     * The signal is emitted each time when some amount of bytes was downloaded.
-     * May be used as indicator of download progress.
-     */
-    void downloadProcess(size_t bytesReceived, size_t bytesTotal);
-
-    /**
-     * @fn UpdateWorker::downloadFinished(QString filename)
-     *
-     * @brief The signal is emitted as soon as downloading completes.
-     */
-    void downloadFinished(QString filename);
-
-    /**
-     * @fn UpdateWorker::downloadError(QString errorStr)
-     *
-     * @brief The signal is emitted when error occures during download.
-     */
-    void downloadError(QString errorStr);
-
 private slots:
     void serveVersionCheckReply();
-
-    void serveDownloadFinish();
-
-    void process(size_t bytesReceived, size_t bytesTotal);
-
-private:
-    QString getRepositeryExt() const;
-    QString getRepositoryFileName() const;
 
 private:
     QNetworkAccessManager nm;
     QVersionNumber latestVersion;
     QTimer t;
     bool pending;
-    QFile downloadFile;
-    QNetworkReply *downloadReply;
     QNetworkReply *checkReply;
 };
 


### PR DESCRIPTION

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Hardcoded prediction of filenames for future releases is too prone to
break, which is what happened with v2.1.0.
So better to provide the link to the release page only.

**Test plan (required)**

* Hardcode an older version number in `UpdateWorker::currentVersionNumber()`
* Click About Cutter -> check for updates
* The dialog should just show the github link to the latest release, which should not be dead