### PR TITLE
Add quick filtering to the Classes window

### DIFF
--- a/src/widgets/ClassesWidget.ui
+++ b/src/widgets/ClassesWidget.ui
@@ -54,7 +54,7 @@
      </widget>
     </item>
     <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_17">
+     <layout class="QHBoxLayout" name="horizontalLayoutSection">
       <property name="spacing">
        <number>10</number>
       </property>
@@ -102,6 +102,16 @@
       </item>
      </layout>
     </item>
+    <item>
+      <widget class="QuickFilterView" name="quickFilterView" native="true">
+        <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+          </sizepolicy>
+        </property>
+      </widget>
+    </item>
    </layout>
   </widget>
   <action name="seekToVTableAction">
@@ -140,6 +150,12 @@
    <class>CutterTreeView</class>
    <extends>QTreeView</extends>
    <header>widgets/CutterTreeView.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QuickFilterView</class>
+   <extends>QWidget</extends>
+   <header>widgets/QuickFilterView.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Previously, the only way to filter classes was by source (Binary Info or Analysis)

This PR enables additional filtering by class name, exhibiting similar behavior to the strings and functions windows.

![image](https://user-images.githubusercontent.com/35229978/211458698-b39ca17f-e8e3-4fd8-be17-9324049607bd.png)

Hotkey | Action
-|-
`<C-f>` | Open Filter
`<Esc>` | Clear Filter

**Test plan (required)**
- Load a binary with RTTI
- Navigate to the classes window
- Type a few class names into the filter and verify it works as expected
