### PR TITLE
Fix "New Function" Dialog (#3102)

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -314,8 +314,7 @@ void DisassemblyContextMenu::addDebugMenu()
 QVector<DisassemblyContextMenu::ThingUsedHere> DisassemblyContextMenu::getThingUsedHere(RVA offset)
 {
     RzCoreLocked core(Core());
-    auto p = fromOwned(
-        rz_core_analysis_name(core, offset), rz_core_analysis_name_free);
+    auto p = fromOwned(rz_core_analysis_name(core, offset), rz_core_analysis_name_free);
     if (!p) {
         return {};
     }
@@ -799,7 +798,6 @@ void DisassemblyContextMenu::on_actionAddComment_triggered()
 
 void DisassemblyContextMenu::on_actionAnalyzeFunction_triggered()
 {
-    bool ok;
     RVA flagOffset;
     QString name = Core()->nearestFlag(offset, &flagOffset);
     if (name.isEmpty() || flagOffset != offset) {
@@ -812,12 +810,20 @@ void DisassemblyContextMenu::on_actionAnalyzeFunction_triggered()
     }
 
     // Create dialog
-    QString functionName =
-            QInputDialog::getText(this, tr("New function at %1").arg(RzAddressString(offset)),
-                                  tr("Function name:"), QLineEdit::Normal, name, &ok);
+    QInputDialog inputDialog(this->mainWindow);
+    inputDialog.resize(500, 100);
+    inputDialog.setWindowTitle(tr("New function at %1").arg(RzAddressString(offset)));
+    inputDialog.setLabelText(tr("Function name:"));
+    inputDialog.setTextValue(name);
+    inputDialog.setWindowFlags(Qt::Window | Qt::WindowMinimizeButtonHint);
 
-    // If user accepted
-    if (ok && !functionName.isEmpty()) {
+    if (inputDialog.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    QString functionName = inputDialog.textValue().trimmed();
+
+    if (!functionName.isEmpty()) {
         Core()->createFunctionAt(offset, functionName);
     }
 }


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

The "New Function" Dialog has been expanded
The main window gets minimized along with the dialog.
The dialog window doesn't stay on top when opening another window

**Test plan (required)**

1.Right click the disassembly then use the "New Function" on the menu

*Dialog Window overlapped window and the dialog title is cluttered together*
![image](https://user-images.githubusercontent.com/47489579/220055383-66b0ea8b-da6c-46fb-93f7-2a3edd3b7516.png)

*Dialog Window is Larger*
![image](https://user-images.githubusercontent.com/47489579/220056002-5afa352b-7aab-4b6f-af2f-49ccc67d4e8a.png)

*Dialog Window doesn't overlap other windows*
![image](https://user-images.githubusercontent.com/47489579/220055934-81cf2a77-ca0d-4517-82ad-56b995081c20.png)


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #3102 
