### PR TITLE
Introduce some helpers to deal with rizin C API more cleanly.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     Main.cpp
     core/Cutter.cpp
     core/CutterJson.cpp
+    core/RizinCpp.cpp
     dialogs/EditStringDialog.cpp
     dialogs/WriteCommandsDialogs.cpp
     widgets/DisassemblerGraphView.cpp
@@ -154,6 +155,7 @@ set(HEADER_FILES
     core/CutterCommon.h
     core/CutterDescriptions.h
     core/CutterJson.h
+    core/RizinCpp.h
     dialogs/EditStringDialog.h
     dialogs/WriteCommandsDialogs.h
     widgets/DisassemblerGraphView.h

--- a/src/common/DecompilerHighlighter.cpp
+++ b/src/common/DecompilerHighlighter.cpp
@@ -49,8 +49,7 @@ void DecompilerHighlighter::highlightBlock(const QString &)
     size_t start = block.position();
     size_t end = block.position() + block.length();
 
-    std::unique_ptr<RzPVector, decltype(&rz_pvector_free)> annotations(
-            rz_annotated_code_annotations_range(code, start, end), &rz_pvector_free);
+    auto annotations = fromOwned(rz_annotated_code_annotations_range(code, start, end));
     void **iter;
     rz_pvector_foreach(annotations.get(), iter)
     {

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -120,7 +120,6 @@ static void updateOwnedCharPtr(char *&variable, const QString &newValue)
     variable = strdup(data.data());
 }
 
-
 static bool reg_sync(RzCore *core, RzRegisterType type, bool write)
 {
     if (rz_core_is_debug(core)) {
@@ -908,8 +907,7 @@ QString CutterCore::getString(RVA addr, uint64_t len, RzStrEnc encoding, bool es
     opt.encoding = encoding;
     opt.escape_nl = escape_nl;
     auto seek = seekTemp(addr);
-    return fromOwnedCharPtr(
-            rz_str_stringify_raw_buffer(&opt, NULL));
+    return fromOwnedCharPtr(rz_str_stringify_raw_buffer(&opt, NULL));
 }
 
 QString CutterCore::getMetaString(RVA addr)
@@ -1083,11 +1081,10 @@ RVA CutterCore::prevOpAddr(RVA startAddr, int count)
 RVA CutterCore::nextOpAddr(RVA startAddr, int count)
 {
     CORE_LOCK();
-    auto vec = fromOwned((RzPVector*)nullptr);
-    {
-        auto seek = seekTemp(startAddr);
-        vec.reset(rz_core_analysis_bytes(core, core->block, (int)core->blocksize, count + 1));
-    }
+    auto seek = seekTemp(startAddr);
+    auto vec =
+            fromOwned(rz_core_analysis_bytes(core, core->block, (int)core->blocksize, count + 1));
+
     RVA addr = startAddr + 1;
     if (!vec) {
         return addr;
@@ -4190,7 +4187,8 @@ void CutterCore::loadPDB(const QString &file)
 QList<DisassemblyLine> CutterCore::disassembleLines(RVA offset, int lines)
 {
     CORE_LOCK();
-    auto vec = fromOwned(rz_pvector_new(reinterpret_cast<RzPVectorFree>(rz_analysis_disasm_text_free)));
+    auto vec = fromOwned(
+            rz_pvector_new(reinterpret_cast<RzPVectorFree>(rz_analysis_disasm_text_free)));
     if (!vec) {
         return {};
     }
@@ -4199,13 +4197,12 @@ QList<DisassemblyLine> CutterCore::disassembleLines(RVA offset, int lines)
     options.cbytes = 1;
     options.vec = vec.get();
     {
-        auto restoreSeek = this->seekTemp(offset);
+        auto restoreSeek = seekTemp(offset);
         if (rz_cons_singleton()->is_html) {
             rz_cons_singleton()->is_html = false;
             rz_cons_singleton()->was_html = true;
         }
-        rz_core_print_disasm(core, offset, core->block, core->blocksize, lines, NULL,
-                             &options);
+        rz_core_print_disasm(core, offset, core->block, core->blocksize, lines, NULL, &options);
     }
 
     QList<DisassemblyLine> r;

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -159,11 +159,24 @@ public:
     class SeekReturn
     {
         RVA returnAddress;
-        SeekReturn(const SeekReturn &) = delete;
+        bool empty = true;
+
     public:
-        SeekReturn(RVA returnAddress) : returnAddress(returnAddress) {}
-        ~SeekReturn() { Core()->seekSilent(returnAddress); }
-        SeekReturn(SeekReturn &&) = default;
+        SeekReturn(RVA returnAddress) : returnAddress(returnAddress), empty(false) {}
+        ~SeekReturn()
+        {
+            if (!empty) {
+                Core()->seekSilent(returnAddress);
+            }
+        }
+        SeekReturn(SeekReturn &&from)
+        {
+            if (this != &from) {
+                returnAddress = from.returnAddress;
+                empty = from.empty;
+                from.empty = true;
+            }
+        };
     };
 
     SeekReturn seekTemp(RVA address)

--- a/src/core/CutterCommon.h
+++ b/src/core/CutterCommon.h
@@ -7,6 +7,7 @@
 
 #include "rz_core.h"
 #include <QString>
+#include "RizinCpp.h"
 
 // Workaround for compile errors on Windows
 #ifdef Q_OS_WIN
@@ -14,103 +15,6 @@
 #    undef max
 #endif // Q_OS_WIN
 
-// Rizin list iteration macros
-#define CutterRzListForeach(list, it, type, x)                                                     \
-    if (list)                                                                                      \
-        for (it = list->head; it && ((x = static_cast<type *>(it->data))); it = it->n)
-
-#define CutterRzVectorForeach(vec, it, type)                                                       \
-    if ((vec) && (vec)->a)                                                                         \
-        for (it = (type *)(vec)->a;                                                                \
-             (char *)it != (char *)(vec)->a + ((vec)->len * (vec)->elem_size);                     \
-             it = (type *)((char *)it + (vec)->elem_size))
-
-template<typename T>
-class CutterPVector
-{
-private:
-    const RzPVector *const vec;
-
-public:
-    class iterator : public std::iterator<std::input_iterator_tag, T *>
-    {
-    private:
-        T **p;
-
-    public:
-        iterator(T **p) : p(p) {}
-        iterator(const iterator &o) : p(o.p) {}
-        iterator &operator++()
-        {
-            p++;
-            return *this;
-        }
-        iterator operator++(int)
-        {
-            iterator tmp(*this);
-            operator++();
-            return tmp;
-        }
-        bool operator==(const iterator &rhs) const { return p == rhs.p; }
-        bool operator!=(const iterator &rhs) const { return p != rhs.p; }
-        T *operator*() { return *p; }
-    };
-
-    CutterPVector(const RzPVector *vec) : vec(vec) {}
-    iterator begin() const { return iterator(reinterpret_cast<T **>(vec->v.a)); }
-    iterator end() const { return iterator(reinterpret_cast<T **>(vec->v.a) + vec->v.len); }
-};
-
-template<typename T>
-class CutterRzList
-{
-private:
-    const RzList *const list;
-
-public:
-    class iterator : public std::iterator<std::input_iterator_tag, T *>
-    {
-    private:
-        RzListIter *iter;
-
-    public:
-        explicit iterator(RzListIter *iter) : iter(iter) {}
-        iterator(const iterator &o) : iter(o.iter) {}
-        iterator &operator++()
-        {
-            if (!iter) {
-                return *this;
-            }
-            iter = iter->n;
-            return *this;
-        }
-        iterator operator++(int)
-        {
-            iterator tmp(*this);
-            operator++();
-            return tmp;
-        }
-        bool operator==(const iterator &rhs) const { return iter == rhs.iter; }
-        bool operator!=(const iterator &rhs) const { return iter != rhs.iter; }
-        T *operator*()
-        {
-            if (!iter) {
-                return nullptr;
-            }
-            return reinterpret_cast<T *>(iter->data);
-        }
-    };
-
-    explicit CutterRzList(const RzList *l) : list(l) {}
-    iterator begin() const
-    {
-        if (!list) {
-            return iterator(nullptr);
-        }
-        return iterator(list->head);
-    }
-    iterator end() const { return iterator(nullptr); }
-};
 
 // Global information for Cutter
 #define APPNAME "Cutter"

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1768,12 +1768,12 @@ void MainWindow::on_actionExport_as_code_triggered()
         return;
     }
 
-    std::unique_ptr<char, decltype(free) *> string {
+
+
+    auto string = fromOwned(
         dialog.selectedNameFilter() != instructionsInComments
                 ? rz_lang_byte_array(buffer.data(), size, typMap[dialog.selectedNameFilter()])
-                : rz_core_print_bytes_with_inst(rc, buffer.data(), 0, size),
-        free
-    };
+                : rz_core_print_bytes_with_inst(rc, buffer.data(), 0, size));
     fileOut << string.get();
 }
 

--- a/src/core/RizinCpp.cpp
+++ b/src/core/RizinCpp.cpp
@@ -1,0 +1,2 @@
+#include "RizinCpp.h"
+

--- a/src/core/RizinCpp.h
+++ b/src/core/RizinCpp.h
@@ -1,6 +1,6 @@
 /** \file RizinCpp.h
- * Various utilities for easier and sefer interactions with Rizin
- * from c++ code.
+ * Various utilities for easier and safer interactions with Rizin
+ * from C++ code.
  */
 #ifndef RIZINCPP_H
 #define RIZINCPP_H
@@ -53,6 +53,7 @@ static inline auto fromOwned(RZ_OWN RzList *data)
 }
 
 // Rizin list iteration macros
+// deprecated, prefer using CutterPVector and CutterRzList instead
 #define CutterRzListForeach(list, it, type, x)                                                     \
     if (list)                                                                                      \
         for (it = list->head; it && ((x = static_cast<type *>(it->data))); it = it->n)

--- a/src/core/RizinCpp.h
+++ b/src/core/RizinCpp.h
@@ -1,0 +1,153 @@
+/** \file RizinCpp.h
+ * Various utilities for easier and sefer interactions with Rizin
+ * from c++ code.
+ */
+#ifndef RIZINCPP_H
+#define RIZINCPP_H
+
+#include "rz_core.h"
+#include <QString>
+#include <memory>
+
+static inline QString fromOwnedCharPtr(char *str)
+{
+    QString result(str ? str : "");
+    rz_mem_free(str);
+    return result;
+}
+
+template<class T, class F>
+std::unique_ptr<T, F *> fromOwned(T *data, F *freeFunction)
+{
+    return std::unique_ptr<T, F *> { data, freeFunction };
+}
+
+static inline std::unique_ptr<char, decltype(&rz_mem_free)> fromOwned(char *text)
+{
+    return { text, rz_mem_free };
+}
+
+template<class T, void (*func)(T *)>
+class FreeBinder
+{
+public:
+    void operator()(T *data) { func(data); }
+};
+
+template<class T, void (*func)(T *)>
+using UniquePtrC = std::unique_ptr<T, FreeBinder<T, func>>;
+
+template<typename T, void (*func)(T)>
+using UniquePtrCP = UniquePtrC<typename std::remove_pointer<T>::type, func>;
+
+static inline auto fromOwned(RZ_OWN RzPVector *data)
+        -> UniquePtrCP<decltype(data), &rz_pvector_free>
+{
+    return { data, {} };
+}
+
+static inline auto fromOwned(RZ_OWN RzList *data)
+        -> UniquePtrCP<decltype(data), &rz_list_free>
+{
+    return { data, {} };
+}
+
+// Rizin list iteration macros
+#define CutterRzListForeach(list, it, type, x)                                                     \
+    if (list)                                                                                      \
+        for (it = list->head; it && ((x = static_cast<type *>(it->data))); it = it->n)
+
+#define CutterRzVectorForeach(vec, it, type)                                                       \
+    if ((vec) && (vec)->a)                                                                         \
+        for (it = (type *)(vec)->a;                                                                \
+             (char *)it != (char *)(vec)->a + ((vec)->len * (vec)->elem_size);                     \
+             it = (type *)((char *)it + (vec)->elem_size))
+
+template<typename T>
+class CutterPVector
+{
+private:
+    const RzPVector *const vec;
+
+public:
+    class iterator : public std::iterator<std::input_iterator_tag, T *>
+    {
+    private:
+        T **p;
+
+    public:
+        iterator(T **p) : p(p) {}
+        iterator(const iterator &o) : p(o.p) {}
+        iterator &operator++()
+        {
+            p++;
+            return *this;
+        }
+        iterator operator++(int)
+        {
+            iterator tmp(*this);
+            operator++();
+            return tmp;
+        }
+        bool operator==(const iterator &rhs) const { return p == rhs.p; }
+        bool operator!=(const iterator &rhs) const { return p != rhs.p; }
+        T *operator*() { return *p; }
+    };
+
+    CutterPVector(const RzPVector *vec) : vec(vec) {}
+    iterator begin() const { return iterator(reinterpret_cast<T **>(vec->v.a)); }
+    iterator end() const { return iterator(reinterpret_cast<T **>(vec->v.a) + vec->v.len); }
+};
+
+template<typename T>
+class CutterRzList
+{
+private:
+    const RzList *const list;
+
+public:
+    class iterator : public std::iterator<std::input_iterator_tag, T *>
+    {
+    private:
+        RzListIter *iter;
+
+    public:
+        explicit iterator(RzListIter *iter) : iter(iter) {}
+        iterator(const iterator &o) : iter(o.iter) {}
+        iterator &operator++()
+        {
+            if (!iter) {
+                return *this;
+            }
+            iter = iter->n;
+            return *this;
+        }
+        iterator operator++(int)
+        {
+            iterator tmp(*this);
+            operator++();
+            return tmp;
+        }
+        bool operator==(const iterator &rhs) const { return iter == rhs.iter; }
+        bool operator!=(const iterator &rhs) const { return iter != rhs.iter; }
+        T *operator*()
+        {
+            if (!iter) {
+                return nullptr;
+            }
+            return reinterpret_cast<T *>(iter->data);
+        }
+    };
+
+    explicit CutterRzList(const RzList *l) : list(l) {}
+    iterator begin() const
+    {
+        if (!list) {
+            return iterator(nullptr);
+        }
+        return iterator(list->head);
+    }
+    iterator end() const { return iterator(nullptr); }
+};
+
+#endif // RIZINCPP_H

--- a/src/dialogs/EditMethodDialog.cpp
+++ b/src/dialogs/EditMethodDialog.cpp
@@ -86,11 +86,7 @@ bool EditMethodDialog::inputValid()
 
 QString EditMethodDialog::convertRealNameToName(const QString &realName)
 {
-    std::unique_ptr<const char, void (*)(const char *)> sanitizedCString(
-            rz_str_sanitize_sdb_key(realName.toUtf8().constData()),
-            [](const char *s) { rz_mem_free((void*)s); });
-
-    return QString(sanitizedCString.get());
+    return fromOwnedCharPtr(rz_str_sanitize_sdb_key(realName.toUtf8().constData()));
 }
 
 void EditMethodDialog::setClass(const QString &className)

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -314,9 +314,8 @@ void DisassemblyContextMenu::addDebugMenu()
 QVector<DisassemblyContextMenu::ThingUsedHere> DisassemblyContextMenu::getThingUsedHere(RVA offset)
 {
     RzCoreLocked core(Core());
-    auto p = std::unique_ptr<RzCoreAnalysisName, decltype(rz_core_analysis_name_free) *> {
-        rz_core_analysis_name(core, offset), rz_core_analysis_name_free
-    };
+    auto p = fromOwned(
+        rz_core_analysis_name(core, offset), rz_core_analysis_name_free);
     if (!p) {
         return {};
     }

--- a/src/widgets/CallGraph.cpp
+++ b/src/widgets/CallGraph.cpp
@@ -74,7 +74,6 @@ static inline bool isBetween(ut64 a, ut64 x, ut64 b)
     return (a == UT64_MAX || a <= x) && (b == UT64_MAX || x <= b);
 }
 
-using PRzList = std::unique_ptr<RzList, decltype(rz_list_free) *>;
 
 void CallGraphView::loadCurrentGraph()
 {
@@ -90,7 +89,7 @@ void CallGraphView::loadCurrentGraph()
         GraphLayout::GraphBlock block;
         block.entry = fcn->addr;
 
-        auto xrefs = PRzList { rz_analysis_function_get_xrefs_from(fcn), rz_list_free };
+        auto xrefs = fromOwned(rz_analysis_function_get_xrefs_from(fcn));
         auto calls = std::unordered_set<ut64>();
         for (const auto &xref : CutterRzList<RzAnalysisXRef>(xrefs.get())) {
             const auto x = xref->to;

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -193,9 +193,7 @@ void DisassemblerGraphView::loadCurrentGraph()
 
     windowTitle = tr("Graph");
     if (fcn && RZ_STR_ISNOTEMPTY(fcn->name)) {
-        std::unique_ptr<char, decltype(std::free) *> fcnName {
-            rz_str_escape_utf8_for_json(fcn->name, -1), std::free
-        };
+        auto fcnName = fromOwned(rz_str_escape_utf8_for_json(fcn->name, -1));
         windowTitle += QString("(%0)").arg(fcnName.get());
     } else {
         windowTitle += "(Empty)";
@@ -267,10 +265,8 @@ void DisassemblerGraphView::loadCurrentGraph()
         }
         rz_io_read_at(core->io, bbi->addr, buf.get(), (int)bbi->size);
 
-        std::unique_ptr<RzPVector, decltype(rz_pvector_free) *> vec {
-            rz_pvector_new(reinterpret_cast<RzPVectorFree>(rz_analysis_disasm_text_free)),
-            rz_pvector_free
-        };
+        auto vec = fromOwned(
+                rz_pvector_new(reinterpret_cast<RzPVectorFree>(rz_analysis_disasm_text_free)));
         if (!vec) {
             break;
         }

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -234,12 +234,10 @@ QVariant FunctionModel::data(const QModelIndex &index, int role) const
         QStringList summary {};
         {
             auto seeker = Core()->seekTemp(function.offset);
-            auto strings = std::unique_ptr<char, decltype(free) *> {
+            auto strings = fromOwnedCharPtr(
                 rz_core_print_disasm_strings(Core()->core(), RZ_CORE_DISASM_STRINGS_MODE_FUNCTION,
-                                             0, NULL),
-                free
-            };
-            summary = QString(strings.get()).split('\n', CUTTER_QT_SKIP_EMPTY_PARTS);
+                                             0, NULL));
+            summary = strings.split('\n', CUTTER_QT_SKIP_EMPTY_PARTS);
         }
 
         const QFont &fnt = Config()->getFont();

--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -21,8 +21,7 @@ VisualNavbar::VisualNavbar(MainWindow *main, QWidget *parent)
       graphicsView(new QGraphicsView),
       seekGraphicsItem(nullptr),
       PCGraphicsItem(nullptr),
-      main(main),
-      stats(nullptr, rz_core_analysis_stats_free)
+      main(main)
 {
     Q_UNUSED(parent);
 
@@ -119,7 +118,7 @@ void VisualNavbar::fetchStats()
 
     RzCoreLocked core(Core());
     stats.reset(nullptr);
-    RzList *list = rz_core_get_boundaries_prot(core, -1, NULL, "search");
+    auto list = fromOwned(rz_core_get_boundaries_prot(core, -1, NULL, "search"));
     if (!list) {
         return;
     }
@@ -127,7 +126,7 @@ void VisualNavbar::fetchStats()
     RzIOMap *map;
     ut64 from = UT64_MAX;
     ut64 to = 0;
-    CutterRzListForeach (list, iter, RzIOMap, map) {
+    CutterRzListForeach (list.get(), iter, RzIOMap, map) {
         ut64 f = rz_itv_begin(map->itv);
         ut64 t = rz_itv_end(map->itv);
         if (f < from) {
@@ -137,7 +136,6 @@ void VisualNavbar::fetchStats()
             to = t;
         }
     }
-    rz_list_free(list);
     to--; // rz_core_analysis_get_stats takes inclusive ranges
     if (to < from) {
         return;

--- a/src/widgets/VisualNavbar.h
+++ b/src/widgets/VisualNavbar.h
@@ -47,7 +47,7 @@ private:
     QGraphicsRectItem *PCGraphicsItem;
     MainWindow *main;
 
-    std::unique_ptr<RzCoreAnalysisStats, decltype(&rz_core_analysis_stats_free)> stats;
+    UniquePtrC<RzCoreAnalysisStats, &rz_core_analysis_stats_free> stats;
     unsigned int statsWidth = 0;
     unsigned int previousWidth = 0;
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Note that these changes are somewhat subjective so I would like to hear what others think whether it actually looks more readable to you. There is a bit of tradeoff between noise and being more explicit.


* Move some of the rizin C++ helpers from CutterCommon to RizinCpp and introduce a few new ones.
* make `QString fromOwnedCharPtr(char*)` available everywhere
* add `fromOwned(T*, void(*deleter)(T*)) -> std::unique_ptr` 
* overloads of `fromOwned(x)` for most common rizin containers like RzList and RzPVector which don't require manually specifying the free function


* refactor `CutterCore::tempSeek` implementation so that it doesn't abuse `unique_ptr`
* Replace  `applyAtSeek` and `returnAtSeek` with the existing `CutterCore::tempSeek`

those functions have a couple of downsides

1) Converting lambda to std::function has some overhead. It probably doesn't matter too much but there is a solution which doesn't require it.
2) (my subjective opinion) all the extra tokens  for declaring block of code as lambda adds noise making it more  difficult to read compared to regular block with temporary seek object at start.
3) in some of the cases core lock was done inside the lambda, which means that in theory the seek could change between  `applyAtSeek` reading seek position and calling the lambda


**Test plan (required)**

**Closing issues**

