### PR TITLE
Set org domain to fix alt tab icon on Linux #3022

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -74,6 +74,9 @@ int main(int argc, char *argv[])
     qRegisterMetaType<QList<FunctionDescription>>();
 
     QCoreApplication::setOrganizationName("rizin");
+#ifndef Q_OS_MACOS // don't set on macOS so that it doesn't affect config path there
+    QCoreApplication::setOrganizationDomain("rizin.re");
+#endif
     QCoreApplication::setApplicationName("cutter");
 
     // Importing settings after setting rename, needs separate handling in addition to regular version to version upgrade.


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

See #3022 for the investigation I did to find out why it's broken.

From what I observed orgDomain is used when looking up .desktop file from which the icon information is read.


**Test plan (required)**

*  [x] settings path not changed on
   *  [x] macOS
   *  [x] Linux
   *  [x] Windows
* [x] appimage icon still works (from what I understand it uses different mechanism)

When testing 

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #3022 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
