### PR TITLE
Construct and destruct CutterCore singleton locally (Fix #2704) 

### DIFF
--- a/src/CutterApplication.h
+++ b/src/CutterApplication.h
@@ -50,6 +50,7 @@ private:
 
 private:
     bool m_FileAlreadyDropped;
+    CutterCore core;
     MainWindow *mainWindow;
     CutterCommandLineOptions clOptions;
 };

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -24,7 +24,7 @@
 #include <rz_cmd.h>
 #include <sdb.h>
 
-Q_GLOBAL_STATIC(CutterCore, uniqueInstance)
+static CutterCore *uniqueInstance;
 
 #define RZ_JSON_KEY(name) static const QString name = QStringLiteral(#name)
 
@@ -182,6 +182,10 @@ CutterCore::CutterCore(QObject *parent)
       coreMutex(QMutex::Recursive)
 #endif
 {
+    if (uniqueInstance) {
+        throw std::logic_error("Only one instance of CutterCore must exist");
+    }
+    uniqueInstance = this;
 }
 
 CutterCore *CutterCore::instance()
@@ -238,6 +242,8 @@ CutterCore::~CutterCore()
     rz_core_task_sync_end(&core_->tasks);
     rz_core_free(this->core_);
     rz_cons_free();
+    assert(uniqueInstance == this);
+    uniqueInstance = nullptr;
 }
 
 RzCoreLocked CutterCore::core()


### PR DESCRIPTION
Using Q_GLOBAL_STATIC meant that the CutterCore was destructed late as
part of a binary destructor. It would then free the RzCore, calling for
example the fini callbacks of all plugins. However global destructors in
shared library plugins may have already been run at this point, leading
to for example rz-ghidra's decompiler_mutex being used after
destruction.
Instead of the Q_GLOBAL_STATIC-managed global object, we are now
handling the lifetime of the CutterCore ourselves and only injecting its
instance to be accessed globally. This can also be a first step towards
making the core instance completely local.

**Closing issues**

Fix #2704