### PR TITLE
Fix "return" key in disassembler widget (#3090)

### DIFF
--- a/src/common/CutterSeekable.cpp
+++ b/src/common/CutterSeekable.cpp
@@ -66,6 +66,7 @@ void CutterSeekable::seekToReference(RVA offset)
     }
 
     RVA target;
+    // finds the xrefs for calls, lea, and jmp
     QList<XrefDescription> refs = Core()->getXRefs(offset, false, false);
 
     if (refs.length()) {

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -89,3 +89,13 @@ RVA DisassemblyPreview::readDisassemblyOffset(QTextCursor tc)
 
     return userData->line.offset;
 }
+
+RVA DisassemblyPreview::readDisassemblyArrow(QTextCursor tc)
+{
+    auto userData = getUserData(tc.block());
+    if (!userData && userData->line.arrow != RVA_INVALID) {
+        return RVA_INVALID;
+    }
+
+    return userData->line.arrow;
+}

--- a/src/common/DisassemblyPreview.h
+++ b/src/common/DisassemblyPreview.h
@@ -41,5 +41,11 @@ bool showDisasPreview(QWidget *parent, const QPoint &pointOfEvent, const RVA off
  * @return The disassembly offset of the hovered asm text
  */
 RVA readDisassemblyOffset(QTextCursor tc);
+
+/*!
+ * @brief Reads the arrow offset for the cursor position
+ * @return The jump address of the hovered asm text
+ */
+RVA readDisassemblyArrow(QTextCursor tc);
 }
 #endif

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -617,6 +617,12 @@ void DisassemblyWidget::jumpToOffsetUnderCursor(const QTextCursor &cursor)
     seekable->seekToReference(offset);
 }
 
+void DisassemblyWidget::jumpToArrowOffsetUnderCursor(const QTextCursor &cursor)
+{
+    RVA offset = DisassemblyPreview::readDisassemblyArrow(cursor);
+    seekable->seek(offset);
+}
+
 bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 {
     if (event->type() == QEvent::MouseButtonDblClick
@@ -647,7 +653,7 @@ void DisassemblyWidget::keyPressEvent(QKeyEvent *event)
 {
     if (event->key() == Qt::Key_Return) {
         const QTextCursor cursor = mDisasTextEdit->textCursor();
-        jumpToOffsetUnderCursor(cursor);
+        jumpToArrowOffsetUnderCursor(cursor);
     }
 
     MemoryDockWidget::keyPressEvent(event);

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -613,6 +613,13 @@ void DisassemblyWidget::moveCursorRelative(bool up, bool page)
 
 void DisassemblyWidget::jumpToOffsetUnderCursor(const QTextCursor &cursor)
 {
+    // Handles "jmp" and conditonal jump instructions
+    RVA arrow = DisassemblyPreview::readDisassemblyArrow(cursor);
+    if (arrow != RVA_INVALID) {
+        seekable->seek(arrow);
+    }
+
+    // Handles "call" and "lea" instructions
     RVA offset = DisassemblyPreview::readDisassemblyOffset(cursor);
     seekable->seekToReference(offset);
 }

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -99,6 +99,7 @@ private:
     void moveCursorRelative(bool up, bool page);
 
     void jumpToOffsetUnderCursor(const QTextCursor &);
+    void jumpToArrowOffsetUnderCursor(const QTextCursor &);
 };
 
 class DisassemblyScrollArea : public QAbstractScrollArea


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

the "return" key used to not be able to jump to the addresses with conditional jumps other than "jmp"
the "return" key can do it now

**Test plan (required)**

1. go to disassembly widget
2. put the disassembly cursor onto a disassembly line with a jump
3. press "return" key

**Closing issues**

closes #3090 