### PR TITLE
Update iterator synthax to be compatible with cpp17 (#3033)

### DIFF
--- a/src/core/RizinCpp.h
+++ b/src/core/RizinCpp.h
@@ -71,8 +71,15 @@ private:
     const RzPVector *const vec;
 
 public:
-    class iterator : public std::iterator<std::input_iterator_tag, T *>
+    class iterator
     {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = T *;
+        using difference_type = ptrdiff_t;
+        using pointer = T **;
+        using reference = T *&;
+
     private:
         T **p;
 
@@ -107,8 +114,15 @@ private:
     const RzList *const list;
 
 public:
-    class iterator : public std::iterator<std::input_iterator_tag, T *>
+    class iterator
     {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = T *;
+        using difference_type = ptrdiff_t;
+        using pointer = T **;
+        using reference = T *&;
+
     private:
         RzListIter *iter;
 


### PR DESCRIPTION
std::iterator is deprecated in cpp17 thus in order to be able to upgrade
to cpp17 if needed we manually define the relevant types for iterator.
See https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/ for
more details.

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

There is two parts:
1. why doing this implementation, refer to this [link](https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/)
2. whether or not cpp17 in activated on purpose in the Qt6 cmake for client

Regarding point 2, in the _/lib/cmake/Qt6/QtFlagHandlingHelpers.cmake_ on my system, I found this:
![image](https://user-images.githubusercontent.com/35852578/188330945-3cf01afb-5a71-4715-b7c2-83bf654f8d3a.png)
It tends to implies that the project would not build due to Qt6 header if cpp17 (or above) is not used.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->
1. test that the change compile with both Qt5 and Qt6 without warning related to std::iterator
4. validate the dashboard section on the Qt5 version

Note that the Qt6 version crashes on my end with Qt6 (with and without the change).
This might be a configuration error on my end though.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3033 