### PR TITLE
Add text debounce to QuickFilterView & ComboQuickFilterView

### DIFF
--- a/src/widgets/ComboQuickFilterView.cpp
+++ b/src/widgets/ComboQuickFilterView.cpp
@@ -6,8 +6,14 @@ ComboQuickFilterView::ComboQuickFilterView(QWidget *parent)
 {
     ui->setupUi(this);
 
+    debounceTimer = new QTimer(this);
+    debounceTimer->setSingleShot(true);
+
+    connect(debounceTimer, &QTimer::timeout, this,
+            [this]() { emit filterTextChanged(ui->lineEdit->text()); });
+
     connect(ui->lineEdit, &QLineEdit::textChanged, this,
-            [this](const QString &text) { emit filterTextChanged(text); });
+            [this](const QString &text) { debounceTimer->start(150); });
 }
 
 ComboQuickFilterView::~ComboQuickFilterView()

--- a/src/widgets/ComboQuickFilterView.h
+++ b/src/widgets/ComboQuickFilterView.h
@@ -5,6 +5,7 @@
 
 #include <QWidget>
 #include <QComboBox>
+#include <QTimer>
 
 namespace Ui {
 class ComboQuickFilterView;
@@ -32,6 +33,7 @@ signals:
 
 private:
     Ui::ComboQuickFilterView *ui;
+    QTimer *debounceTimer;
 };
 
 #endif // COMBOQUICKFILTERVIEW_H

--- a/src/widgets/QuickFilterView.cpp
+++ b/src/widgets/QuickFilterView.cpp
@@ -7,10 +7,16 @@ QuickFilterView::QuickFilterView(QWidget *parent, bool defaultOn)
 {
     ui->setupUi(this);
 
+    debounceTimer = new QTimer(this);
+    debounceTimer->setSingleShot(true);
+
     connect(ui->closeFilterButton, &QAbstractButton::clicked, this, &QuickFilterView::closeFilter);
 
+    connect(debounceTimer, &QTimer::timeout, this,
+            [this]() { emit filterTextChanged(ui->filterLineEdit->text()); });
+
     connect(ui->filterLineEdit, &QLineEdit::textChanged, this,
-            [this](const QString &text) { emit filterTextChanged(text); });
+            [this](const QString &text) { debounceTimer->start(150); });
 
     if (!defaultOn) {
         closeFilter();

--- a/src/widgets/QuickFilterView.h
+++ b/src/widgets/QuickFilterView.h
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include <QWidget>
+#include <QTimer>
 
 namespace Ui {
 class QuickFilterView;
@@ -31,6 +32,7 @@ signals:
 
 private:
     std::unique_ptr<Ui::QuickFilterView> ui;
+    QTimer *debounceTimer;
 };
 
 #endif // QUICKFILTERVIEW_H


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

Using the quick filter in places like the Strings window can be painfully laggy with a large number of list items due to the fact that the list is updated on *every* keystroke.

I adapted the code [here](https://wiki.qt.io/Delay_action_to_wait_for_user_interaction) to debounce the input in both of these widgets.

I chose to use a hard-coded value of ~300ms based on the average typist's CPM of 200~ 150ms, but this could be turned into a setting if desired.

**Test plan (required)**

- Open Cutter
- Load a binary (preferably with a large amount of strings)
- Navigate to the Strings window (or any other window that uses a filter widget)
- Type in some text and observe that the filter behaves as expected, but without updating the list on every keystroke.

**Closing issues**

N/A (I couldn't find any relating to this)
