### PR TITLE
Store action data as QString.

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -524,7 +524,7 @@ void DisassemblyContextMenu::aboutToShowSlot()
                     continue;
                 }
                 structureOffsetMenu->addAction("[" + memBaseReg + " + " + ty->path + "]")
-                        ->setData(ty->path);
+                        ->setData(QString(ty->path));
             }
             rz_list_free(typeoffs);
         }


### PR DESCRIPTION
Fixes compilation error in newer QT versions, and also prevents risk of potential memory issues.

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**


**Test plan (required)**
* Tested locally the that it fixes the same error(at least on Arch Linux with similar Qt version)
* CI builds with different QT versions still work.

**Closing issues**

Closes #3064
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
