### PR TITLE
Fix "return" key in disassembler widget (#3090) and graph jumps

### DIFF
--- a/src/common/CutterSeekable.cpp
+++ b/src/common/CutterSeekable.cpp
@@ -66,6 +66,7 @@ void CutterSeekable::seekToReference(RVA offset)
     }
 
     RVA target;
+    // finds the xrefs for calls, lea, and jmp
     QList<XrefDescription> refs = Core()->getXRefs(offset, false, false);
 
     if (refs.length()) {

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -89,3 +89,13 @@ RVA DisassemblyPreview::readDisassemblyOffset(QTextCursor tc)
 
     return userData->line.offset;
 }
+
+RVA DisassemblyPreview::readDisassemblyArrow(QTextCursor tc)
+{
+    auto userData = getUserData(tc.block());
+    if (!userData && userData->line.arrow != RVA_INVALID) {
+        return RVA_INVALID;
+    }
+
+    return userData->line.arrow;
+}

--- a/src/common/DisassemblyPreview.h
+++ b/src/common/DisassemblyPreview.h
@@ -41,5 +41,11 @@ bool showDisasPreview(QWidget *parent, const QPoint &pointOfEvent, const RVA off
  * @return The disassembly offset of the hovered asm text
  */
 RVA readDisassemblyOffset(QTextCursor tc);
+
+/*!
+ * @brief Reads the arrow offset for the cursor position
+ * @return The jump address of the hovered asm text
+ */
+RVA readDisassemblyArrow(QTextCursor tc);
 }
 #endif

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -914,7 +914,41 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
                                                QPoint pos)
 {
     Q_UNUSED(event);
-    seekable->seekToReference(getAddrForMouseEvent(block, &pos));
+    RVA arrow = NULL;
+    RVA offset = getAddrForMouseEvent(block, &pos);
+    DisassemblyBlock *db = blockForAddress(offset);
+
+    Instr lastInstruction = db->instrs.back();
+
+    // Handle the blocks without any paths
+    if (offset == lastInstruction.addr && db->false_path == RVA_INVALID
+        && db->true_path == RVA_INVALID) {
+        return;
+    }
+
+    // Handle the blocks with just one path
+    if (offset == lastInstruction.addr && db->false_path == RVA_INVALID) {
+        seekable->seek(db->true_path);
+        return;
+    }
+
+    // Handle blocks with two paths
+    if (offset == lastInstruction.addr && db->false_path != RVA_INVALID) {
+        // gets the offset for the next instruction
+        RVA nextOffset = lastInstruction.addr + lastInstruction.size;
+        // sets "arrow" to the path that isn't going to the next offset
+        if (db->false_path == nextOffset) {
+            arrow = db->true_path;
+        } else if (db->true_path == nextOffset) {
+            arrow = db->false_path;
+        }
+
+        seekable->seek(arrow);
+        return;
+    }
+
+    // Handle "call" instruction to functions
+    seekable->seekToReference(offset);
 }
 
 void DisassemblerGraphView::blockHelpEvent(GraphView::GraphBlock &block, QHelpEvent *event,

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -613,6 +613,13 @@ void DisassemblyWidget::moveCursorRelative(bool up, bool page)
 
 void DisassemblyWidget::jumpToOffsetUnderCursor(const QTextCursor &cursor)
 {
+    // Handles "jmp" and conditonal jump instructions
+    RVA arrow = DisassemblyPreview::readDisassemblyArrow(cursor);
+    if (arrow != RVA_INVALID) {
+        seekable->seek(arrow);
+    }
+
+    // Handles "call" and "lea" instructions
     RVA offset = DisassemblyPreview::readDisassemblyOffset(cursor);
     seekable->seekToReference(offset);
 }
@@ -627,9 +634,8 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
         jumpToOffsetUnderCursor(cursor);
 
         return true;
-    } else if (Config()->getPreviewValue()
-            && event->type() == QEvent::ToolTip
-            && obj == mDisasTextEdit->viewport()) {
+    } else if (Config()->getPreviewValue() && event->type() == QEvent::ToolTip
+               && obj == mDisasTextEdit->viewport()) {
         QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
 
         auto cursorForWord = mDisasTextEdit->cursorForPosition(helpEvent->pos());


### PR DESCRIPTION
Fixed the return key in disassembler
Fix graph jumps

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

I fixed the problem with the disassembler not jumping when the instruction is a jump conditional
The graph also had a similar problem with not jumping when the instruction is a conditional jump so I also fixed the graph jumps since it also used similar functions to when the disassembler wants to jump.

**Test plan (required)**

The test can be performed on "jne" instruction and other conditonal jump instructions.
The test should also be performed on the disassembler graph.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #3140 
closes #3090
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
