### PR TITLE
Fix parsing of new types from C

### DIFF
--- a/src/widgets/TypesWidget.cpp
+++ b/src/widgets/TypesWidget.cpp
@@ -293,7 +293,6 @@ void TypesWidget::on_actionLoad_New_Types_triggered()
     TypesInteractionDialog dialog(this);
     connect(&dialog, &TypesInteractionDialog::newTypesLoaded, this, &TypesWidget::refreshTypes);
     dialog.setWindowTitle(tr("Load New Types"));
-    dialog.setTypeName(t.type);
     dialog.exec();
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

In the TypesWidget, right-click+Load New Types was opening the dialog for editing an existing type instead of creating a new one. This would either result in an error (for atomic types) or the old type being deleted on success.

**Test plan (required)**

* In the TypesWidget, right click above an atomic type and click "Load New Types"
* Enter a valid type definition and click ok
* The type should be loaded successfully and the previously selected type should still exist