### PR TITLE
Keep scroll history in decompiler widget.

### DIFF
--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -418,7 +418,9 @@ void DecompilerWidget::seekChanged(RVA /* addr */, CutterCore::SeekHistoryType t
     }
     if (type == CutterCore::SeekHistoryType::New) {
         // Erase previous history past this point.
-        scrollHistory.erase(scrollHistory.begin() + historyPos + 1, scrollHistory.end());
+        if (scrollHistory.size() > historyPos + 1) {
+            scrollHistory.erase(scrollHistory.begin() + historyPos + 1, scrollHistory.end());
+        }
         scrollHistory.push_back({ 0, 0 });
         historyPos = scrollHistory.size() - 1;
     } else if (type == CutterCore::SeekHistoryType::Undo) {

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -53,7 +53,7 @@ private slots:
      *     - Seek changed to an offset contained in the decompiled function.
      *     - Auto-refresh is disabled.
      */
-    void seekChanged();
+    void seekChanged(RVA /* addr */, CutterCore::SeekHistoryType type);
     void decompilationFinished(RzAnnotatedCode *code);
 
 private:
@@ -72,8 +72,8 @@ private:
     bool decompilerBusy;
 
     bool seekFromCursor;
-    int scrollerHorizontal;
-    int scrollerVertical;
+    int historyPos;
+    QVector<QPair<int, int>> scrollHistory;
     RVA previousFunctionAddr;
     RVA decompiledFunctionAddr;
     std::unique_ptr<RzAnnotatedCode, void (*)(RzAnnotatedCode *)> code;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

This commit adds a `scrollHistory` on top of the rizin-managed
history, that keeps track of the scroll position within decompiled
functions. It basically does for the decompiler widget what #3171 
does for the disassembly widget.
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

1. Navigate through various functions in the decompiler widget.
2. Go back in history.
3. Notice that the scroll position is conserved.
<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
