### PR TITLE
Fix #3113 - Wrong usage of rz_cmd_call instead of rz_core_cmd and @!

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -475,8 +475,8 @@ QString CutterCore::cmdRaw(const char *cmd)
     CORE_LOCK();
     rz_cons_push();
 
-    // rz_cmd_call does not return the output of the command
-    rz_cmd_call(core->rcmd, cmd);
+    // rz_core_cmd does not return the output of the command
+    rz_core_cmd(core, cmd, 0);
 
     // we grab the output straight from rz_cons
     res = rz_cons_get_buffer();
@@ -4494,7 +4494,6 @@ QByteArray CutterCore::ioRead(RVA addr, int len)
     /* Zero-copy */
     array.resize(len);
     if (!rz_io_read_at(core->io, addr, (uint8_t *)array.data(), len)) {
-        qWarning() << "Can't read data" << addr << len;
         array.fill(0xff);
     }
 

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -240,7 +240,7 @@ void HexdumpWidget::updateParseWindow(RVA start_address, int size)
 
         ui->hexDisasTextEdit->setPlainText(
                 selectedCommand != "" ? Core()->cmdRawAt(
-                        QString("%1 %2").arg(selectedCommand).arg(size), start_address)
+                        QString("%1 @! %2").arg(selectedCommand).arg(size), start_address)
                                       : "");
     } else {
         // Fill the information tab hashes and entropy


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

There were 2 issues with cutter. Cutter was calling `rz_cmd_call` instead of  `rz_core_cmd` and the HexdumpWidget was executing the `pd` commands without setting the right block size

**Closing issues**

Fix #3113