### PR TITLE
Address Qt 6 deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         name: [
             linux-x86_64,
             linux-x86_64-system-deps,
+            linux-x86_64-qt6-system-deps,
             macos-x86_64,
             windows-x86_64,
             tarball
@@ -39,6 +40,12 @@ jobs:
             system-deps: true
             cc-override: '/usr/bin/gcc-7'
             cxx-override: '/usr/bin/g++-7'
+          - name: linux-x86_64-qt6-system-deps # ensure that Cutter can be built at least in basic config on Ubuntu 22.04 using sytem libraries
+            os: ubuntu-22.04
+            python-version: 3.10.x
+            system-deps: true
+            cc-override: '/usr/bin/gcc-12'
+            cxx-override: '/usr/bin/g++-12'
           - name: linux-x86_64
             os: ubuntu-18.04
             python-version: 3.7.x
@@ -69,15 +76,20 @@ jobs:
       if: contains(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
-        sudo apt-get install libgraphviz-dev mesa-common-dev libxkbcommon-x11-dev libclang-8-dev llvm-8 ninja-build
-        if [[ "${{ matrix.os }}" = "ubuntu-18.04" ]]
+        sudo apt-get install libgraphviz-dev mesa-common-dev libxkbcommon-x11-dev ninja-build
+        if [[ "${{ matrix.os }}" = "ubuntu-18.04" || "${{ matrix.os }}" = "ubuntu-20.04" ]]
         then
           # install additional packages needed for appimage
-          sudo apt-get install libxcb1-dev libxkbcommon-dev libxcb-*-dev libegl1
+          sudo apt-get install libxcb1-dev libxkbcommon-dev libxcb-*-dev libegl1 libclang-8-dev llvm-8
         fi
-        if [[ "${{ matrix.system-deps }}" = "true" ]]
+        if [[ "${{ matrix.os }}" = "ubuntu-18.04" && "${{ matrix.system-deps }}" = "true" ]]
         then
           sudo apt-get install qt5-default libqt5svg5-dev qttools5-dev qttools5-dev-tools
+        fi
+        if [[ "${{ matrix.os }}" = "ubuntu-22.04" ]]
+        then
+          sudo apt-get install libclang-12-dev llvm-12 qt6-base-dev qt6-tools-dev \
+            qt6-tools-dev-tools libqt6svg6-dev libqt6core5compat6-dev libqt6svgwidgets6 qt6-l10n-tools
         fi
     - uses: actions/setup-python@v4
       with:
@@ -145,6 +157,14 @@ jobs:
             -DCUTTER_PACKAGE_RZ_LIBYARA=ON \
             -DCMAKE_INSTALL_PREFIX=appdir/usr \
             -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
+            ..
+        elif [[ "${{ matrix.os }}" = "ubuntu-22.04" ]]
+        then
+          cmake \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCUTTER_QT6=ON \
+            -DCUTTER_USE_BUNDLED_RIZIN=ON \
             ..
         else
           cmake \

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1114,7 +1114,7 @@ void MainWindow::initBackForwardMenu()
         connect(button, &QWidget::customContextMenuRequested, button,
                 [menu, button](const QPoint &pos) { menu->exec(button->mapToGlobal(pos)); });
 
-        QFontMetrics metrics(fontMetrics());
+        QFontMetrics metrics(font());
         // Roughly 10-16 lines depending on padding size, no need to calculate more precisely
         menu->setMaximumHeight(metrics.lineSpacing() * 20);
 

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -48,8 +48,9 @@ void ColorOptionDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
 
     ColorOption currCO = index.data(Qt::UserRole).value<ColorOption>();
 
+    QFontMetrics fm = QFontMetrics(painter->font());
     int penWidth = painter->pen().width();
-    int fontHeight = painter->fontMetrics().height();
+    int fontHeight = fm.height();
     QPoint tl = option.rect.topLeft();
 
     QRect optionNameRect;
@@ -126,9 +127,9 @@ void ColorOptionDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
 
     painter->setPen(qApp->palette().text().color());
 
-    QString name =
-            painter->fontMetrics().elidedText(optionInfoMap__[currCO.optionName].displayingtext,
-                                              Qt::ElideRight, optionNameRect.width());
+    QFontMetrics fm2 = QFontMetrics(painter->font());
+    QString name = fm2.elidedText(optionInfoMap__[currCO.optionName].displayingtext,
+            Qt::ElideRight, optionNameRect.width());
     painter->drawText(optionNameRect, name);
 
     QPainterPath roundedOptionRect;
@@ -155,7 +156,8 @@ void ColorOptionDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
     painter->setPen(currCO.color);
     painter->fillPath(roundedColorRect, currCO.color);
 
-    QString desc = painter->fontMetrics().elidedText(
+    QFontMetrics fm3 = QFontMetrics(painter->font());
+    QString desc = fm3.elidedText(
             currCO.optionName + ": " + optionInfoMap__[currCO.optionName].info, Qt::ElideRight,
             descTextRect.width());
     painter->setPen(qApp->palette().text().color());
@@ -197,7 +199,8 @@ QPixmap ColorOptionDelegate::getPixmapFromSvg(const QString &fileName, const QCo
     data.replace(QRegularExpression("#[0-9a-fA-F]{6}"), QString("%1").arg(after.name()));
 
     QSvgRenderer svgRenderer(data.toUtf8());
-    QPixmap pix(QSize(qApp->fontMetrics().height(), qApp->fontMetrics().height()));
+    QFontMetrics fm = QFontMetrics(qApp->font());
+    QPixmap pix(QSize(fm.height(), fm.height()));
     pix.fill(Qt::transparent);
 
     QPainter pixPainter(&pix);

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -211,7 +211,7 @@ QString DisassemblyWidget::getWidgetType()
 
 QFontMetrics DisassemblyWidget::getFontMetrics()
 {
-    return mDisasTextEdit->fontMetrics();
+    return QFontMetrics(mDisasTextEdit->font());
 }
 
 QList<DisassemblyLine> DisassemblyWidget::getLines()

--- a/src/widgets/SimpleTextGraphView.cpp
+++ b/src/widgets/SimpleTextGraphView.cpp
@@ -119,8 +119,9 @@ void SimpleTextGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block, b
 
     p.setPen(palette().color(QPalette::WindowText));
     // Render node text
+    QFontMetrics fm = QFontMetrics(p.font());
     auto x = block.x + padding / 2;
-    int y = block.y + padding / 2 + p.fontMetrics().ascent();
+    int y = block.y + padding / 2 + fm.ascent();
     p.drawText(QPoint(x, y), content.text);
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

- Address `fontMetrics()` deprecation (in favor of `QFontMetrics`)
- Add Qt 6 CI job based on Ubuntu 22.04 Jammy

**Test plan (required)**

CI is green

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

Addresses parts of https://github.com/rizinorg/cutter/issues/2464 and https://github.com/rizinorg/cutter/issues/3034