### PR TITLE
Fix disassembly scroll history.

### DIFF
--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -665,8 +665,10 @@ void DisassemblyWidget::on_seekChanged(RVA offset, CutterCore::SeekHistoryType t
 {
     if (type == CutterCore::SeekHistoryType::New) {
         // Erase previous history past this point.
-        topOffsetHistory.erase(topOffsetHistory.begin() + topOffsetHistoryPos + 1,
-                               topOffsetHistory.end());
+        if (topOffsetHistory.size() > topOffsetHistoryPos + 1) {
+            topOffsetHistory.erase(topOffsetHistory.begin() + topOffsetHistoryPos + 1,
+                                   topOffsetHistory.end());
+        }
         topOffsetHistory.push_back(offset);
         topOffsetHistoryPos = topOffsetHistory.size() - 1;
     } else if (type == CutterCore::SeekHistoryType::Undo) {


### PR DESCRIPTION

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Cf. #3181.
Avoid calling `erase()` when `topOffsetHistoryPos + 1 >= `topOffsetHistory.size()`.
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #3181
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
