### PR TITLE
Remove "copy" action from context menu documentation

### DIFF
--- a/docs/source/user-docs/menus/disassembly-context-menu.rst
+++ b/docs/source/user-docs/menus/disassembly-context-menu.rst
@@ -9,14 +9,6 @@ Disassembly Context Menu
 
 The Disassembly context menu contains actions that operate with selected instruction in disassembly and graph widgets.
 
-Copy
-----------------------------------------
-**Description:** Copy the selected text.  
-
-**Steps:**  Right-click on a selected text and choose ``Copy``  
-
-**Shortcut:** :kbd:`Ctrl` + :kbd:`C`  
-
 Copy Address
 ----------------------------------------
 **Description:** Copy the address of the location under the cursor.  


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**
Removed "copy" from documentations because it has been removed from the disassembly context menu

Current context menu
![image](https://user-images.githubusercontent.com/47489579/227792016-640a2b3b-2a98-4b1a-b0ca-1a9d74ddb7c6.png)

**Closing issues**

