### PR TITLE
Support editing in hex editor

### DIFF
--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -26,6 +26,7 @@
 static constexpr uint64_t MAX_COPY_SIZE = 128 * 1024 * 1024;
 static constexpr int MAX_LINE_WIDTH_PRESET = 32;
 static constexpr int MAX_LINE_WIDTH_BYTES = 128 * 1024;
+static constexpr int WARNING_TIME_MS = 500;
 
 HexWidget::HexWidget(QWidget *parent)
     : QScrollArea(parent),
@@ -42,7 +43,8 @@ HexWidget::HexWidget(QWidget *parent)
       showHeader(true),
       showAscii(true),
       showExHex(true),
-      showExAddr(true)
+      showExAddr(true),
+      warningTimer(this)
 {
     setMouseTracking(true);
     setFocusPolicy(Qt::FocusPolicy::StrongFocus);
@@ -103,7 +105,7 @@ HexWidget::HexWidget(QWidget *parent)
     actionItemBigEndian = new QAction(tr("Big Endian"), this);
     actionItemBigEndian->setCheckable(true);
     actionItemBigEndian->setEnabled(false);
-    connect(actionItemBigEndian, &QAction::triggered, this, &HexWidget::setItemEndianess);
+    connect(actionItemBigEndian, &QAction::triggered, this, &HexWidget::setItemEndianness);
 
     actionHexPairs = new QAction(tr("Bytes as pairs"), this);
     actionHexPairs->setCheckable(true);
@@ -125,14 +127,14 @@ HexWidget::HexWidget(QWidget *parent)
     actionComment = new QAction(tr("Add Comment"), this);
     actionComment->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
     actionComment->setShortcut(Qt::Key_Semicolon);
-    connect(actionComment, &QAction::triggered, this, &HexWidget::on_actionAddComment_triggered);
+    connect(actionComment, &QAction::triggered, this, &HexWidget::onActionAddCommentTriggered);
     addAction(actionComment);
 
     // delete comment option
     actionDeleteComment = new QAction(tr("Delete Comment"), this);
     actionDeleteComment->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
     connect(actionDeleteComment, &QAction::triggered, this,
-            &HexWidget::on_actionDeleteComment_triggered);
+            &HexWidget::onActionDeleteCommentTriggered);
     addAction(actionDeleteComment);
 
     actionSelectRange = new QAction(tr("Select range"), this);
@@ -183,8 +185,13 @@ HexWidget::HexWidget(QWidget *parent)
     connect(actionIncDec, &QAction::triggered, this, &HexWidget::w_increaseDecrease);
     actionsWriteOther.append(actionIncDec);
 
+    actionKeyboardEdit = new QAction(tr("Edit with keyboard"), this);
+    actionKeyboardEdit->setCheckable(true);
+    connect(actionKeyboardEdit, &QAction::triggered, this, &HexWidget::onKeyboardEditTriggered);
+    connect(actionKeyboardEdit, &QAction::toggled, this, &HexWidget::onKeyboardEditChanged);
+
     connect(this, &HexWidget::selectionChanged, this,
-            [this](Selection selection) { actionCopy->setEnabled(!selection.empty); });
+            [this](Selection newSelection) { actionCopy->setEnabled(!newSelection.empty); });
 
     updateMetrics();
     updateItemLength();
@@ -202,9 +209,10 @@ HexWidget::HexWidget(QWidget *parent)
     cursor.startBlinking();
 
     updateColors();
-}
 
