### PR TITLE
Add note on missing `qt5-default` in latest Debian dists

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -63,6 +63,9 @@ On Debian-based Linux distributions, all of these essential packages can be inst
 
    sudo apt install build-essential cmake meson libzip-dev zlib1g-dev qt5-default libqt5svg5-dev qttools5-dev qttools5-dev-tools
 
+.. note::
+ On Debian 11 (bullseye) and higher or Ubuntu 22.04 (Jammy) and higher, replace ``qt5-default`` above with ``qtbase5-dev``.
+
 Depending on your configuration you'll might also need the following:
 
 ::


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr adds a small note to `building.rst` regarding replacement of the missing `qt5-default` package on current Debian and Ubuntu distributions. The reason it's missing is given [here](https://askubuntu.com/questions/1335184/qt5-default-not-in-ubuntu-21-04/1337334#1337334) ... not quite sure `qt5-default` won't return.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

Check English is ok. 

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->
