### PR TITLE
Remove use of deprecated rz_analysis_var_all_list()

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3966,8 +3966,7 @@ QList<XrefDescription> CutterCore::getXRefsForVariable(QString variableName, boo
     const auto typ =
             findWrites ? RZ_ANALYSIS_VAR_ACCESS_TYPE_WRITE : RZ_ANALYSIS_VAR_ACCESS_TYPE_READ;
     QList<XrefDescription> xrefList = QList<XrefDescription>();
-    RzList *vars = rz_analysis_var_all_list(core->analysis, fcn);
-    for (const auto &v : CutterRzList<RzAnalysisVar>(vars)) {
+    for (const auto &v : CutterPVector<RzAnalysisVar>(&fcn->vars)) {
         if (variableName != v->name) {
             continue;
         }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

This function will be removed in https://github.com/rizinorg/rizin/pull/3157