### PR TITLE
Keep CallGraph widget active when seeking to other functions

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1086,6 +1086,12 @@ MemoryDockWidget *MainWindow::addNewMemoryWidget(MemoryWidgetType type, RVA addr
     case MemoryWidgetType::Decompiler:
         memoryWidget = new DecompilerWidget(this);
         break;
+    case MemoryWidgetType::CallGraph:
+      memoryWidget = new CallGraphWidget(this, false);
+      break;
+    case MemoryWidgetType::GlobalCallGraph:
+      memoryWidget = new CallGraphWidget(this, true);
+      break;
     }
     auto seekable = memoryWidget->getSeekable();
     seekable->setSynchronization(synchronized);

--- a/src/widgets/CallGraph.cpp
+++ b/src/widgets/CallGraph.cpp
@@ -7,9 +7,9 @@
 #include <QJsonObject>
 
 CallGraphWidget::CallGraphWidget(MainWindow *main, bool global)
-    : AddressableDockWidget(main), graphView(new CallGraphView(this, main, global)), global(global)
+    : MemoryDockWidget(MemoryWidgetType::CallGraph, main), graphView(new CallGraphView(this, main, global)), global(global)
 {
-    setObjectName(main->getUniqueObjectName("CallGraphWidget"));
+    setObjectName(main ? main->getUniqueObjectName(getWidgetType()) : getWidgetType());
     this->setWindowTitle(getWindowTitle());
     connect(seekable, &CutterSeekable::seekableSeekChanged, this, &CallGraphWidget::onSeekChanged);
 
@@ -21,6 +21,11 @@ CallGraphWidget::~CallGraphWidget() {}
 QString CallGraphWidget::getWindowTitle() const
 {
     return global ? tr("Global Callgraph") : tr("Callgraph");
+}
+
+QString CallGraphWidget::getWidgetType() const
+{
+    return global ? tr("GlobalCallgraph") : tr("Callgraph");
 }
 
 void CallGraphWidget::onSeekChanged(RVA address)

--- a/src/widgets/CallGraph.h
+++ b/src/widgets/CallGraph.h
@@ -2,7 +2,7 @@
 #define CALL_GRAPH_WIDGET_H
 
 #include "core/Cutter.h"
-#include "AddressableDockWidget.h"
+#include "MemoryDockWidget.h"
 #include "widgets/SimpleTextGraphView.h"
 #include "common/RefreshDeferrer.h"
 
@@ -30,13 +30,15 @@ private:
     RVA lastLoadedAddress = RVA_INVALID;
 };
 
-class CallGraphWidget : public AddressableDockWidget
+class CallGraphWidget : public MemoryDockWidget
 {
     Q_OBJECT
 
 public:
     explicit CallGraphWidget(MainWindow *main, bool global);
     ~CallGraphWidget();
+
+    QString getWidgetType() const;
 
 protected:
     QString getWindowTitle() const override;

--- a/src/widgets/MemoryDockWidget.h
+++ b/src/widgets/MemoryDockWidget.h
@@ -7,7 +7,7 @@
 #include <QAction>
 
 /* Disassembly/Graph/Hexdump/Decompiler view priority */
-enum class MemoryWidgetType { Disassembly, Graph, Hexdump, Decompiler };
+enum class MemoryWidgetType { Disassembly, Graph, Hexdump, Decompiler, CallGraph, GlobalCallGraph };
 
 class CUTTER_EXPORT MemoryDockWidget : public AddressableDockWidget
 {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [X] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The problem was that when seeking to other functions by using the Functions Widget, if the Call Graph (or Global Call Graph) was the active widget, then it would be replaced by the Disassembly Widget.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3047