-HexWidget::~HexWidget() {}
+    warningTimer.setSingleShot(true);
+    connect(&warningTimer, &QTimer::timeout, this, &HexWidget::hideWarningRect);
+}
 
 void HexWidget::setMonospaceFont(const QFont &font)
 {
@@ -228,6 +236,8 @@ void HexWidget::setItemSize(int nbytes)
     if (!values.contains(nbytes))
         return;
 
+    finishEditingWord();
+
     itemByteLen = nbytes;
     if (itemByteLen > rowSizeBytes) {
         rowSizeBytes = itemByteLen;
@@ -236,7 +246,12 @@ void HexWidget::setItemSize(int nbytes)
     actionsItemFormat.at(ItemFormatFloat)->setEnabled(nbytes >= 4);
     actionItemBigEndian->setEnabled(nbytes != 1);
 
+    refreshWordEditState();
+
     updateItemLength();
+    if (!cursorOnAscii && cursor.address % itemByteLen) {
+        moveCursor(-int(cursor.address % itemByteLen));
+    }
     fetchData();
     updateCursorMeta();
 
@@ -245,6 +260,8 @@ void HexWidget::setItemSize(int nbytes)
 
 void HexWidget::setItemFormat(ItemFormat format)
 {
+    finishEditingWord();
+
     itemFormat = format;
 
     bool sizeEnabled = true;
@@ -252,6 +269,8 @@ void HexWidget::setItemFormat(ItemFormat format)
         sizeEnabled = false;
     actionsItemSize.at(0)->setEnabled(sizeEnabled);
     actionsItemSize.at(1)->setEnabled(sizeEnabled);
+
+    refreshWordEditState();
 
     updateItemLength();
     fetchData();
@@ -382,7 +401,7 @@ void HexWidget::selectRange(RVA start, RVA end)
 
 void HexWidget::clearSelection()
 {
-    setCursorAddr(cursor.address, false);
+    setCursorAddr(BasicCursor(cursor.address), false);
     emit selectionChanged(getSelection());
 }
 
@@ -393,7 +412,16 @@ HexWidget::Selection HexWidget::getSelection()
 
 void HexWidget::seek(uint64_t address)
 {
-    setCursorAddr(address);
+    if (!cursorOnAscii) {
+        // when other widget causes seek to the middle of word
+        // switch to ascii column which operates with byte positions
+        auto viewOffset = startAddress % itemByteLen;
+        auto addrOffset = address % itemByteLen;
+        if ((addrOffset + itemByteLen - viewOffset) % itemByteLen) {
+            setCursorOnAscii(true);
+        }
+    }
+    setCursorAddr(BasicCursor(address));
 }
 
 void HexWidget::refresh()
@@ -402,8 +430,9 @@ void HexWidget::refresh()
     viewport()->update();
 }
 
-void HexWidget::setItemEndianess(bool bigEndian)
+void HexWidget::setItemEndianness(bool bigEndian)
 {
+    finishEditingWord();
     itemBigEndian = bigEndian;
 
     updateCursorMeta(); // Update cached item character
@@ -422,6 +451,7 @@ void HexWidget::updateColors()
     defColor = Config()->getColor("btext");
     addrColor = Config()->getColor("func_var_addr");
     diffColor = Config()->getColor("graph.diff.unmatch");
+    warningColor = QColor("red");
 
     updateCursorMeta();
     viewport()->update();
@@ -450,6 +480,11 @@ void HexWidget::paintEvent(QPaintEvent *event)
     drawItemArea(painter);
     drawAsciiArea(painter);
 
+    if (warningRectVisible) {
+        painter.setPen(warningColor);
+        painter.drawRect(warningRect);
+    }
+
     if (!cursorEnabled)
         return;
 
@@ -465,6 +500,11 @@ void HexWidget::updateWidth()
         max += charWidth;
     horizontalScrollBar()->setMaximum(max);
     horizontalScrollBar()->setSingleStep(charWidth);
+}
+
+bool HexWidget::isFixedWidth() const
+{
+    return itemFormat == ItemFormatHex || itemFormat == ItemFormatOct;
 }
 
 void HexWidget::resizeEvent(QResizeEvent *event)
@@ -526,13 +566,88 @@ void HexWidget::mousePressEvent(QMouseEvent *event)
     if (event->button() == Qt::LeftButton) {
         bool selectingData = itemArea.contains(pos);
         bool selecting = selectingData || asciiArea.contains(pos);
+        bool holdingShift = event->modifiers() == Qt::ShiftModifier;
+
+        // move cursor within actively edited item
+        if (selectingData && !holdingShift && editWordState >= EditWordState::WriteNotEdited) {
+
+            auto editWordArea = itemRectangle(cursor.address - startAddress);
+            if (editWordArea.contains(pos)) {
+                int wordOffset = 0;
+                auto cursorPosition = screenPosToAddr(pos, false, &wordOffset);
+                if (cursorPosition.address == cursor.address
+                    // allow selecting after last character only when cursor limited to current word
+                    && (wordOffset < editWord.length()
+                        || navigationMode == HexNavigationMode::WordChar)) {
+                    editWordPos = std::max(0, wordOffset);
+                    editWordPos = std::min(editWordPos, editWord.length());
+
+                    if (isFixedWidth()) {
+                        updatingSelection = true;
+                        auto selectionCursor = cursorPosition;
+                        if (editWordPos > itemCharLen / 2) {
+                            selectionCursor += itemByteLen;
+                        }
+                        selection.init(selectionCursor);
+                    }
+
+                    viewport()->update();
+                    return;
+                }
+            }
+        }
+
+        // cursor within any item if the mode allows
+        if (selectingData && !holdingShift && editWordState >= EditWordState::WriteNotStarted
+            && navigationMode == HexNavigationMode::AnyChar) {
+            updatingSelection = true;
+            setCursorOnAscii(false);
+            int wordOffset = 0;
+            auto cursorPosition = screenPosToAddr(pos, false, &wordOffset);
+            finishEditingWord();
+            if (isFixedWidth() && wordOffset >= itemCharLen - itemPrefixLen) {
+                wordOffset = 0;
+                cursorPosition += itemByteLen;
+            }
+            setCursorAddr(cursorPosition, holdingShift);
+            auto selectionPosition = currentAreaPosToAddr(pos, true);
+            selection.init(selectionPosition);
+            emit selectionChanged(getSelection());
+
+            if (wordOffset > 0) {
+                startEditWord();
+                editWordPos = std::min(wordOffset, editWord.length() - 1);
+            }
+            viewport()->update();
+            return;
+        }
+
         if (selecting) {
+            finishEditingWord();
+
             updatingSelection = true;
             setCursorOnAscii(!selectingData);
             auto cursorPosition = currentAreaPosToAddr(pos, true);
-            setCursorAddr(cursorPosition, event->modifiers() == Qt::ShiftModifier);
+            setCursorAddr(cursorPosition, holdingShift);
             viewport()->update();
         }
+    }
+}
+
+void HexWidget::mouseDoubleClickEvent(QMouseEvent *event)
+{
+    QPoint pos(event->pos());
+    pos.rx() += horizontalScrollBar()->value();
+
+    if (event->button() == Qt::LeftButton && !isFixedWidth()
+        && editWordState == EditWordState::WriteNotStarted && itemArea.contains(pos)) {
+        int wordOffset = 0;
+        auto cursorPosition = screenPosToAddr(pos, false, &wordOffset);
+        setCursorAddr(cursorPosition, false);
+        startEditWord();
+        int padding = std::max(0, itemCharLen - editWord.length());
+        editWordPos = std::max(0, wordOffset - padding);
+        editWordPos = std::min(editWordPos, editWord.length());
     }
 }
 
@@ -540,7 +655,7 @@ void HexWidget::mouseReleaseEvent(QMouseEvent *event)
 {
     if (event->button() == Qt::LeftButton) {
         if (selection.isEmpty()) {
-            selection.init(cursor.address);
+            selection.init(BasicCursor(cursor.address));
             cursorEnabled = true;
         }
         updatingSelection = false;
@@ -560,13 +675,14 @@ void HexWidget::wheelEvent(QWheelEvent *event)
         startAddress = 0;
     } else if (delta > 0 && data->maxIndex() < static_cast<uint64_t>(bytesPerScreen())) {
         startAddress = 0;
+    } else if ((data->maxIndex() - startAddress)
+               <= static_cast<uint64_t>(bytesPerScreen() + delta - 1)) {
+        startAddress = (data->maxIndex() - bytesPerScreen()) + 1;
     } else {
         startAddress += delta;
     }
+
     fetchData();
-    if ((data->maxIndex() - startAddress) <= static_cast<uint64_t>(bytesPerScreen() + delta - 1)) {
-        startAddress = (data->maxIndex() - bytesPerScreen()) + 1;
-    }
     if (cursor.address >= startAddress && cursor.address <= lastVisibleAddr()) {
         /* Don't enable cursor blinking if selection isn't empty */
         cursorEnabled = selection.isEmpty();
@@ -575,6 +691,297 @@ void HexWidget::wheelEvent(QWheelEvent *event)
         cursorEnabled = false;
     }
     viewport()->update();
+}
+
+bool HexWidget::validCharForEdit(QChar digit)
+{
+    switch (itemFormat) {
+    case ItemFormatHex:
+        return (digit >= '0' && digit <= '9') || (digit >= 'a' && digit <= 'f')
+                || (digit >= 'A' && digit <= 'F');
+    case ItemFormatOct: {
+        if (editWordPos > 0) {
+            return (digit >= '0' && digit <= '7');
+        } else {
+            int bitsInMSD = (itemByteLen * 8) % 3;
+            int biggestDigit = (1 << bitsInMSD) - 1;
+            return digit >= '0' && digit <= char('0' + biggestDigit);
+        }
+    }
+    case ItemFormatDec:
+        return (digit >= '0' && digit <= '9');
+    case ItemFormatSignedDec:
+        return (digit >= '0' && digit <= '9') || digit == '-';
+    case ItemFormatFloat:
+        return (digit >= '0' && digit <= '9') || digit == '-' || digit == '+' || digit == '.'
+                || digit == ',' || digit == '+' || digit == 'e' || digit == 'E' || digit == 'i'
+                || digit == 'n' || digit == 'f' || digit == 'I' || digit == 'N' || digit == 'F'
+                || digit == 'a' || digit == 'A';
+    }
+
+    return false;
+}
+
+void HexWidget::movePrevEditCharAny()
+{
+    if (!selection.isEmpty()) {
+        clearSelection();
+    }
+    editWordPos -= 1;
+    if (editWordPos < 0) {
+        finishEditingWord();
+        if (moveCursor(-itemByteLen, false, OverflowMove::Ignore)) {
+            startEditWord();
+            editWordPos = editWord.length() - 1;
+        }
+    }
+    viewport()->update();
+}
+
+void HexWidget::typeOverwriteModeChar(QChar c)
+{
+    if (editWordState < EditWordState::WriteNotEdited || !isFixedWidth()) {
+        return;
+    }
+    editWord[editWordPos] = c;
+    editWordPos++;
+    editWordState = EditWordState::WriteEdited;
+    if (editWordPos >= editWord.length()) {
+        finishEditingWord();
+        bool moved = moveCursor(itemByteLen, false, OverflowMove::Ignore);
+        startEditWord();
+        if (!moved) {
+            editWordPos = editWord.length() - 1;
+        }
+    }
+}
+
+HexWidget::HexNavigationMode HexWidget::defaultNavigationMode()
+{
+    switch (editWordState) {
+    case EditWordState::Read:
+        return HexNavigationMode::Words;
+    case EditWordState::WriteNotStarted:
+        return isFixedWidth() ? HexNavigationMode::AnyChar : HexNavigationMode::Words;
+    case EditWordState::WriteNotEdited:
+    case EditWordState::WriteEdited:
+        return isFixedWidth() ? HexNavigationMode::AnyChar : HexNavigationMode::WordChar;
+    }
+    return HexNavigationMode::Words;
+}
+
+void HexWidget::refreshWordEditState()
+{
+    navigationMode = defaultNavigationMode();
+}
+
+bool HexWidget::handleAsciiWrite(QKeyEvent *event)
+{
+    if (!cursorOnAscii || !canKeyboardEdit()) {
+        return false;
+    }
+    if (event->key() == Qt::Key_Backspace || event->matches(QKeySequence::Backspace)) {
+        if (!selection.isEmpty()) {
+            writeZeros(selection.start(), selection.size());
+        } else {
+            moveCursor(-1, false);
+            writeZeros(cursor.address, 1);
+        }
+        return true;
+    }
+    if (event->key() == Qt::Key_Delete || event->matches(QKeySequence::Delete)) {
+        if (!selection.isEmpty()) {
+            writeZeros(selection.start(), selection.size());
+        } else {
+            writeZeros(cursor.address, 1);
+            moveCursor(1, false);
+        }
+        return true;
+    }
+    QString text;
+    if (event->matches(QKeySequence::Paste)) {
+        text = QApplication::clipboard()->text();
+        if (text.length() <= 0) {
+            return false;
+        }
+    } else {
+        text = event->text();
+        if (text.length() <= 0) {
+            return false;
+        }
+        QChar c = text[0];
+        if (c <= 0x1f || c == 0x7f) {
+            return false;
+        }
+    }
+
+    auto bytes = text.toUtf8(); // TODO:#3028 use selected text encoding
+    auto address = getLocationAddress();
+    clearSelection();
+    data->write(reinterpret_cast<const uint8_t *>(bytes.data()), address, bytes.length());
+    seek(address + bytes.length());
+    viewport()->update();
+    return true;
+}
+
+bool HexWidget::handleNumberWrite(QKeyEvent *event)
+{
+    if (editWordState < EditWordState::WriteNotStarted) {
+        return false;
+    }
+    bool overwrite = isFixedWidth();
+    auto keyText = event->text();
+    bool editingWord = editWordState >= EditWordState::WriteNotEdited;
+    if (keyText.length() > 0 && validCharForEdit(keyText[0])) {
+        if (!selection.isEmpty()) {
+            setCursorAddr(BasicCursor(selection.start()));
+        }
+        if (!editingWord) {
+            startEditWord();
+        }
+        if (overwrite) {
+            typeOverwriteModeChar(keyText[0]);
+        } else if (!editingWord /* && !overwrite */) {
+            editWord = keyText;
+            editWordPos = editWord.length();
+            editWordState = EditWordState::WriteEdited;
+        } else if (itemFormat == ItemFormatFloat || editWord.length() < itemCharLen) {
+            editWord.insert(editWordPos, keyText);
+            editWordPos += keyText.length();
+            editWordState = EditWordState::WriteEdited;
+        }
+        return true;
+    }
+    if (event->matches(QKeySequence::Paste) && (editingWord || overwrite)) {
+        QString text = QApplication::clipboard()->text();
+        if (text.length() > 0) {
+            if (overwrite) {
+                startEditWord();
+                for (QChar c : text) {
+                    if (validCharForEdit(c)) {
+                        typeOverwriteModeChar(c);
+                    }
+                }
+            } else {
+                editWord.insert(editWordPos, text);
+                editWordPos += text.length();
+                editWordState = EditWordState::WriteEdited;
+            }
+        }
+        return true;
+    }
+    if (editingWord) {
+        if (event->matches(QKeySequence::Cancel)) {
+            cancelEditedWord();
+            return true;
+        } else if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
+            bool needToAdvance =
+                    !(editWordPos == 0 && overwrite && editWordState < EditWordState::WriteEdited);
+            if (finishEditingWord(false) && needToAdvance) {
+                moveCursor(itemByteLen);
+            }
+            return true;
+        }
+    }
+    if (event->matches(QKeySequence::Delete)) {
+        if (!selection.isEmpty()) {
+            writeZeros(selection.start(), selection.size());
+            clearSelection();
+        } else {
+            startEditWord();
+            if (overwrite) {
+                typeOverwriteModeChar('0');
+            } else if (editWordPos < editWord.length()) {
+                editWord.remove(editWordPos, 1);
+                editWordState = EditWordState::WriteEdited;
+            }
+        }
+        return true;
+    }
+    if (event->matches(QKeySequence::DeleteEndOfWord) && selection.isEmpty()) {
+        startEditWord();
+        if (overwrite) {
+            for (int i = editWordPos; i < editWord.length(); i++) {
+                typeOverwriteModeChar('0');
+            }
+        }
+        if (editWordPos < editWord.length()) {
+            editWord.remove(editWordPos, editWord.length());
+            editWordState = EditWordState::WriteEdited;
+        }
+        return true;
+    }
+    if (event->matches(QKeySequence::DeleteStartOfWord) && selection.isEmpty()) {
+        if (!editingWord) {
+            if (!moveCursor(-itemByteLen, false, OverflowMove::Ignore)) {
+                return false;
+            }
+            startEditWord();
+            editWordPos = editWord.length();
+        }
+        if (overwrite) {
+            while (editWordPos > 0) {
+                editWordPos--;
+                editWord[editWordPos] = '0';
+            }
+            editWordState = EditWordState::WriteEdited;
+            return true;
+        } else {
+            if (editWordPos > 0) {
+                editWord.remove(0, editWordPos);
+                editWordState = EditWordState::WriteEdited;
+                editWordPos = 0;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    if (event->key() == Qt::Key_Backspace) {
+        if (!selection.isEmpty()) {
+            writeZeros(selection.start(), selection.size());
+            clearSelection();
+            setCursorAddr(BasicCursor(selection.start()), false);
+            return true;
+        } else {
+            if (!editingWord || (overwrite && editWordPos == 0)) {
+                if (!moveCursor(-itemByteLen, false, OverflowMove::Ignore)) {
+                    return false;
+                }
+                startEditWord();
+                editWordPos = editWord.length();
+            }
+            if (editWordPos > 0) {
+                editWordPos -= 1;
+                if (overwrite) {
+                    editWord[editWordPos] = '0';
+                } else {
+                    editWord.remove(editWordPos, 1);
+                }
+                editWordState = EditWordState::WriteEdited;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    return false;
+}
+
+bool HexWidget::event(QEvent *event)
+{
+    // prefer treating keys like 's' 'g' '.' as typing input instead of global shortcuts
+    if (event->type() == QEvent::ShortcutOverride) {
+        auto keyEvent = static_cast<QKeyEvent *>(event);
+        auto modifiers = keyEvent->modifiers();
+        if ((modifiers == Qt::NoModifier || modifiers == Qt::ShiftModifier)
+            && keyEvent->key() < Qt::Key_Escape && canKeyboardEdit()) {
+            keyEvent->accept();
+            return true;
+        }
+    }
+
+    return QScrollArea::event(event);
 }
 
 void HexWidget::keyPressEvent(QKeyEvent *event)
@@ -591,26 +998,126 @@ void HexWidget::keyPressEvent(QKeyEvent *event)
         }
         return false;
     };
-    if (moveOrSelect(QKeySequence::MoveToNextLine, QKeySequence::SelectNextLine)) {
-        moveCursor(itemRowByteLen(), select);
-    } else if (moveOrSelect(QKeySequence::MoveToPreviousLine, QKeySequence::SelectPreviousLine)) {
-        moveCursor(-itemRowByteLen(), select);
-    } else if (moveOrSelect(QKeySequence::MoveToNextChar, QKeySequence::SelectNextChar)) {
-        moveCursor(cursorOnAscii ? 1 : itemByteLen, select);
-    } else if (moveOrSelect(QKeySequence::MoveToPreviousChar, QKeySequence::SelectPreviousChar)) {
-        moveCursor(cursorOnAscii ? -1 : -itemByteLen, select);
-    } else if (moveOrSelect(QKeySequence::MoveToNextPage, QKeySequence::SelectNextPage)) {
-        moveCursor(bytesPerScreen(), select);
-    } else if (moveOrSelect(QKeySequence::MoveToPreviousPage, QKeySequence::SelectPreviousPage)) {
-        moveCursor(-bytesPerScreen(), select);
-    } else if (moveOrSelect(QKeySequence::MoveToStartOfLine, QKeySequence::SelectStartOfLine)) {
-        int linePos = int((cursor.address % itemRowByteLen()) - (startAddress % itemRowByteLen()));
-        moveCursor(-linePos, select);
-    } else if (moveOrSelect(QKeySequence::MoveToEndOfLine, QKeySequence::SelectEndOfLine)) {
-        int linePos = int((cursor.address % itemRowByteLen()) - (startAddress % itemRowByteLen()));
-        moveCursor(itemRowByteLen() - linePos, select);
+
+    if (canKeyboardEdit()) {
+        if (handleAsciiWrite(event)) {
+            viewport()->update();
+            return;
+        }
+        if (editWordState >= EditWordState::WriteNotStarted && !cursorOnAscii) {
+            if (handleNumberWrite(event)) {
+                viewport()->update();
+                return;
+            }
+        }
     }
-    // viewport()->update();
+
+    if (cursorOnAscii || navigationMode == HexNavigationMode::Words
+        || navigationMode == HexNavigationMode::AnyChar) {
+        if (moveOrSelect(QKeySequence::MoveToNextPage, QKeySequence::SelectNextPage)) {
+            moveCursor(bytesPerScreen(), select);
+        } else if (moveOrSelect(QKeySequence::MoveToPreviousPage,
+                                QKeySequence::SelectPreviousPage)) {
+            moveCursor(-bytesPerScreen(), select);
+        } else if (moveOrSelect(QKeySequence::MoveToStartOfLine, QKeySequence::SelectStartOfLine)) {
+            int linePos =
+                    int((cursor.address % itemRowByteLen()) - (startAddress % itemRowByteLen()));
+            moveCursor(-linePos, select);
+        } else if (moveOrSelect(QKeySequence::MoveToEndOfLine, QKeySequence::SelectEndOfLine)) {
+            int linePos =
+                    int((cursor.address % itemRowByteLen()) - (startAddress % itemRowByteLen()));
+            moveCursor(itemRowByteLen() - linePos, select);
+        }
+    }
+
+    if (navigationMode == HexNavigationMode::Words || cursorOnAscii) {
+        if (moveOrSelect(QKeySequence::MoveToNextLine, QKeySequence::SelectNextLine)) {
+            moveCursor(itemRowByteLen(), select, OverflowMove::Ignore);
+        } else if (moveOrSelect(QKeySequence::MoveToPreviousLine,
+                                QKeySequence::SelectPreviousLine)) {
+            moveCursor(-itemRowByteLen(), select, OverflowMove::Ignore);
+        } else if (moveOrSelect(QKeySequence::MoveToNextChar, QKeySequence::SelectNextChar)
+                   || moveOrSelect(QKeySequence::MoveToNextWord, QKeySequence::SelectNextWord)) {
+            moveCursor(cursorOnAscii ? 1 : itemByteLen, select);
+        } else if (moveOrSelect(QKeySequence::MoveToPreviousChar, QKeySequence::SelectPreviousChar)
+                   || moveOrSelect(QKeySequence::MoveToPreviousWord,
+                                   QKeySequence::SelectPreviousWord)) {
+            moveCursor(cursorOnAscii ? -1 : -itemByteLen, select);
+        }
+    } else if (navigationMode == HexNavigationMode::AnyChar && !cursorOnAscii) {
+        if (moveOrSelect(QKeySequence::MoveToNextLine, QKeySequence::SelectNextLine)) {
+            moveCursorKeepEditOffset(itemRowByteLen(), select, OverflowMove::Ignore);
+        } else if (moveOrSelect(QKeySequence::MoveToPreviousLine,
+                                QKeySequence::SelectPreviousLine)) {
+            moveCursorKeepEditOffset(-itemRowByteLen(), select, OverflowMove::Ignore);
+        } else if (moveOrSelect(QKeySequence::MoveToNextChar, QKeySequence::SelectNextChar)) {
+            if (select) {
+                moveCursor(itemByteLen, select);
+            } else {
+                if (!selection.isEmpty()) {
+                    clearSelection();
+                }
+                if (editWordState == EditWordState::WriteNotStarted) {
+                    startEditWord();
+                }
+                editWordPos += 1;
+                if (editWordPos >= editWord.length()) {
+                    bool moved = moveCursor(itemByteLen, false, OverflowMove::Ignore);
+                    startEditWord();
+                    if (!moved) {
+                        editWordPos = editWord.length() - 1;
+                    }
+                }
+            }
+            viewport()->update();
+        } else if (event->matches(QKeySequence::MoveToPreviousChar)) {
+            movePrevEditCharAny();
+        } else if (event->matches(QKeySequence::SelectPreviousChar)) {
+            moveCursor(-itemByteLen, true);
+        } else if (moveOrSelect(QKeySequence::MoveToNextWord, QKeySequence::SelectNextWord)) {
+            moveCursor(itemByteLen, select);
+        } else if (event->matches(QKeySequence::MoveToPreviousWord)) {
+            if (editWordPos > 0) {
+                editWordPos = 0;
+                viewport()->update();
+            } else {
+                moveCursor(-itemByteLen, false);
+            }
+        } else if (event->matches(QKeySequence::SelectPreviousWord)) {
+            moveCursor(-itemByteLen, true);
+        }
+    } else if (navigationMode == HexNavigationMode::WordChar) {
+        if (event->matches(QKeySequence::MoveToNextChar)) {
+            editWordPos = std::min(editWord.length(), editWordPos + 1);
+            viewport()->update();
+        } else if (event->matches(QKeySequence::MoveToPreviousChar)) {
+            editWordPos = std::max(0, editWordPos - 1);
+            viewport()->update();
+        } else if (event->matches(QKeySequence::MoveToStartOfLine)) {
+            editWordPos = 0;
+            viewport()->update();
+        } else if (event->matches(QKeySequence::MoveToEndOfLine)) {
+            editWordPos = editWord.length();
+            viewport()->update();
+        } else if (event->matches(QKeySequence::MoveToPreviousWord)) {
+            if (editWordPos > 0) {
+                editWordPos = 0;
+            } else {
+                moveCursor(-itemByteLen, select);
+                startEditWord();
+            }
+            viewport()->update();
+        } else if (event->matches(QKeySequence::MoveToNextWord)) {
+            if (editWordPos < editWord.length()) {
+                editWordPos = editWord.length();
+            } else {
+                moveCursor(itemByteLen, select);
+                startEditWord();
+                editWordPos = editWord.length();
+            }
+            viewport()->update();
+        }
+    }
 }
 
 void HexWidget::contextMenuEvent(QContextMenuEvent *event)
@@ -645,7 +1152,11 @@ void HexWidget::contextMenuEvent(QContextMenuEvent *event)
         actionComment->setText(tr("Edit Comment"));
     }
 
-    QMenu *menu = new QMenu();
+    if (!ioModesController.canWrite()) {
+        actionKeyboardEdit->setChecked(false);
+    }
+
+    auto *menu = new QMenu(this);
     QMenu *sizeMenu = menu->addMenu(tr("Item size:"));
     sizeMenu->addActions(actionsItemSize);
     QMenu *formatMenu = menu->addMenu(tr("Item format:"));
@@ -657,6 +1168,8 @@ void HexWidget::contextMenuEvent(QContextMenuEvent *event)
     writeMenu->addActions(actionsWriteString);
     writeMenu->addSeparator();
     writeMenu->addActions(actionsWriteOther);
+    menu->addAction(actionKeyboardEdit);
+
     menu->addSeparator();
     menu->addAction(actionCopy);
     disableOutsideSelectionActions(mouseOutsideSelection);
@@ -700,23 +1213,20 @@ void HexWidget::copy()
 
 void HexWidget::copyAddress()
 {
-    uint64_t addr = cursor.address;
-    if (!selection.isEmpty()) {
-        addr = selection.start();
-    }
+    uint64_t addr = getLocationAddress();
     QClipboard *clipboard = QApplication::clipboard();
     clipboard->setText(RzAddressString(addr));
 }
 
 // slot for add comment action
-void HexWidget::on_actionAddComment_triggered()
+void HexWidget::onActionAddCommentTriggered()
 {
     uint64_t addr = cursor.address;
     CommentsDialog::addOrEditComment(addr, this);
 }
 
 // slot for deleting comment action
-void HexWidget::on_actionDeleteComment_triggered()
+void HexWidget::onActionDeleteCommentTriggered()
 {
     uint64_t addr = cursor.address;
     Core()->delComment(addr);
@@ -729,6 +1239,20 @@ void HexWidget::onRangeDialogAccepted()
         return;
     }
     selectRange(rangeDialog.getStartAddress(), rangeDialog.getEndAddress());
+}
+
+void HexWidget::writeZeros(uint64_t address, uint64_t length)
+{
+    const uint64_t MAX_BUFFER = 1024;
+    std::vector<uint8_t> zeroes(std::min(MAX_BUFFER, length), 0);
+    while (length > zeroes.size()) {
+        data->write(zeroes.data(), address, zeroes.size());
+        address += zeroes.size();
+        length -= zeroes.size();
+    }
+    if (length > 0) {
+        data->write(zeroes.data(), address, length);
+    }
 }
 
 void HexWidget::w_writeString()
@@ -825,10 +1349,7 @@ void HexWidget::w_writeZeros()
         return;
     }
     {
-        RzCoreLocked core(Core());
-        auto *buf = (uint8_t *)calloc(len, sizeof(uint8_t));
-        rz_core_write_at(core, getLocationAddress(), buf, len);
-        free(buf);
+        writeZeros(getLocationAddress(), len);
     }
     refresh();
 }
