### PR TITLE
Graph widget - do not print basic block address - Fixed 

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -345,7 +345,6 @@ void DisassemblerGraphView::prepareGraphNode(GraphBlock &block)
             lw += mFontMetrics->width(part.text);
         if (lw > width)
             width = lw;
-        height += 1;
     }
     for (Instr &instr : db.instrs) {
         for (auto &line : instr.text.lines) {
@@ -469,11 +468,6 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block,
     // Render node text
     auto x = block.x + padding;
     int y = block.y + getTextOffset(0).y();
-    for (auto &line : db.header_text.lines) {
-        RichTextPainter::paintRichText<qreal>(&p, x, y, block.width, charHeight, 0, line,
-                                              mFontMetrics.get());
-        y += charHeight;
-    }
 
     auto bih = Core()->getBIHighlighter();
     for (const Instr &instr : db.instrs) {

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -108,7 +108,6 @@ public:
 
     void loadCurrentGraph();
     QString windowTitle;
-
     int getWidth() { return width; }
     int getHeight() { return height; }
     std::unordered_map<ut64, GraphBlock> getBlocks() { return blocks; }


### PR DESCRIPTION

**Checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's   [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the  [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

To make these changes, I removed the lines that were responsible for rendering the "Extra Address" section, and I also removed the lines that were increasing the height of the graph block.

**Test plan (required)**
I have converted the design from taking up extra space on the screen (see image 1) to the design with a reduced block height, which saves space on the screen (see image 2).

Image 1
![image](https://user-images.githubusercontent.com/52560435/227731356-02520834-e8c9-44da-80ff-1dd66e8aed24.png)

Image 2
![image](https://user-images.githubusercontent.com/52560435/227731262-c5d06990-4c10-49a2-908c-98c1ea99c0b1.png)


**Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**
This pull request closes issue #3144.
