### PR TITLE
Only jump to reference when double-clicking with left mouse button.

### DIFF
--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -623,10 +623,12 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
         && (obj == mDisasTextEdit || obj == mDisasTextEdit->viewport())) {
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
 
-        const QTextCursor &cursor = mDisasTextEdit->cursorForPosition(mouseEvent->pos());
-        jumpToOffsetUnderCursor(cursor);
+        if (mouseEvent->button() == Qt::LeftButton) {
+            const QTextCursor &cursor = mDisasTextEdit->cursorForPosition(mouseEvent->pos());
+            jumpToOffsetUnderCursor(cursor);
 
-        return true;
+            return true;
+        }
     } else if (Config()->getPreviewValue()
             && event->type() == QEvent::ToolTip
             && obj == mDisasTextEdit->viewport()) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

In the disassembly widget, double clicking a reference (such as `rip + 0x123` within a `lea rdi, [rip + 0x123]` instruction) seeks the corresponding offset. However, this happens regardless of which mouse button was double-clicked, which messes with mouse-based history navigation (for mouses with back/forward buttons).
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

Cf. #3173
<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #3173
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
