### PR TITLE
Don't refresh graph breakpoints during redraw.

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -170,6 +170,7 @@ void DisassemblerGraphView::refreshView()
 {
     CutterGraphView::refreshView();
     loadCurrentGraph();
+    breakpoints = Core()->getBreakpointsAddresses();
     emit viewRefreshed();
 }
 
@@ -369,8 +370,6 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block,
     p.setBrush(Qt::gray);
     p.setFont(Config()->getFont());
     p.drawRect(blockRect);
-
-    breakpoints = Core()->getBreakpointsAddresses();
 
     // Render node
     DisassemblyBlock &db = disassembly_blocks[block.entry];


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**


Move the breakpoint refresh to common refresh function. Mainly doing this because cutter core access during redraw can easily cause UI to freeze while doing long action like "Run script".  Came across this when testing #3017. 

Even without that It doesn't make sense refreshing them when drawing each block.

**Test plan (required)**

* Select line and press F2 in disassembly (not necesarry to start debugging) make sure corresponding graph line gets hilighted
* start a long script using "Run script" in file menu, observe that GUI doesn't hang

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
