### PR TITLE
Fix build on 32-bit systems.

### DIFF
--- a/src/widgets/GraphGridLayout.cpp
+++ b/src/widgets/GraphGridLayout.cpp
@@ -554,7 +554,7 @@ void GraphGridLayout::calculateEdgeMainColumn(GraphGridLayout::LayoutState &stat
 
     struct Event
     {
-        size_t blockId;
+        ut64 blockId;
         size_t edgeId;
         int row;
         enum Type { Edge = 0, Block = 1 } type;


### PR DESCRIPTION
**Your checklist for this pull request**

- [X] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [X] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [X] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Should fix the build on all 32-bit systems where casting a `ut64` to a `size_t` may truncate, and this causes a build error like:

```
/pobj/cutter-2.1.0/cutter-2.1.0/src/widgets/GraphGridLayout.cpp:559:28: error: non-constant-expression cannot be narrowed from type 'const unsigned long long' to 'size_t' (aka 'unsigned long') in initializer list [-Wc++11-narrowing]
        events.push_back({ it.first, 0, it.second.row, Event::Block });
                           ^~~~~~~~
```

Found on OpenBSD/i386. Already applied to the OpenBSD port.

The patch has [been in OpenBSD since August 2020](http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/devel/cutter/patches/patch-src_widgets_GraphGridLayout_cpp?rev=1.1&content-type=text/x-cvsweb-markup) (well, I accidentally removed it when I updated cutter last week, but you get the idea :) )

**Test plan (required)**

Tested in the ports tree for the latest cutter release.

Can someone try a quick build on a linux/amd64 machine to check I didn't break it?

**Closing issues**

Fixes #3031 
