### PR TITLE
Get rid of stale jump arrows in disassembly widget.

### DIFF
--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -132,7 +132,7 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main)
     connect(Core(), &CutterCore::functionRenamed, this, [this]() { refreshDisasm(); });
     connect(Core(), SIGNAL(varsChanged()), this, SLOT(refreshDisasm()));
     connect(Core(), SIGNAL(asmOptionsChanged()), this, SLOT(refreshDisasm()));
-    connect(Core(), &CutterCore::instructionChanged, this, &DisassemblyWidget::refreshIfInRange);
+    connect(Core(), &CutterCore::instructionChanged, this, &DisassemblyWidget::instructionChanged);
     connect(Core(), &CutterCore::breakpointsChanged, this, &DisassemblyWidget::refreshIfInRange);
     connect(Core(), SIGNAL(refreshCodeViews()), this, SLOT(refreshDisasm()));
 
@@ -224,6 +224,12 @@ void DisassemblyWidget::refreshIfInRange(RVA offset)
     if (offset >= topOffset && offset <= bottomOffset) {
         refreshDisasm();
     }
+}
+
+void DisassemblyWidget::instructionChanged(RVA offset)
+{
+    leftPanel->clearArrowFrom(offset);
+    refreshDisasm();
 }
 
 void DisassemblyWidget::refreshDisasm(RVA offset)
@@ -989,4 +995,13 @@ void DisassemblyLeftPanel::paintEvent(QPaintEvent *event)
     }
 
     lastBeginOffset = lines.first().offset;
+}
+
+void DisassemblyLeftPanel::clearArrowFrom(RVA offset)
+{
+    auto it = std::find_if(arrows.begin(), arrows.end(),
+                           [&](const Arrow &it) { return it.jmpFromOffset() == offset; });
+    if (it != arrows.end()) {
+        arrows.erase(it);
+    }
 }

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -53,6 +53,7 @@ public slots:
 protected slots:
     void on_seekChanged(RVA offset);
     void refreshIfInRange(RVA offset);
+    void instructionChanged(RVA offset);
     void refreshDisasm(RVA offset = RVA_INVALID);
 
     bool updateMaxLines();
@@ -153,6 +154,7 @@ public:
     DisassemblyLeftPanel(DisassemblyWidget *disas);
     void paintEvent(QPaintEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
+    void clearArrowFrom(RVA offset);
 
 private:
     DisassemblyWidget *disas;


### PR DESCRIPTION


<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

This commit forces the jump arrows to be recomputed upon `paintEvent`, thus avoiding to draw stale arrows (e.g. after a jump instruction was edited).

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

Cf. #3114


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #3114
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