@@ -964,15 +1485,42 @@ void HexWidget::w_writeCString()
     refresh();
 }
 
+void HexWidget::onKeyboardEditTriggered(bool enabled)
+{
+    if (!enabled) {
+        return;
+    }
+    if (!ioModesController.prepareForWriting()) {
+        actionKeyboardEdit->setChecked(false);
+    }
+}
+
+void HexWidget::onKeyboardEditChanged(bool enabled)
+{
+    if (!enabled) {
+        finishEditingWord();
+        navigationMode = HexNavigationMode::Words;
+        editWordState = EditWordState::Read;
+    } else {
+        editWordState = EditWordState::WriteNotStarted;
+        navigationMode = defaultNavigationMode();
+    }
+    updateCursorMeta();
+    viewport()->update();
+}
+
 void HexWidget::updateItemLength()
 {
     itemPrefixLen = 0;
+    itemPrefix.clear();
 
     switch (itemFormat) {
     case ItemFormatHex:
         itemCharLen = 2 * itemByteLen;
-        if (itemByteLen > 1 && showExHex)
+        if (itemByteLen > 1 && showExHex) {
             itemPrefixLen = hexPrefix.length();
+            itemPrefix = hexPrefix;
+        }
         break;
     case ItemFormatOct:
         itemCharLen = (itemByteLen * 8 + 3) / 3;
@@ -1056,7 +1604,13 @@ void HexWidget::drawCursor(QPainter &painter, bool shadow)
         QPen pen(Qt::gray);
         pen.setStyle(Qt::DashLine);
         painter.setPen(pen);
-        shadowCursor.screenPos.setWidth(cursorOnAscii ? itemWidth() : charWidth);
+        qreal shadowWidth = charWidth;
+        if (cursorOnAscii) {
+            shadowWidth = itemWidth();
+        } else if (editWordState >= EditWordState::WriteNotEdited) {
+            shadowWidth = itemByteLen * charWidth;
+        }
+        shadowCursor.screenPos.setWidth(shadowWidth);
         painter.drawRect(shadowCursor.screenPos);
         painter.setPen(Qt::SolidLine);
     }
@@ -1102,20 +1656,26 @@ void HexWidget::drawItemArea(QPainter &painter)
 
     fillSelectionBackground(painter);
 
+    bool haveEditWord = false;
+    QRectF editWordRect;
+    QColor editWordColor;
+
     uint64_t itemAddr = startAddress;
     for (int line = 0; line < visibleLines; ++line) {
         itemRect.moveLeft(itemArea.left());
         for (int j = 0; j < itemColumns; ++j) {
             for (int k = 0; k < itemGroupSize && itemAddr <= data->maxIndex();
                  ++k, itemAddr += itemByteLen) {
+
                 itemString = renderItem(itemAddr - startAddress, &itemColor);
 
                 if (!getFlagsAndComment(itemAddr).isEmpty()) {
                     QColor markerColor(borderColor);
                     markerColor.setAlphaF(0.5);
-                    const auto shape = rangePolygons(itemAddr, itemAddr, false)[0];
                     painter.setPen(markerColor);
-                    painter.drawPolyline(shape);
+                    for (const auto &shape : rangePolygons(itemAddr, itemAddr, false)) {
+                        painter.drawPolyline(shape);
+                    }
                 }
                 if (selection.contains(itemAddr) && !cursorOnAscii) {
                     itemColor = palette().highlightedText().color();
@@ -1123,18 +1683,52 @@ void HexWidget::drawItemArea(QPainter &painter)
                 if (isItemDifferentAt(itemAddr)) {
                     itemColor.setRgb(diffColor.rgb());
                 }
-                painter.setPen(itemColor);
-                painter.drawText(itemRect, Qt::AlignVCenter, itemString);
-                itemRect.translate(itemWidth(), 0);
-                if (cursor.address == itemAddr) {
-                    auto &itemCursor = cursorOnAscii ? shadowCursor : cursor;
-                    itemCursor.cachedChar = itemString.at(0);
+
+                if (editWordState <= EditWordState::WriteNotStarted || cursor.address != itemAddr) {
+                    painter.setPen(itemColor);
+                    painter.drawText(itemRect, Qt::AlignVCenter, itemString);
+                    itemRect.translate(itemWidth(), 0);
+                    if (cursor.address == itemAddr) {
+                        auto &itemCursor = cursorOnAscii ? shadowCursor : cursor;
+                        int itemCharPos = 0;
+                        if (editWordState > EditWordState::Read) {
+                            itemCharPos += itemPrefixLen;
+                        }
+                        if (itemCharPos < itemString.length()) {
+                            itemCursor.cachedChar = itemString.at(itemCharPos);
+                        } else {
+                            itemCursor.cachedChar = ' ';
+                        }
+                        itemCursor.cachedColor = itemColor;
+                    }
+                } else {
+                    haveEditWord = true;
+                    editWordRect = itemRect;
+                    editWordColor = itemColor;
+
+                    auto &itemCursor = cursor;
+                    itemCursor.cachedChar =
+                            editWordPos < editWord.length() ? editWord[editWordPos] : QChar(' ');
                     itemCursor.cachedColor = itemColor;
+                    itemCursor.screenPos.moveTopLeft(itemRect.topLeft());
+                    itemCursor.screenPos.translate(charWidth * (editWordPos + itemPrefixLen), 0);
+
+                    itemRect.translate(itemWidth(), 0);
                 }
             }
             itemRect.translate(columnSpacingWidth(), 0);
         }
         itemRect.translate(0, lineHeight);
+    }
+    if (haveEditWord) {
+        auto length = std::max(itemCharLen, editWord.length());
+        auto rect = editWordRect;
+        rect.setWidth(length * charWidth);
+        painter.fillRect(rect, backgroundColor);
+
+        painter.setPen(editWordColor);
+        editWordRect.setWidth(4000);
+        painter.drawText(editWordRect, Qt::AlignVCenter | Qt::AlignLeft, itemPrefix + editWord);
     }
 
     painter.setPen(borderColor);
@@ -1324,18 +1918,44 @@ void HexWidget::updateAreasHeight()
     asciiArea.setHeight(height);
 }
 
-void HexWidget::moveCursor(int offset, bool select)
+bool HexWidget::moveCursor(int offset, bool select, OverflowMove overflowMove)
 {
-    BasicCursor addr = cursor.address;
-    addr += offset;
-    if (addr.address > data->maxIndex()) {
-        addr.address = data->maxIndex();
+    BasicCursor addr(cursor.address);
+    if (overflowMove == OverflowMove::Ignore) {
+        if (addr.moveChecked(offset)) {
+            if (addr.address > data->maxIndex()) {
+                addr.address = data->maxIndex();
+                addr.pastEnd = true;
+            }
+            setCursorAddr(addr, select);
+            return true;
+        }
+        return false;
+    } else {
+        addr += offset;
+        if (addr.address > data->maxIndex()) {
+            addr.address = data->maxIndex();
+        }
+        setCursorAddr(addr, select);
+        return true;
     }
-    setCursorAddr(addr, select);
+}
+
+void HexWidget::moveCursorKeepEditOffset(int byteOffset, bool select, OverflowMove overflowMove)
+{
+    int wordOffset = editWordPos;
+    moveCursor(byteOffset, select, overflowMove);
+    // preserve position within word when moving vertically in hex or oct modes
+    if (!cursorOnAscii && !select && wordOffset > 0 && navigationMode == HexNavigationMode::AnyChar
+        && editWordState > EditWordState::Read) {
+        startEditWord();
+        editWordPos = wordOffset;
+    }
 }
 
 void HexWidget::setCursorAddr(BasicCursor addr, bool select)
 {
+    finishEditingWord();
     if (!select) {
         bool clearingSelection = !selection.isEmpty();
         selection.init(addr);
@@ -1345,6 +1965,9 @@ void HexWidget::setCursorAddr(BasicCursor addr, bool select)
     emit positionChanged(addr.address);
 
     cursor.address = addr.address;
+    if (!cursorOnAscii) {
+        cursor.address -= cursor.address % itemByteLen;
+    }
 
     /* Pause cursor repainting */
     cursorEnabled = false;
@@ -1361,7 +1984,9 @@ void HexWidget::setCursorAddr(BasicCursor addr, bool select)
         addressValue -= (addressValue % itemRowByteLen());
 
         /* FIXME: handling Page Up/Down */
-        if (addressValue == startAddress + bytesPerScreen()) {
+        uint64_t rowAfterVisibleAddress = startAddress + bytesPerScreen();
+        if (addressValue == rowAfterVisibleAddress && addressValue > startAddress) {
+            // when pressing down add only one new row
             startAddress += itemRowByteLen();
         } else {
             startAddress = addressValue;
@@ -1410,6 +2035,10 @@ void HexWidget::updateCursorMeta()
     point += itemArea.topLeft();
     pointAscii += asciiArea.topLeft();
 
+    if (editWordState > EditWordState::Read && !cursorOnAscii) {
+        point.rx() += itemPrefixLen * charWidth;
+    }
+
     cursor.screenPos.moveTopLeft(cursorOnAscii ? pointAscii : point);
     shadowCursor.screenPos.moveTopLeft(cursorOnAscii ? point : pointAscii);
 }
@@ -1419,7 +2048,7 @@ void HexWidget::setCursorOnAscii(bool ascii)
     cursorOnAscii = ascii;
 }
 
-const QColor HexWidget::itemColor(uint8_t byte)
+QColor HexWidget::itemColor(uint8_t byte)
 {
     QColor color(defColor);
 
@@ -1547,7 +2176,7 @@ QString HexWidget::renderItem(int offset, QColor *color)
         item = QString("%1").arg(itemVal.toLongLong(), itemLen, 10);
         break;
     case ItemFormatFloat:
-        item = QString("%1").arg(itemVal.toDouble(), itemLen);
+        item = QString("%1").arg(itemVal.toDouble(), itemLen, 'g', itemByteLen == 4 ? 6 : 15);
         break;
     }
 
@@ -1588,13 +2217,165 @@ QString HexWidget::getFlagsAndComment(uint64_t address)
     return metaData;
 }
 
+bool HexWidget::canKeyboardEdit()
+{
+    return ioModesController.canWrite() && actionKeyboardEdit->isChecked();
+}
+
+template<class T, class BigValue>
+static bool checkRange(BigValue v)
+{
+    return v >= std::numeric_limits<T>::min() && v <= std::numeric_limits<T>::max();
+}
+
+template<class T, class BigInteger>
+static bool checkAndWrite(BigInteger value, uint8_t *buf, bool littleEndian)
+{
+    if (!checkRange<T>(value)) {
+        return false;
+    }
+    if (littleEndian) {
+        qToLittleEndian((T)value, buf);
+    } else {
+        qToBigEndian((T)value, buf);
+    }
+    return true;
+}
+
+template<class UType, class SType>
+static bool checkAndWriteWithSign(const QVariant &value, uint8_t *buf, bool isSigned,
+                                  bool littleEndian)
+{
+    if (isSigned) {
+        return checkAndWrite<SType>(value.toLongLong(), buf, littleEndian);
+    } else {
+        return checkAndWrite<UType>(value.toULongLong(), buf, littleEndian);
+    }
+}
+
+bool HexWidget::parseWord(QString word, uint8_t *buf, size_t bufferSize) const
+{
+    bool parseOk = false;
+    if (bufferSize < size_t(itemByteLen)) {
+        return false;
+    }
+    if (itemFormat == ItemFormatFloat) {
+        if (itemByteLen == 4) {
+            float value = word.toFloat(&parseOk);
+            if (!parseOk) {
+                return false;
+            }
+            if (itemBigEndian) {
+                rz_write_be_float(buf, value);
+            } else {
+                rz_write_le_float(buf, value);
+            }
+            return true;
+        } else if (itemByteLen == 8) {
+            double value = word.toDouble(&parseOk);
+            if (!parseOk) {
+                return false;
+            }
+            if (itemBigEndian) {
+                rz_write_be_double(buf, value);
+            } else {
+                rz_write_le_double(buf, value);
+            }
+            return true;
+        }
+        return false;
+    } else {
+        QVariant value;
+        bool isSigned = false;
+        switch (itemFormat) {
+        case ItemFormatHex:
+            value = word.toULongLong(&parseOk, 16);
+            break;
+        case ItemFormatOct:
+            value = word.toULongLong(&parseOk, 8);
+            break;
+        case ItemFormatDec:
+            value = word.toULongLong(&parseOk, 10);
+            break;
+        case ItemFormatSignedDec:
+            isSigned = true;
+            value = word.toLongLong(&parseOk, 10);
+            break;
+        default:
+            break;
+        }
+        if (!parseOk) {
+            return false;
+        }
+
+        switch (itemByteLen) {
+        case 1:
+            return checkAndWriteWithSign<uint8_t, int8_t>(value, buf, isSigned, !itemBigEndian);
+        case 2:
+            return checkAndWriteWithSign<uint16_t, int16_t>(value, buf, isSigned, !itemBigEndian);
+        case 4:
+            return checkAndWriteWithSign<quint32, qint32>(value, buf, isSigned, !itemBigEndian);
+        case 8:
+            return checkAndWriteWithSign<quint64, qint64>(value, buf, isSigned, !itemBigEndian);
+        }
+    }
+    return false;
+}
+
+bool HexWidget::finishEditingWord(bool force)
+{
+    if (editWordState == EditWordState::WriteEdited) {
+        uint8_t buf[16];
+        if (parseWord(editWord, buf, sizeof(buf))) {
+            data->write(buf, cursor.address, itemByteLen);
+        } else if (!force) {
+            qWarning() << "Not a valid number in current format or size" << editWord;
+            showWarningRect(itemRectangle(cursor.address - startAddress).adjusted(-1, -1, 1, 1));
+            return false;
+        }
+    }
+    editWord.clear();
+    editWordPos = 0;
+    editWordState = canKeyboardEdit() ? EditWordState::WriteNotStarted : EditWordState::Read;
+    navigationMode = defaultNavigationMode();
+    return true;
+}
+
+void HexWidget::cancelEditedWord()
+{
+    editWordPos = 0;
+    editWordState = canKeyboardEdit() ? EditWordState::WriteNotStarted : EditWordState::Read;
+    editWord.clear();
+    navigationMode = defaultNavigationMode();
+    updateCursorMeta();
+    viewport()->update();
+}
+
+void HexWidget::startEditWord()
+{
+    if (!canKeyboardEdit()) {
+        return;
+    }
+    if (editWordState >= EditWordState::WriteNotEdited) {
+        return;
+    }
+    editWordPos = 0;
+    editWordState = EditWordState::WriteNotEdited;
+    navigationMode = defaultNavigationMode();
+    editWord = renderItem(cursor.address - startAddress).trimmed();
+    if (itemPrefixLen > 0) {
+        editWord = editWord.mid(itemPrefixLen);
+    }
+    viewport()->update();
+}
+
 void HexWidget::fetchData()
 {
     data.swap(oldData);
     data->fetch(startAddress, bytesPerScreen());
 }
 
-BasicCursor HexWidget::screenPosToAddr(const QPoint &point, bool middle) const
+BasicCursor HexWidget::screenPosToAddr(const QPoint &point, bool middle, int *wordOffset) const
 {
     QPointF pt = point - itemArea.topLeft();
 
@@ -1605,9 +2386,21 @@ BasicCursor HexWidget::screenPosToAddr(const QPoint &point, bool middle) const
     relativeAddress += column * itemGroupByteLen();
     pt.rx() -= column * columnExWidth();
     auto roundingOffset = middle ? itemWidth() / 2 : 0;
-    relativeAddress += static_cast<int>((pt.x() + roundingOffset) / itemWidth()) * itemByteLen;
+    int posInGroup = static_cast<int>((pt.x() + roundingOffset) / itemWidth());
+    if (!middle) {
+        posInGroup = std::min(posInGroup, itemGroupSize - 1);
+    }
+    relativeAddress += posInGroup * itemByteLen;
+    pt.rx() -= posInGroup * itemWidth();
     BasicCursor result(startAddress);
     result += relativeAddress;
+
+    if (!middle && wordOffset != nullptr) {
+        int charPos = static_cast<int>((pt.x() / charWidth) + 0.5);
+        charPos -= itemPrefixLen;
+        charPos = std::max(0, charPos);
+        *wordOffset = charPos;
+    }
     return result;
 }
 
@@ -1678,4 +2471,18 @@ QRectF HexWidget::asciiRectangle(int offset)
 RVA HexWidget::getLocationAddress()
 {
     return !selection.isEmpty() ? selection.start() : cursor.address;
+}
+
+void HexWidget::hideWarningRect()
+{
+    warningRectVisible = false;
+    viewport()->update();
+}
+
+void HexWidget::showWarningRect(QRectF rect)
+{
+    warningRect = rect;
+    warningRectVisible = true;
+    warningTimer.start(WARNING_TIME_MS);
+    viewport()->update();
 }

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -580,7 +580,7 @@ void HexWidget::mousePressEvent(QMouseEvent *event)
                     && (wordOffset < editWord.length()
                         || navigationMode == HexNavigationMode::WordChar)) {
                     editWordPos = std::max(0, wordOffset);
-                    editWordPos = std::min(editWordPos, editWord.length());
+                    editWordPos = std::min<int>(editWordPos, editWord.length());
 
                     if (isFixedWidth()) {
                         updatingSelection = true;
@@ -616,7 +616,7 @@ void HexWidget::mousePressEvent(QMouseEvent *event)
 
             if (wordOffset > 0) {
                 startEditWord();
-                editWordPos = std::min(wordOffset, editWord.length() - 1);
+                editWordPos = std::min<int>(wordOffset, editWord.length() - 1);
             }
             viewport()->update();
             return;
@@ -645,9 +645,9 @@ void HexWidget::mouseDoubleClickEvent(QMouseEvent *event)
         auto cursorPosition = screenPosToAddr(pos, false, &wordOffset);
         setCursorAddr(cursorPosition, false);
         startEditWord();
-        int padding = std::max(0, itemCharLen - editWord.length());
+        int padding = std::max<int>(0, itemCharLen - editWord.length());
         editWordPos = std::max(0, wordOffset - padding);
-        editWordPos = std::min(editWordPos, editWord.length());
+        editWordPos = std::min<int>(editWordPos, editWord.length());
     }
 }
 
@@ -810,7 +810,7 @@ bool HexWidget::handleAsciiWrite(QKeyEvent *event)
             return false;
         }
         QChar c = text[0];
-        if (c <= 0x1f || c == 0x7f) {
+        if (c <= '\x1f' || c == '\x7f') {
             return false;
         }
     }
@@ -1087,7 +1087,7 @@ void HexWidget::keyPressEvent(QKeyEvent *event)
         }
     } else if (navigationMode == HexNavigationMode::WordChar) {
         if (event->matches(QKeySequence::MoveToNextChar)) {
-            editWordPos = std::min(editWord.length(), editWordPos + 1);
+            editWordPos = std::min<int>(editWord.length(), editWordPos + 1);
             viewport()->update();
         } else if (event->matches(QKeySequence::MoveToPreviousChar)) {
             editWordPos = std::max(0, editWordPos - 1);
@@ -1720,7 +1720,7 @@ void HexWidget::drawItemArea(QPainter &painter)
         itemRect.translate(0, lineHeight);
     }
     if (haveEditWord) {
-        auto length = std::max(itemCharLen, editWord.length());
+        auto length = std::max<int>(itemCharLen, editWord.length());
         auto rect = editWordRect;
         rect.setWidth(length * charWidth);
         painter.fillRect(rect, backgroundColor);

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -904,15 +904,14 @@ bool HexWidget::handleNumberWrite(QKeyEvent *event)
             for (int i = editWordPos; i < editWord.length(); i++) {
                 typeOverwriteModeChar('0');
             }
-        }
-        if (editWordPos < editWord.length()) {
+        } else if (editWordPos < editWord.length()) {
             editWord.remove(editWordPos, editWord.length());
             editWordState = EditWordState::WriteEdited;
         }
         return true;
     }
     if (event->matches(QKeySequence::DeleteStartOfWord) && selection.isEmpty()) {
-        if (!editingWord) {
+        if (!editingWord || (overwrite && editWordPos == 0)) {
             if (!moveCursor(-itemByteLen, false, OverflowMove::Ignore)) {
                 return false;
             }

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -657,6 +657,7 @@ void HexWidget::mouseReleaseEvent(QMouseEvent *event)
         if (selection.isEmpty()) {
             selection.init(BasicCursor(cursor.address));
             cursorEnabled = true;
+            viewport()->update();
         }
         updatingSelection = false;
     }

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -973,7 +973,7 @@ bool HexWidget::event(QEvent *event)
     if (event->type() == QEvent::ShortcutOverride) {
         auto keyEvent = static_cast<QKeyEvent *>(event);
         auto modifiers = keyEvent->modifiers();
-        if ((modifiers == Qt::NoModifier || modifiers == Qt::ShiftModifier)
+        if ((modifiers == Qt::NoModifier || modifiers == Qt::ShiftModifier || modifiers == Qt::KeypadModifier )
             && keyEvent->key() < Qt::Key_Escape && canKeyboardEdit()) {
             keyEvent->accept();
             return true;

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -14,7 +14,7 @@ struct BasicCursor
 {
     uint64_t address;
     bool pastEnd;
-    BasicCursor(uint64_t pos) : address(pos), pastEnd(false) {}
+    explicit BasicCursor(uint64_t pos) : address(pos), pastEnd(false) {}
     BasicCursor() : address(0), pastEnd(false) {}
     BasicCursor &operator+=(int64_t offset)
     {
@@ -35,6 +35,14 @@ struct BasicCursor
         *this += int64_t(offset);
         return *this;
     }
+
+    bool moveChecked(int offset)
+    {
+        auto oldAddress = address;
+        *this += offset;
+        return address - oldAddress == uint64_t(offset);
+    }
+
     BasicCursor &operator+=(uint64_t offset)
     {
         if (uint64_t(offset) > (UINT64_MAX - address)) {
@@ -46,7 +54,10 @@ struct BasicCursor
         }
         return *this;
     }
-    bool operator<(const BasicCursor &r) { return address < r.address || (pastEnd < r.pastEnd); }
+    bool operator<(const BasicCursor &r) const
+    {
+        return address < r.address || (pastEnd < r.pastEnd);
+    }
 };
 
 struct HexCursor
@@ -74,9 +85,10 @@ struct HexCursor
 class AbstractData
 {
 public:
-    virtual ~AbstractData() {}
+    virtual ~AbstractData() = default;
     virtual void fetch(uint64_t addr, int len) = 0;
     virtual bool copy(void *out, uint64_t adr, size_t len) = 0;
+    virtual bool write(const uint8_t *in, uint64_t adr, size_t len) = 0;
     virtual uint64_t maxIndex() = 0;
     virtual uint64_t minIndex() = 0;
 };
@@ -86,7 +98,7 @@ class BufferData : public AbstractData
 public:
     BufferData() { m_buffer.fill(0, 1); }
 
-    BufferData(const QByteArray &buffer)
+    explicit BufferData(const QByteArray &buffer)
     {
         if (buffer.isEmpty()) {
             m_buffer.fill(0, 1);
@@ -95,7 +107,7 @@ public:
         }
     }
 
-    ~BufferData() override {}
+    ~BufferData() override = default;
 
     void fetch(uint64_t, int) override {}
 
@@ -104,6 +116,16 @@ public:
         if (addr < static_cast<uint64_t>(m_buffer.size())
             && (static_cast<uint64_t>(m_buffer.size()) - addr) < len) {
             memcpy(out, m_buffer.constData() + addr, len);
+            return true;
+        }
+        return false;
+    }
+
+    bool write(const uint8_t *in, uint64_t addr, size_t len) override
+    {
+        if (addr < static_cast<uint64_t>(m_buffer.size())
+            && (static_cast<uint64_t>(m_buffer.size()) - addr) < len) {
+            memcpy(m_buffer.data() + addr, in, len);
             return true;
         }
         return false;
@@ -118,8 +140,8 @@ private:
 class MemoryData : public AbstractData
 {
 public:
-    MemoryData() {}
-    ~MemoryData() override {}
+    MemoryData() = default;
+    ~MemoryData() override = default;
     static constexpr size_t BLOCK_SIZE = 4096;
 
     void fetch(uint64_t address, int length) override
@@ -144,10 +166,11 @@ public:
 
     bool copy(void *out, uint64_t addr, size_t len) override
     {
-        if (addr < m_firstBlockAddr || addr > m_lastValidAddr
-            || (m_lastValidAddr - addr + 1)
-                    < len /* do not merge with last check to handle overflows */
-            || m_blocks.isEmpty()) {
+        if (addr < m_firstBlockAddr
+            || addr > m_lastValidAddr
+            /* do not merge with previous check to handle overflows */
+            || (m_lastValidAddr - addr + 1) < len || m_blocks.isEmpty()) {
+            memset(out, 0xff, len);
             return false;
         }
 
@@ -165,9 +188,47 @@ public:
         return true;
     }
 
-    virtual uint64_t maxIndex() override { return m_lastValidAddr; }
+    void writeToCache(const uint8_t *in, uint64_t adr, size_t len)
+    {
+        if (adr < m_firstBlockAddr) {
+            uint64_t prefix = m_firstBlockAddr - adr;
+            if (prefix <= len) {
+                return;
+            }
+            in = in + prefix;
+            adr += prefix;
+            len -= prefix;
+        }
+        if (adr > m_lastValidAddr) {
+            return;
+        }
+        int offset = (int)(adr - m_firstBlockAddr);
+        int blockId = offset / BLOCK_SIZE;
+        int blockOffset = offset % BLOCK_SIZE;
+        while (len > 0 && blockId < m_blocks.size()) {
+            size_t l = BLOCK_SIZE - blockOffset;
+            l = std::min(l, len);
+            memcpy(m_blocks[blockId].data() + blockOffset, in, l);
+            len -= l;
+            blockOffset = 0;
+            adr += l;
+            in += l;
+            blockId += 1;
+        }
+    }
 
-    virtual uint64_t minIndex() override { return m_firstBlockAddr; }
+    bool write(const uint8_t *in, uint64_t adr, size_t len) override
+    {
+        RzCoreLocked core(Core());
+        rz_core_write_at(core, adr, in, len);
+        writeToCache(in, adr, len);
+        emit Core()->instructionChanged(adr);
+        return true;
+    }
+
+    uint64_t maxIndex() override { return std::numeric_limits<uint64_t>::max(); }
+
+    uint64_t minIndex() override { return m_firstBlockAddr; }
 
 private:
     QVector<QByteArray> m_blocks;
@@ -178,7 +239,11 @@ private:
 class HexSelection
 {
 public:
-    HexSelection() { m_empty = true; }
+    HexSelection()
+    {
+        m_empty = true;
+        m_start = m_end = 0;
+    }
 
     inline void init(BasicCursor addr)
     {
@@ -189,7 +254,8 @@ public:
     void set(uint64_t start, uint64_t end)
     {
         m_empty = false;
-        m_init = m_start = start;
+        m_init = BasicCursor(start);
+        m_start = start;
         m_end = end;
     }
 
@@ -219,7 +285,7 @@ public:
 
     bool contains(uint64_t pos) const { return !m_empty && m_start <= pos && pos <= m_end; }
 
-    uint64_t size()
+    uint64_t size() const
     {
         uint64_t size = 0;
         if (!isEmpty())
@@ -227,9 +293,9 @@ public:
         return size;
     }
 
-    inline bool isEmpty() { return m_empty; }
-    inline uint64_t start() { return m_start; }
-    inline uint64_t end() { return m_end; }
+    inline bool isEmpty() const { return m_empty; }
+    inline uint64_t start() const { return m_start; }
+    inline uint64_t end() const { return m_end; }
 
 private:
     BasicCursor m_init;
@@ -244,7 +310,7 @@ class HexWidget : public QScrollArea
 
 public:
     explicit HexWidget(QWidget *parent = nullptr);
-    ~HexWidget();
+    ~HexWidget() override = default;
 
     void setMonospaceFont(const QFont &font);
 
@@ -258,10 +324,12 @@ public:
         ItemFormatFloat
     };
     enum class ColumnMode { Fixed, PowerOf2 };
+    enum class EditWordState { Read, WriteNotStarted, WriteNotEdited, WriteEdited };
+    enum class HexNavigationMode { Words, WordChar, AnyChar };
 
     void setItemSize(int nbytes);
     void setItemFormat(ItemFormat format);
-    void setItemEndianess(bool bigEndian);
+    void setItemEndianness(bool bigEndian);
     void setItemGroupSize(int size);
     /**
      * @brief Sets line size in bytes.
@@ -292,7 +360,7 @@ public slots:
     void refresh();
     void updateColors();
 signals:
-    void selectionChanged(Selection selection);
+    void selectionChanged(HexWidget::Selection selection);
     void positionChanged(RVA start);
 
 protected:
@@ -300,10 +368,12 @@ protected:
     void resizeEvent(QResizeEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
     void contextMenuEvent(QContextMenuEvent *event) override;
+    bool event(QEvent *event) override;
 
 private slots:
     void onCursorBlinked();
@@ -311,13 +381,13 @@ private slots:
     void copy();
     void copyAddress();
     void onRangeDialogAccepted();
-    void on_actionAddComment_triggered();
-    void on_actionDeleteComment_triggered();
+    void onActionAddCommentTriggered();
+    void onActionDeleteCommentTriggered();
 
     // Write command slots
     void w_writeString();
     void w_increaseDecrease();
-	void w_writeBytes();
+    void w_writeBytes();
     void w_writeZeros();
     void w_write64();
     void w_writeRandom();
@@ -325,6 +395,9 @@ private slots:
     void w_writePascalString();
     void w_writeWideString();
     void w_writeCString();
+
+    void onKeyboardEditTriggered(bool enabled);
+    void onKeyboardEditChanged(bool enabled);
 
 private:
     void updateItemLength();
@@ -338,12 +411,15 @@ private:
     void updateMetrics();
     void updateAreasPosition();
     void updateAreasHeight();
-    void moveCursor(int offset, bool select = false);
+    enum class OverflowMove { Clamp, Ignore };
+    bool moveCursor(int offset, bool select = false, 
+                    OverflowMove overflowMove = OverflowMove::Clamp);
+    void moveCursorKeepEditOffset(int byteOffset, bool select, OverflowMove overflowMove);
     void setCursorAddr(BasicCursor addr, bool select = false);
     void updateCursorMeta();
     void setCursorOnAscii(bool ascii);
     bool isItemDifferentAt(uint64_t address);
-    const QColor itemColor(uint8_t byte);
+    QColor itemColor(uint8_t byte);
     QVariant readItem(int offset, QColor *color = nullptr);
     QString renderItem(int offset, QColor *color = nullptr);
     QChar renderAscii(int offset, QColor *color = nullptr);
@@ -359,12 +435,13 @@ private:
     /**
      * @brief Convert mouse position to address.
      * @param point mouse position in widget
-     * @param middle start next position from middle of symbol. Use middle=true for vertical cursror
+     * @param middle start next position from middle of symbol. Use middle=true for vertical cursor
      * position between symbols, middle=false for insert mode cursor and getting symbol under
      * cursor.
      * @return
      */
-    BasicCursor screenPosToAddr(const QPoint &point, bool middle = false) const;
+    BasicCursor screenPosToAddr(const QPoint &point, bool middle = false,
+                                int *wordOffset = nullptr) const;
     BasicCursor asciiPosToAddr(const QPoint &point, bool middle = false) const;
     BasicCursor currentAreaPosToAddr(const QPoint &point, bool middle = false) const;
     BasicCursor mousePosToAddr(const QPoint &point, bool middle = false) const;
@@ -412,6 +489,25 @@ private:
     inline uint64_t lastVisibleAddr() const { return (startAddress - 1) + bytesPerScreen(); }
 
     const QRectF &currentArea() const { return cursorOnAscii ? asciiArea : itemArea; }
+    bool isFixedWidth() const;
+
+    bool canKeyboardEdit();
+    bool finishEditingWord(bool force = true);
+    void cancelEditedWord();
+    void startEditWord();
+    bool validCharForEdit(QChar digit);
+    void movePrevEditCharAny();
+    void typeOverwriteModeChar(QChar c);
+    HexNavigationMode defaultNavigationMode();
+    void refreshWordEditState();
+    bool parseWord(QString word, uint8_t *buf, size_t bufferSize) const;
+    bool handleAsciiWrite(QKeyEvent *event);
+    bool handleNumberWrite(QKeyEvent *event);
+
+    void writeZeros(uint64_t address, uint64_t length);
+
+    void hideWarningRect();
+    void showWarningRect(QRectF rect);
 
     bool cursorEnabled;
     bool cursorOnAscii;
@@ -436,14 +532,13 @@ private:
     ItemFormat itemFormat;
 
     bool itemBigEndian;
+    QString itemPrefix;
 
     int visibleLines;
     uint64_t startAddress;
     qreal charWidth;
-    int byteWidth;
     qreal lineHeight;
     int addrCharLen;
-    int addrAreaWidth;
     QFont monospaceFont;
 
     bool showHeader;
@@ -460,6 +555,7 @@ private:
     QColor b0x7fColor;
     QColor b0xffColor;
     QColor printableColor;
+    QColor warningColor;
 
     HexdumpRangeDialog rangeDialog;
 
@@ -479,14 +575,23 @@ private:
     QAction *actionCopyAddress;
     QAction *actionComment;
     QAction *actionDeleteComment;
-    QAction *actionSetFlag;
     QAction *actionSelectRange;
+    QAction *actionKeyboardEdit;
     QList<QAction *> actionsWriteString;
     QList<QAction *> actionsWriteOther;
 
     std::unique_ptr<AbstractData> oldData;
     std::unique_ptr<AbstractData> data;
     IOModesController ioModesController;
+
+    int editWordPos = 0;
+    QString editWord;
+    EditWordState editWordState = EditWordState::Read;
+    HexNavigationMode navigationMode = HexNavigationMode::Words;
+
+    bool warningRectVisible = false;
+    QRectF warningRect;
+    QTimer warningTimer;
 };
 
 #endif // HEXWIDGET_H

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -412,7 +412,7 @@ private:
     void updateAreasPosition();
     void updateAreasHeight();
     enum class OverflowMove { Clamp, Ignore };
-    bool moveCursor(int offset, bool select = false, 
+    bool moveCursor(int offset, bool select = false,
                     OverflowMove overflowMove = OverflowMove::Clamp);
     void moveCursorKeepEditOffset(int byteOffset, bool select, OverflowMove overflowMove);
     void setCursorAddr(BasicCursor addr, bool select = false);
@@ -492,7 +492,9 @@ private:
     bool isFixedWidth() const;
 
     bool canKeyboardEdit();
+    bool flushCurrentlyEditedWord();
     bool finishEditingWord(bool force = true);
+    void maybeFlushCharEdit();
     void cancelEditedWord();
     void startEditWord();
     bool validCharForEdit(QChar digit);
@@ -588,6 +590,13 @@ private:
     QString editWord;
     EditWordState editWordState = EditWordState::Read;
     HexNavigationMode navigationMode = HexNavigationMode::Words;
+    enum class EarlyEditFlush {
+        OnFinish,
+        EditNibble,
+        EditFixedWidthChar,
+        /* AllFormats(not implemented) */
+    };
+    EarlyEditFlush earlyEditFlush = EarlyEditFlush::EditFixedWidthChar;
 
     bool warningRectVisible = false;
     QRectF warningRect;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

In the following text "word" and "item" refers to single 1-8 byte number depending on currently selected display mode.

* Allow editing words in all the formats (hex, oct, decimal, floating point) and sizes by simply typing
* Allow writing text in the text column

<details>
  <summary>Spoiler warning! Do not read before blindly testing the feature.</summary>

Editing with keyboard requires enabling it in context menu.  This was not an easy choice. But this can be discussed
_Reasons against:_
* one more somewhat unexpected step especially when using as general purpose hex editor. 


_Reasons why I chose adding it:_
* Navigation when editing is enabled works slightly differently. Moving over each nibble of 4-8 byte word when you are not going to edit them or can't interact with them seems like bad experience
* Potentially too easy to accidentally break your executable. Especially due to lack of proper undo system, the way saving and "write mode" currently works and some of the global shortcuts being mapped to plain letters similar to keys used for editing. 
* (unintentional benefit) Having to enable writing before gives a good moment to show the choice for "cache mode" and direct "write mode". Showing that popup on when starting to type would be in my opinion worse. Easier to forget if you typed the first character before popup or not. 


Editing of words  uses states `enum class EditWordState { Read, WriteNotStarted, WriteNotEdited, WriteEdited };`. One of the reasons for tracking different states is to avoid unintentional edits on floating point numbers due to ambiguity of textual representation of 0, non canonical forms for inf/NaN, Cutter potentially printing insufficient amount of digits.

##### Editing workflow:

Read mode:
* functions more  or less like the hexwidget behaved until now
* movement in item area functions at item level

Text

* Move cursor to text column by clicking in it
* type or paste text to write it in current cursor position
* backspace or delete overwrites with zeros and moves cursor
* backspace, delete when range is selected replaces range with 0
* copy shortcut copies text (was implemented before)
* common navigation shortcuts (was implemented before)


Hex bytes or Oct

* most of the behavior active only when cursor is in item area (instead of text area)
* when using arrows cursor moves single character
* move prev/next word shortcuts (same as commonly used by text editors on corresponding platform) moves by single item speeding up movement when you don't want to move character by character
* move up/down preserves position within word
* single click positions cursor between corresponding characters
* typing overwrites digit after cursor
* backspace, delete (without selection) equivalent to typing single 0 digit and moving cursor
* with selection backspace and delete overwrites selected range with 0


Decimal and floating point numbers:
* most of the behavior active only when cursor is in item area (instead of text area)
* By default functions same as read mode
* single click moves cursor at item level
* typing a digit or backspace/delete **starts editing** the **item** next to cursor
* alternatively **start editing** an **item** by double clicking on one, this also correctly positions cursor within item
* when editing an item movement is limited within current item
* when editing an item, single mouse click can be used to position cursor within current word
* delete to start/end of word works (if current OS has commonly used text editing shortcut for that)
* press "enter" to finish editing a word, if current word is not valid number word edit mode will remain active and it will be outlined red, navigating with mouse also finishes editing of current word
* press "esc" to cancel editing current word, it will revert to the state before you started editing it
* text can be pasted within currently edited word


 
</details>

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Limitations:**
* Selection always functions at word level. It is not possible to select single decimal digit or even byte when word size is greater than 1.
* Multi byte hexadecimal words are treated more or less same as words in decimal notation. Meaning the fact that certain positions within word map to byte address is not used and treated specially just like in decimal notation where there is no direct mapping from digits to single specific byte address. If you want to poke bytes switch to single byte mode. Multibyte word editing could be partially simulated by extending the "hexpair" mode to 4 and 8 byte column grouping.
* Copying (behaves mostly the same as before). I have some bigger ideas but that's work for separate issue. See https://github.com/rizinorg/cutter/issues/1524#issuecomment-1222460436
* Pasting - pasting in item area is mostly for pasting in currently edited word.  Similar to copying i have some ideas that would better be done in separate PR:


**Quirks making non ideal as general purpose hex editor:**
* Size of file is not obvious, no easy way to resize


**Test plan (required)**

This is one of those features that I would like to be tried out by as many devs as possible due to high chance of bugginess caused by large amount different modes and formatting options involved. 
<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

Closes #2931 
