### PR TITLE
Unify parents of dialogs shown by DisassemblyContextMenu

### DIFF
--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -387,7 +387,7 @@ void DecompilerContextMenu::actionCopyReferenceAddressTriggered()
 
 void DecompilerContextMenu::actionAddCommentTriggered()
 {
-    CommentsDialog::addOrEditComment(this->firstOffsetInLine, this);
+    CommentsDialog::addOrEditComment(this->firstOffsetInLine, parentForDialog());
 }
 
 void DecompilerContextMenu::actionDeleteCommentTriggered()

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -161,6 +161,11 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
 
 DisassemblyContextMenu::~DisassemblyContextMenu() {}
 
+QWidget *DisassemblyContextMenu::parentForDialog()
+{
+    return parentWidget();
+}
+
 void DisassemblyContextMenu::addSetBaseMenu()
 {
     setBaseMenu = addMenu(tr("Set Immediate Base to..."));
@@ -690,7 +695,7 @@ void DisassemblyContextMenu::on_actionEditInstruction_triggered()
     if (!ioModesController.prepareForWriting()) {
         return;
     }
-    EditInstructionDialog e(EDIT_TEXT, this);
+    EditInstructionDialog e(EDIT_TEXT, parentForDialog());
     e.setWindowTitle(tr("Edit Instruction at %1").arg(RzAddressString(offset)));
 
     QString oldInstructionOpcode = Core()->getInstructionOpcode(offset);
@@ -740,7 +745,7 @@ void DisassemblyContextMenu::on_actionEditBytes_triggered()
     if (!ioModesController.prepareForWriting()) {
         return;
     }
-    EditInstructionDialog e(EDIT_BYTES, this);
+    EditInstructionDialog e(EDIT_BYTES, parentForDialog());
     e.setWindowTitle(tr("Edit Bytes at %1").arg(RzAddressString(offset)));
 
     QString oldBytes = Core()->getInstructionBytes(offset);
@@ -774,9 +779,9 @@ void DisassemblyContextMenu::on_actionAdvancedBreakpoint_triggered()
 {
     int index = Core()->breakpointIndexAt(offset);
     if (index >= 0) {
-        BreakpointsDialog::editBreakpoint(Core()->getBreakpointAt(offset), this);
+        BreakpointsDialog::editBreakpoint(Core()->getBreakpointAt(offset), parentForDialog());
     } else {
-        BreakpointsDialog::createNewBreakpoint(offset, this);
+        BreakpointsDialog::createNewBreakpoint(offset, parentForDialog());
     }
 }
 
@@ -793,7 +798,7 @@ void DisassemblyContextMenu::on_actionSetPC_triggered()
 
 void DisassemblyContextMenu::on_actionAddComment_triggered()
 {
-    CommentsDialog::addOrEditComment(offset, this);
+    CommentsDialog::addOrEditComment(offset, parentForDialog());
 }
 
 void DisassemblyContextMenu::on_actionAnalyzeFunction_triggered()
@@ -810,7 +815,7 @@ void DisassemblyContextMenu::on_actionAnalyzeFunction_triggered()
     }
 
     // Create dialog
-    QInputDialog inputDialog(this->mainWindow);
+    QInputDialog inputDialog(parentForDialog());
     inputDialog.resize(500, 100);
     inputDialog.setWindowTitle(tr("New function at %1").arg(RzAddressString(offset)));
     inputDialog.setLabelText(tr("Function name:"));
@@ -839,12 +844,12 @@ void DisassemblyContextMenu::on_actionRename_triggered()
             Core()->renameFunction(doRenameInfo.addr, newName);
         }
     } else if (doRenameAction == RENAME_FLAG || doRenameAction == RENAME_ADD_FLAG) {
-        FlagDialog dialog(doRenameInfo.addr, this->mainWindow);
+        FlagDialog dialog(doRenameInfo.addr, parentForDialog());
         ok = dialog.exec();
     } else if (doRenameAction == RENAME_LOCAL) {
         RzAnalysisFunction *fcn = Core()->functionIn(offset);
         if (fcn) {
-            EditVariablesDialog dialog(fcn->addr, curHighlightedWord, this->mainWindow);
+            EditVariablesDialog dialog(fcn->addr, curHighlightedWord, parentForDialog());
             if (!dialog.empty()) {
                 // Don't show the dialog if there are no variables
                 ok = dialog.exec();
@@ -873,7 +878,7 @@ void DisassemblyContextMenu::on_actionSetFunctionVarTypes_triggered()
         return;
     }
 
-    EditVariablesDialog dialog(fcn->addr, curHighlightedWord, this->mainWindow);
+    EditVariablesDialog dialog(fcn->addr, curHighlightedWord, parentForDialog());
     if (dialog.empty()) { // don't show the dialog if there are no variables
         return;
     }
@@ -898,7 +903,7 @@ void DisassemblyContextMenu::on_actionXRefsForVariables_triggered()
 
 void DisassemblyContextMenu::on_actionDisplayOptions_triggered()
 {
-    PreferencesDialog dialog(this->window());
+    PreferencesDialog dialog(parentForDialog());
     dialog.showSection(PreferencesDialog::Section::Disassembly);
     dialog.exec();
 }
@@ -920,7 +925,7 @@ void DisassemblyContextMenu::on_actionSetAsStringRemove_triggered()
 
 void DisassemblyContextMenu::on_actionSetAsStringAdvanced_triggered()
 {
-    EditStringDialog dialog(parentWidget());
+    EditStringDialog dialog(parentForDialog());
     const int predictedStrSize = Core()->getString(offset).size();
     dialog.setStringSizeValue(predictedStrSize);
     dialog.setStringStartAddress(offset);
@@ -970,7 +975,7 @@ void DisassemblyContextMenu::on_actionSetToData_triggered()
 
 void DisassemblyContextMenu::on_actionSetToDataEx_triggered()
 {
-    SetToDataDialog dialog(offset, this->window());
+    SetToDataDialog dialog(offset, parentForDialog());
     if (!dialog.exec()) {
         return;
     }
@@ -1000,7 +1005,7 @@ void DisassemblyContextMenu::on_actionDeleteFunction_triggered()
 void DisassemblyContextMenu::on_actionEditFunction_triggered()
 {
     RzCore *core = Core()->core();
-    EditFunctionDialog dialog(mainWindow);
+    EditFunctionDialog dialog(parentForDialog());
     RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(core->analysis, offset, 0);
 
     if (fcn) {

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -168,6 +168,11 @@ private:
     QMenu *pluginMenu = nullptr;
     QAction *pluginActionMenuAction = nullptr;
 
+    /**
+     * \return widget that should be used as parent for presenting dialogs
+     */
+    QWidget *parentForDialog();
+
     // For creating anonymous entries (that are always visible)
     QAction *addAnonymousAction(QString name, const char *slot, QKeySequence shortcut);
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Analogous to 2d7fd02a62dd3405d5405a997a8263c6e7706d67, parents of dialogs shown from the DisassemblyContextMenu are consistent now and windowing issues when lauched through shortcuts are fixed.

**Test plan (required)**

* Seek to some offset in the disassembly
* Press ; to add a comment
* The dialog should be positioned in a sensible position and not at e.g. (0, 0).
