### PR TITLE
Fix changing the CC of a function

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -1023,18 +1023,15 @@ void DisassemblyContextMenu::on_actionEditFunction_triggered()
 
         if (dialog.exec()) {
             QString new_name = dialog.getNameText();
-            Core()->renameFunction(fcn->addr, new_name);
+            rz_core_analysis_function_rename(core, fcn->addr, new_name.toStdString().c_str());
             QString new_start_addr = dialog.getStartAddrText();
             fcn->addr = Core()->math(new_start_addr);
             QString new_stack_size = dialog.getStackSizeText();
             fcn->stack = int(Core()->math(new_stack_size));
 
-            const char *ccSelected = dialog.getCallConSelected().toUtf8().constData();
-            if (RZ_STR_ISEMPTY(ccSelected)) {
-                return;
-            }
-            if (rz_analysis_cc_exist(core->analysis, ccSelected)) {
-                fcn->cc = rz_str_constpool_get(&core->analysis->constpool, ccSelected);
+            QByteArray newCC = dialog.getCallConSelected().toUtf8();
+            if (!newCC.isEmpty() && rz_analysis_cc_exist(core->analysis, newCC.constData())) {
+                fcn->cc = rz_str_constpool_get(&core->analysis->constpool, newCC.constData());
             }
 
             emit Core()->functionsChanged();


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

The QByteArray must be kept alive as long as its contens are used. Also in this function, Core()->renameFunction() is not used to avoid sending multiple signals for a single edit action.


**Test plan (required)**

* Right-click a function -> Edit function
* Change the CC and click ok
* Open the same dialog again and see the cc has changed
