### PR TITLE
Get type format from RzBaseType directly

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3850,7 +3850,7 @@ QList<TypeDescription> CutterCore::getBaseType(RzBaseTypeKind kind, const char *
 
         exp.type = type->name;
         exp.size = rz_type_db_base_get_bitsize(core->analysis->typedb, type);
-        exp.format = rz_type_format(core->analysis->typedb, type->name);
+        exp.format = rz_base_type_as_format(core->analysis->typedb, type);
         exp.category = tr(category);
         types << exp;
     }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

Previously used `rz_type_format()` searched `RzBaseType` from the database by name. But we already got the `RzBaseType` as the result of `rz_type_db_get_base_types_of_kind()`, thus we can omit unnecessary search. It should speedup loading of big files with a lot of types, e.g. with DWARF or PDB info available.


**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
