### PR TITLE
Remove `pci` hexdump parsing mode

### DIFF
--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -144,7 +144,6 @@ void HexdumpWidget::initParsing()
     ui->parseTypeComboBox->addItem(tr("String"), "pcs");
     ui->parseTypeComboBox->addItem(tr("Assembler"), "pca");
     ui->parseTypeComboBox->addItem(tr("C bytes"), "pc");
-    ui->parseTypeComboBox->addItem(tr("C bytes with instructions"), "pci");
     ui->parseTypeComboBox->addItem(tr("C half-words (2 byte)"), "pch");
     ui->parseTypeComboBox->addItem(tr("C words (4 byte)"), "pcw");
     ui->parseTypeComboBox->addItem(tr("C dwords (8 byte)"), "pcd");


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Because `pci` was removed from Rizin, remove its usage from Cutter too to prevent this problem:

<img width="1209" alt="Screenshot 2023-02-20 at 15 08 32" src="https://user-images.githubusercontent.com/203261/220037018-4d19cc3d-2169-4499-b69f-a18c90c626d0.png">


**Test plan (required)**

- Open any file
- Go to Hexdump widget
- Select "Parsing" tab, then "C  bytes with instructions" (if present there is a problem, should not be presented)
- Select some bytes range, confirm everything is in order
