### PR TITLE
Don't try to load files with wrong extension as native plugins. #2626

### DIFF
--- a/src/plugins/PluginManager.cpp
+++ b/src/plugins/PluginManager.cpp
@@ -133,6 +133,10 @@ QString PluginManager::getUserPluginsDirectory() const
 void PluginManager::loadNativePlugins(const QDir &directory)
 {
     for (const QString &fileName : directory.entryList(QDir::Files)) {
+        if (!QLibrary::isLibrary(fileName)) {
+            // Reduce amount of warnings, by not attempting files which are obviously not plugins
+            continue;
+        }
         QPluginLoader pluginLoader(directory.absoluteFilePath(fileName));
         QObject *plugin = pluginLoader.instance();
         if (!plugin) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

* Create some file in plugin folder (don't use the extension used by dynamic libraries on your OS)
* Start cutter, make sure the part of log which list folders from which it tries to load plugins doesn't have any warnings about failing to load the file you created in previous step (run cutter from command line to see the early startup log)
* Wait for PR artifacts to finish building
* Make sure the native plugins (ghidra) in the artifacts built by Github still works
    - [x] Linux
    - [x] Windows
    - [x]  macOS


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #2626 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
