### PR TITLE
Fix broken English in UI

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -143,8 +143,8 @@ Configuration::Configuration() : QObject(), nativePalette(qApp->palette())
     mPtr = this;
     if (!s.isWritable()) {
         QMessageBox::critical(
-                nullptr, tr("Critical!"),
-                tr("!!! Settings are not writable! Make sure you have a write access to \"%1\"")
+                nullptr, tr("Critical Error!"),
+                tr("Settings are not writable! Make sure you have a write access to \"%1\".")
                         .arg(s.fileName()));
     }
 #ifdef CUTTER_ENABLE_KSYNTAXHIGHLIGHTING

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -44,13 +44,6 @@ bool DisassemblyPreview::showDisasPreview(QWidget *parent, const QPoint &pointOf
         }
 
         RVA offsetTo = refs.at(0).to; // This is the offset we want to preview
-
-        if (Q_UNLIKELY(offsetFrom != refs.at(0).from)) {
-            qWarning() << QObject::tr("offsetFrom (%1) differs from refs.at(0).from (%(2))")
-                                  .arg(offsetFrom)
-                                  .arg(refs.at(0).from);
-        }
-
         /*
          * Only if the offset we point *to* is different from the one the cursor is currently
          * on *and* the former is a valid offset, we are allowed to get a preview of offsetTo

--- a/src/dialogs/InitialOptionsDialog.ui
+++ b/src/dialogs/InitialOptionsDialog.ui
@@ -323,7 +323,7 @@
            </size>
           </property>
           <property name="text">
-           <string>Auto Exp</string>
+           <string>Experimental</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -287,7 +287,7 @@ void NewFileDialog::fillIOPluginsList()
 {
     ui->ioPlugin->clear();
     ui->ioPlugin->addItem("file://");
-    ui->ioPlugin->setItemData(0, tr("Open a file with no extra treatment."), Qt::ToolTipRole);
+    ui->ioPlugin->setItemData(0, tr("Open a file without additional options/settings."), Qt::ToolTipRole);
 
     int index = 1;
     QList<RzIOPluginDescription> ioPlugins = Core()->getRIOPluginDescriptions();

--- a/src/dialogs/preferences/AsmOptionsWidget.ui
+++ b/src/dialogs/preferences/AsmOptionsWidget.ui
@@ -142,7 +142,7 @@
                 <item row="17" column="1">
                  <widget class="QLabel" name="asmTabsOffLabel">
                   <property name="text">
-                   <string>Tabs before assembly (asm.tabs.off):</string>
+                   <string>The number of tabulate spaces after the offset (asm.tabs.off):</string>
                   </property>
                   <property name="textInteractionFlags">
                    <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
@@ -479,7 +479,7 @@
              <item>
               <widget class="QCheckBox" name="varsubCheckBox">
                <property name="text">
-                <string>Substitute variables (asm.sub.var)</string>
+                <string>Substitute variables in disassembly (asm.sub.var)</string>
                </property>
               </widget>
              </item>

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -168,7 +168,7 @@ QWidget *DisassemblyContextMenu::parentForDialog()
 
 void DisassemblyContextMenu::addSetBaseMenu()
 {
-    setBaseMenu = addMenu(tr("Set Immediate Base to..."));
+    setBaseMenu = addMenu(tr("Set base of immediate value to.."));
 
     initAction(&actionSetBaseBinary, tr("Binary"));
     setBaseMenu->addAction(&actionSetBaseBinary);

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -400,8 +400,7 @@ const QMap<QString, OptionInfo> optionInfoMap__ = {
     { "fname", { QObject::tr("Color of names of functions"), QObject::tr("Function name") } },
     { "floc", { QObject::tr("Color of function location"), QObject::tr("Function location") } },
     { "fline",
-      { QObject::tr(
-                "Color of ascii line in left side that shows what opcodes are belong to function"),
+      { QObject::tr("Color of the line which shows which opcodes belongs to a function"),
         QObject::tr("Function line") } },
     { "flag",
       { QObject::tr("Color of flags (similar to bookmarks for offset)"), QObject::tr("Flag") } },

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -160,7 +160,7 @@ HexWidget::HexWidget(QWidget *parent)
     connect(actionWriteCString, &QAction::triggered, this, &HexWidget::w_writeCString);
     actionsWriteString.append(actionWriteCString);
 
-    QAction *actionWrite64 = new QAction(tr("Write De\\Encoded Base64 string"), this);
+    QAction *actionWrite64 = new QAction(tr("Write a decoded or encoded Base64 string"), this);
     connect(actionWrite64, &QAction::triggered, this, &HexWidget::w_write64);
     actionsWriteString.append(actionWrite64);
 
@@ -1407,7 +1407,7 @@ void HexWidget::w_writeRandom()
     }
 
     bool ok = false;
-    int nbytes = QInputDialog::getInt(this, tr("Write random"), tr("Number of bytes:"), size, 1,
+    int nbytes = QInputDialog::getInt(this, tr("Write random bytes"), tr("Number of bytes:"), size, 1,
                                       0x7FFFFFFF, 1, &ok);
     if (!ok) {
         return;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Fixes various English strings in the Cutter UI.

Needs to be cherry-picked for https://github.com/rizinorg/cutter/pull/3168