### PR TITLE
Make library list in dashboard scrollbable when needed #3019

### DIFF
--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -133,32 +133,20 @@ void Dashboard::updateContents()
     setPlainText(ui->codeSizeLineEdit, QString::number(code) + " bytes");
     setPlainText(ui->percentageLineEdit, QString::number(precentage) + "%");
 
-    // dunno: why not label->setText(lines.join("\n")?
-    while (ui->verticalLayout_2->count() > 0) {
-        QLayoutItem *item = ui->verticalLayout_2->takeAt(0);
-        if (item != nullptr) {
-            QWidget *w = item->widget();
-            if (w != nullptr) {
-                w->deleteLater();
-            }
-
-            delete item;
-        }
-    }
-
+    ui->libraryList->setPlainText("");
     const RzList *libs = bf ? rz_bin_object_get_libs(bf->o) : nullptr;
     if (libs) {
+        QString libText;
+        bool first = true;
         for (const auto &lib : CutterRzList<char>(libs)) {
-            auto *label = new QLabel(this);
-            label->setText(lib);
-            label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-            label->setTextInteractionFlags(Qt::TextSelectableByMouse);
-            ui->verticalLayout_2->addWidget(label);
+            if (!first) {
+                libText.append("\n");
+            }
+            libText.append(lib);
+            first = false;
         }
+        ui->libraryList->setPlainText(libText);
     }
-
-    QSpacerItem *spacer = new QSpacerItem(1, 1, QSizePolicy::Fixed, QSizePolicy::Expanding);
-    ui->verticalLayout_2->addSpacerItem(spacer);
 
     // Check if signature info and version info available
     if (!Core()->getSignatureInfo().size()) {

--- a/src/widgets/Dashboard.ui
+++ b/src/widgets/Dashboard.ui
@@ -42,7 +42,7 @@
        <enum>QFrame::Plain</enum>
       </property>
       <property name="verticalScrollBarPolicy">
-       <enum>Qt::ScrollBarAlwaysOff</enum>
+       <enum>Qt::ScrollBarAsNeeded</enum>
       </property>
       <property name="horizontalScrollBarPolicy">
        <enum>Qt::ScrollBarAlwaysOff</enum>
@@ -1331,10 +1331,33 @@
                  </item>
                 </layout>
                </item>
+               <item>
+                <spacer name="verticalSpacer_3">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
               </layout>
              </item>
              <item>
-              <layout class="QVBoxLayout" name="verticalLayout_2"/>
+              <widget class="QPlainTextEdit" name="libraryList">
+               <property name="horizontalScrollBarPolicy">
+                <enum>Qt::ScrollBarAlwaysOff</enum>
+               </property>
+               <property name="lineWrapMode">
+                <enum>QPlainTextEdit::NoWrap</enum>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+               </property>
+              </widget>
              </item>
             </layout>
            </item>


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Use text area for displaying the libraries. This ensures that scrollbar is added when necessary and makes it much easier to select and copy them. 


**Test plan (required)**

Before:
![imageBefore](https://user-images.githubusercontent.com/7101031/184640439-3440c7f9-2294-4d5e-aa09-ef6421e5f1cd.png)
After:
![imageAfter](https://user-images.githubusercontent.com/7101031/184640567-30671f97-3a30-421d-bee0-fcacb6956287.png)


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #3019
