### PR TITLE
Show C type definition in tooltip in Types widget

### DIFF
--- a/src/widgets/TypesWidget.cpp
+++ b/src/widgets/TypesWidget.cpp
@@ -14,6 +14,17 @@ TypesModel::TypesModel(QList<TypeDescription> *types, QObject *parent)
 {
 }
 
+QVariant TypesModel::toolTipValue(const QModelIndex &index) const
+{
+    TypeDescription t = index.data(TypesModel::TypeDescriptionRole).value<TypeDescription>();
+
+    if (t.category == "Primitive") {
+        return QVariant();
+    }
+
+    return Core()->getTypeAsC(t.type).trimmed();
+}
+
 int TypesModel::rowCount(const QModelIndex &) const
 {
     return types->count();
@@ -45,6 +56,8 @@ QVariant TypesModel::data(const QModelIndex &index, int role) const
         default:
             return QVariant();
         }
+    case Qt::ToolTipRole:
+        return toolTipValue(index);
     case TypeDescriptionRole:
         return QVariant::fromValue(exp);
     default:

--- a/src/widgets/TypesWidget.h
+++ b/src/widgets/TypesWidget.h
@@ -30,6 +30,11 @@ class TypesModel : public QAbstractListModel
 private:
     QList<TypeDescription> *types;
 
+    /**
+     * @brief Returns a description of the type for the given index
+     */
+    QVariant toolTipValue(const QModelIndex &index) const;
+
 public:
     enum Columns { TYPE = 0, SIZE, CATEGORY, FORMAT, COUNT };
     static const int TypeDescriptionRole = Qt::UserRole;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
This PR adds a tooltip with the C type definition when hovering a line in the Types widget.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

![2023-05-04-113125_490x364_scrot](https://user-images.githubusercontent.com/2215778/236167841-60726d3e-a943-47e4-8611-0f964329fa1e.png)


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #3143
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
