### PR TITLE
Show disassembly var tooltips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ docs/source/_build
 # Local gdb files
 .gdb_history
 .gdbinit
+
+# Kdevelop
+.kdev/
+*.kdev4

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -134,7 +134,6 @@ static const QHash<QString, QVariant> asmOptions = { { "asm.esil", false },
                                                      { "asm.flags.real", true },
                                                      { "asm.reloff", false },
                                                      { "asm.reloff.flags", false },
-                                                     { "asm.varTooltips", false },
                                                      { "esil.breakoninvalid", true },
                                                      { "dbg.trace_continue", true },
                                                      { "graph.offset", false } };
@@ -786,12 +785,12 @@ bool Configuration::getPreviewValue() const
 
 void Configuration::setShowVarTooltips(bool enabled)
 {
-    s.setValue("asm.varTooltips", enabled);
+    s.setValue("showVarTooltips", enabled);
 }
 
 bool Configuration::getShowVarTooltips() const
 {
-    return s.value("asm.varTooltips").toBool();
+    return s.value("showVarTooltips").toBool();
 }
 
 bool Configuration::getGraphBlockEntryOffset()

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -134,6 +134,7 @@ static const QHash<QString, QVariant> asmOptions = { { "asm.esil", false },
                                                      { "asm.flags.real", true },
                                                      { "asm.reloff", false },
                                                      { "asm.reloff.flags", false },
+                                                     { "asm.varTooltips", false },
                                                      { "esil.breakoninvalid", true },
                                                      { "dbg.trace_continue", true },
                                                      { "graph.offset", false } };
@@ -781,6 +782,16 @@ void Configuration::setPreviewValue(bool checked)
 bool Configuration::getPreviewValue() const
 {
     return s.value("asm.preview").toBool();
+}
+
+void Configuration::setShowVarTooltips(bool enabled)
+{
+    s.setValue("asm.varTooltips", enabled);
+}
+
+bool Configuration::getShowVarTooltips() const
+{
+    return s.value("asm.varTooltips").toBool();
 }
 
 bool Configuration::getGraphBlockEntryOffset()

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -216,6 +216,12 @@ public:
     bool getPreviewValue() const;
 
     /**
+     * @brief Show tooltips for known values of registers, variables, and memory when debugging
+     */
+    void setShowVarTooltips(bool enabled);
+    bool getShowVarTooltips() const;
+
+    /**
      * @brief Recently opened binaries, as shown in NewFileDialog.
      */
     QStringList getRecentFiles() const;

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -83,23 +83,24 @@ RVA DisassemblyPreview::readDisassemblyOffset(QTextCursor tc)
     return userData->line.offset;
 }
 
-
-typedef struct mmio_lookup_context {
+typedef struct mmio_lookup_context
+{
     QString selected;
     RVA mmio_address;
 } mmio_lookup_context_t;
 
-
-static bool lookup_mmio_addr_cb(void *user, const ut64 key, const void *value) {
-    mmio_lookup_context_t* ctx = (mmio_lookup_context_t*) user;
-    if (ctx->selected == (const char*)value) {
+static bool lookup_mmio_addr_cb(void *user, const ut64 key, const void *value)
+{
+    mmio_lookup_context_t *ctx = (mmio_lookup_context_t *)user;
+    if (ctx->selected == (const char *)value) {
         ctx->mmio_address = key;
         return false;
     }
     return true;
 }
 
-bool DisassemblyPreview::showDebugValueTooltip(QWidget *parent, const QPoint &pointOfEvent, const QString &selectedText, const RVA offset)
+bool DisassemblyPreview::showDebugValueTooltip(QWidget *parent, const QPoint &pointOfEvent,
+                                               const QString &selectedText, const RVA offset)
 {
     if (selectedText.isEmpty())
         return false;
@@ -118,7 +119,7 @@ bool DisassemblyPreview::showDebugValueTooltip(QWidget *parent, const QPoint &po
 
         if (offset != RVA_INVALID) {
             auto vars = Core()->getVariables(offset);
-            for (auto &var: vars) {
+            for (auto &var : vars) {
                 if (var.name == selectedText) {
                     auto msg = Core()->cmdRawAt(QString("afvd %1").arg(var.name), offset);
                     QToolTip::showText(pointOfEvent, msg.trimmed(), parent);

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -121,8 +121,8 @@ bool DisassemblyPreview::showDebugValueTooltip(QWidget *parent, const QPoint &po
             auto vars = Core()->getVariables(offset);
             for (auto &var : vars) {
                 if (var.name == selectedText) {
-                    auto msg = Core()->cmdRawAt(QString("afvd %1").arg(var.name), offset);
-                    QToolTip::showText(pointOfEvent, msg.trimmed(), parent);
+                    auto msg = QString("var %1 = %2").arg(var.name, var.value);
+                    QToolTip::showText(pointOfEvent, msg, parent);
                     return true;
                 }
             }

--- a/src/common/DisassemblyPreview.h
+++ b/src/common/DisassemblyPreview.h
@@ -41,5 +41,12 @@ bool showDisasPreview(QWidget *parent, const QPoint &pointOfEvent, const RVA off
  * @return The disassembly offset of the hovered asm text
  */
 RVA readDisassemblyOffset(QTextCursor tc);
+
+/**
+ * @brief Show a QToolTip that shows the value of the highlighted register, variable, or memory
+ * @return True if the tooltip is shown
+ */
+bool showDebugValueTooltip(QWidget *parent, const QPoint &pointOfEvent, const QString &selectedText, const RVA offset);
+
 }
 #endif

--- a/src/common/DisassemblyPreview.h
+++ b/src/common/DisassemblyPreview.h
@@ -46,7 +46,8 @@ RVA readDisassemblyOffset(QTextCursor tc);
  * @brief Show a QToolTip that shows the value of the highlighted register, variable, or memory
  * @return True if the tooltip is shown
  */
-bool showDebugValueTooltip(QWidget *parent, const QPoint &pointOfEvent, const QString &selectedText, const RVA offset);
+bool showDebugValueTooltip(QWidget *parent, const QPoint &pointOfEvent, const QString &selectedText,
+                           const RVA offset);
 
 }
 #endif

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1804,6 +1804,12 @@ QList<VariableDescription> CutterCore::getVariables(RVA at)
         }
         desc.type = QString::fromUtf8(tn);
         rz_mem_free(tn);
+
+        if (char *v = rz_core_analysis_var_display(core, var, false)) {
+            desc.value = QString::fromUtf8(v).trimmed();
+            rz_mem_free(v);
+        }
+
         ret.push_back(desc);
     }
     return ret;

--- a/src/core/CutterDescriptions.h
+++ b/src/core/CutterDescriptions.h
@@ -357,6 +357,7 @@ struct VariableDescription
     RzAnalysisVarStorageType storageType;
     QString name;
     QString type;
+    QString value;
 };
 
 struct RegisterRefValueDescription

--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -42,7 +42,8 @@ AsmOptionsWidget::AsmOptionsWidget(PreferencesDialog *dialog)
                    { ui->emuStrCheckBox, "emu.str" },
                    { ui->varsumCheckBox, "asm.var.summary" },
                    { ui->sizeCheckBox, "asm.size" },
-                   { ui->realnameCheckBox, "asm.flags.real" } };
+                   { ui->realnameCheckBox, "asm.flags.real" },
+                   { ui->varTooltipsCheckBox, "asm.varTooltips" } };
 
     QList<ConfigCheckbox>::iterator confCheckbox;
 

--- a/src/dialogs/preferences/AsmOptionsWidget.cpp
+++ b/src/dialogs/preferences/AsmOptionsWidget.cpp
@@ -42,8 +42,7 @@ AsmOptionsWidget::AsmOptionsWidget(PreferencesDialog *dialog)
                    { ui->emuStrCheckBox, "emu.str" },
                    { ui->varsumCheckBox, "asm.var.summary" },
                    { ui->sizeCheckBox, "asm.size" },
-                   { ui->realnameCheckBox, "asm.flags.real" },
-                   { ui->varTooltipsCheckBox, "asm.varTooltips" } };
+                   { ui->realnameCheckBox, "asm.flags.real" } };
 
     QList<ConfigCheckbox>::iterator confCheckbox;
 
@@ -66,6 +65,12 @@ AsmOptionsWidget::AsmOptionsWidget(PreferencesDialog *dialog)
             &AsmOptionsWidget::relOffCheckBoxToggled);
     connect(Core(), &CutterCore::asmOptionsChanged, this,
             &AsmOptionsWidget::updateAsmOptionsFromVars);
+
+    connect(ui->varTooltipsCheckBox, &QCheckBox::toggled, [this](bool checked) {
+        Config()->setShowVarTooltips(checked);
+        triggerAsmOptionsChanged();
+    });
+
     updateAsmOptionsFromVars();
 }
 
@@ -138,6 +143,8 @@ void AsmOptionsWidget::updateAsmOptionsFromVars()
     ui->previewCheckBox->blockSignals(true);
     ui->previewCheckBox->setChecked(Config()->getPreviewValue());
     ui->previewCheckBox->blockSignals(false);
+
+    qhelpers::setCheckedWithoutSignals(ui->varTooltipsCheckBox, Config()->getShowVarTooltips());
 
     QList<ConfigCheckbox>::iterator confCheckbox;
 

--- a/src/dialogs/preferences/AsmOptionsWidget.ui
+++ b/src/dialogs/preferences/AsmOptionsWidget.ui
@@ -48,8 +48,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>582</width>
-              <height>766</height>
+              <width>686</width>
+              <height>886</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -65,51 +65,114 @@
                 <string>Disassembly</string>
                </property>
                <layout class="QGridLayout" name="gridLayout">
-                <item row="12" column="2">
-                 <widget class="QSpinBox" name="nbytesSpinBox">
-                  <property name="enabled">
-                   <bool>true</bool>
-                  </property>
+                <item row="5" column="2">
+                 <widget class="QComboBox" name="caseComboBox">
+                  <item>
+                   <property name="text">
+                    <string>Lowercase</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>Uppercase (asm.ucase)</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>Capitalize (asm.capitalize)</string>
+                   </property>
+                  </item>
                  </widget>
                 </item>
-                <item row="17" column="2">
-                 <widget class="QSpinBox" name="asmTabsOffSpinBox">
-                  <property name="maximum">
-                   <number>100</number>
-                  </property>
-                  <property name="singleStep">
-                   <number>5</number>
-                  </property>
-                 </widget>
-                </item>
-                <item row="19" column="1" colspan="2">
-                 <widget class="QCheckBox" name="lbytesCheckBox">
+                <item row="17" column="1">
+                 <widget class="QLabel" name="asmTabsLabel">
                   <property name="text">
-                   <string>Align bytes to the left (asm.lbytes)</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="15" column="1">
-                 <widget class="QCheckBox" name="previewCheckBox">
-                  <property name="text">
-                   <string>Show preview when hovering:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="4" column="1">
-                 <widget class="QLabel" name="syntaxLabel">
-                  <property name="text">
-                   <string>Syntax (asm.syntax):</string>
+                   <string>Tabs in assembly (asm.tabs):</string>
                   </property>
                   <property name="textInteractionFlags">
                    <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
                   </property>
                  </widget>
                 </item>
-                <item row="8" column="2">
-                 <widget class="QCheckBox" name="relOffFlagsCheckBox">
+                <item row="11" column="1">
+                 <widget class="QCheckBox" name="bytesCheckBox">
                   <property name="text">
-                   <string>Flags (asm.reloff.flags)</string>
+                   <string>Display the bytes of each instruction (asm.bytes)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="1">
+                 <widget class="QLabel" name="label">
+                  <property name="text">
+                   <string>Show Disassembly as:</string>
+                  </property>
+                  <property name="textInteractionFlags">
+                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1" colspan="2">
+                 <spacer name="verticalSpacer_3">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>10</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item row="13" column="1">
+                 <widget class="QCheckBox" name="realnameCheckBox">
+                  <property name="text">
+                   <string>Display flags' real name (asm.flags.real)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="8" column="1">
+                 <layout class="QHBoxLayout" name="horizontalLayout">
+                  <item>
+                   <widget class="QLabel" name="relOffsetLabel">
+                    <property name="text">
+                     <string>Show offsets relative to:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="relOffsetCheckBox">
+                    <property name="text">
+                     <string>Functions (asm.reloff)</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+                <item row="18" column="1">
+                 <widget class="QLabel" name="asmTabsOffLabel">
+                  <property name="text">
+                   <string>The number of tabulate spaces after the offset (asm.tabs.off):</string>
+                  </property>
+                  <property name="textInteractionFlags">
+                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="19" column="1" colspan="2">
+                 <widget class="QCheckBox" name="indentCheckBox">
+                  <property name="text">
+                   <string>Indent disassembly based on reflines depth (asm.indent)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="1">
+                 <widget class="QCheckBox" name="offsetCheckBox">
+                  <property name="text">
+                   <string>Show offsets (asm.offset)</string>
                   </property>
                  </widget>
                 </item>
@@ -132,20 +195,44 @@
                   </item>
                  </widget>
                 </item>
-                <item row="7" column="1">
-                 <widget class="QCheckBox" name="offsetCheckBox">
+                <item row="14" column="1" colspan="2">
+                 <widget class="QCheckBox" name="bblineCheckBox">
                   <property name="text">
-                   <string>Show offsets (asm.offset)</string>
+                   <string>Show empty line after every basic block (asm.bb.line)</string>
                   </property>
                  </widget>
                 </item>
-                <item row="17" column="1">
-                 <widget class="QLabel" name="asmTabsOffLabel">
+                <item row="15" column="1">
+                 <widget class="QCheckBox" name="previewCheckBox">
                   <property name="text">
-                   <string>The number of tabulate spaces after the offset (asm.tabs.off):</string>
+                   <string>Show preview when hovering</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="4" column="1">
+                 <widget class="QLabel" name="syntaxLabel">
+                  <property name="text">
+                   <string>Syntax (asm.syntax):</string>
                   </property>
                   <property name="textInteractionFlags">
                    <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="21" column="1" colspan="2">
+                 <widget class="QCheckBox" name="bytespaceCheckBox">
+                  <property name="text">
+                   <string>Separate bytes with whitespace (asm.bytes.space)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="18" column="2">
+                 <widget class="QSpinBox" name="asmTabsOffSpinBox">
+                  <property name="maximum">
+                   <number>100</number>
+                  </property>
+                  <property name="singleStep">
+                   <number>5</number>
                   </property>
                  </widget>
                 </item>
@@ -163,13 +250,13 @@
                  </widget>
                 </item>
                 <item row="20" column="1" colspan="2">
-                 <widget class="QCheckBox" name="bytespaceCheckBox">
+                 <widget class="QCheckBox" name="lbytesCheckBox">
                   <property name="text">
-                   <string>Separate bytes with whitespace (asm.bytes.space)</string>
+                   <string>Align bytes to the left (asm.lbytes)</string>
                   </property>
                  </widget>
                 </item>
-                <item row="16" column="2">
+                <item row="17" column="2">
                  <widget class="QSpinBox" name="asmTabsSpinBox">
                   <property name="maximum">
                    <number>100</number>
@@ -179,107 +266,27 @@
                   </property>
                  </widget>
                 </item>
-                <item row="11" column="1">
-                 <widget class="QCheckBox" name="bytesCheckBox">
+                <item row="8" column="2">
+                 <widget class="QCheckBox" name="relOffFlagsCheckBox">
                   <property name="text">
-                   <string>Display the bytes of each instruction (asm.bytes)</string>
+                   <string>Flags (asm.reloff.flags)</string>
                   </property>
                  </widget>
-                </item>
-                <item row="5" column="2">
-                 <widget class="QComboBox" name="caseComboBox">
-                  <item>
-                   <property name="text">
-                    <string>Lowercase</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>Uppercase (asm.ucase)</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>Capitalize (asm.capitalize)</string>
-                   </property>
-                  </item>
-                 </widget>
-                </item>
-                <item row="14" column="1" colspan="2">
-                 <widget class="QCheckBox" name="bblineCheckBox">
-                  <property name="text">
-                   <string>Show empty line after every basic block (asm.bb.line)</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="8" column="1">
-                 <layout class="QHBoxLayout" name="horizontalLayout">
-                  <item>
-                   <widget class="QLabel" name="relOffsetLabel">
-                    <property name="text">
-                     <string>Show offsets relative to:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="relOffsetCheckBox">
-                    <property name="text">
-                     <string>Functions (asm.reloff)</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
                 </item>
                 <item row="4" column="2">
                  <widget class="QComboBox" name="syntaxComboBox"/>
                 </item>
-                <item row="0" column="1" colspan="2">
-                 <spacer name="verticalSpacer_3">
-                  <property name="orientation">
-                   <enum>Qt::Vertical</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Fixed</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>20</width>
-                    <height>10</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item row="3" column="1">
-                 <widget class="QLabel" name="label">
-                  <property name="text">
-                   <string>Show Disassembly as:</string>
-                  </property>
-                  <property name="textInteractionFlags">
-                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                <item row="12" column="2">
+                 <widget class="QSpinBox" name="nbytesSpinBox">
+                  <property name="enabled">
+                   <bool>true</bool>
                   </property>
                  </widget>
                 </item>
                 <item row="16" column="1">
-                 <widget class="QLabel" name="asmTabsLabel">
+                 <widget class="QCheckBox" name="varTooltipsCheckBox">
                   <property name="text">
-                   <string>Tabs in assembly (asm.tabs):</string>
-                  </property>
-                  <property name="textInteractionFlags">
-                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-                  </property>
-                 </widget>
-                </item>
-                <item row="18" column="1" colspan="2">
-                 <widget class="QCheckBox" name="indentCheckBox">
-                  <property name="text">
-                   <string>Indent disassembly based on reflines depth (asm.indent)</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="13" column="1">
-                 <widget class="QCheckBox" name="realnameCheckBox">
-                  <property name="text">
-                   <string>Display flags' real name (asm.flags.real)</string>
+                   <string>Show known variables values when hovering</string>
                   </property>
                  </widget>
                 </item>
@@ -415,8 +422,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>454</width>
-              <height>286</height>
+              <width>518</width>
+              <height>326</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_6">

--- a/src/dialogs/preferences/AsmOptionsWidget.ui
+++ b/src/dialogs/preferences/AsmOptionsWidget.ui
@@ -286,7 +286,7 @@
                 <item row="16" column="1">
                  <widget class="QCheckBox" name="varTooltipsCheckBox">
                   <property name="text">
-                   <string>Show known variables values when hovering</string>
+                   <string>Show known variable values when hovering</string>
                   </property>
                  </widget>
                 </item>

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -535,7 +535,7 @@ GraphView::EdgeConfiguration DisassemblerGraphView::edgeConfiguration(GraphView:
 bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
 {
     if ((Config()->getGraphPreview() || Config()->getShowVarTooltips())
-        && event->type() == QEvent::Type::ToolTip ) {
+        && event->type() == QEvent::Type::ToolTip) {
 
         QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
         QPoint pointOfEvent = helpEvent->globalPos();
@@ -549,9 +549,9 @@ bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
             RVA offsetFrom = RVA_INVALID;
 
             /*
-            * getAddrForMouseEvent() doesn't work for jmps, like
-            * getInstrForMouseEvent() with false as a 3rd argument.
-            */
+             * getAddrForMouseEvent() doesn't work for jmps, like
+             * getInstrForMouseEvent() with false as a 3rd argument.
+             */
             Instr *inst = getInstrForMouseEvent(*block, &pos, true);
             if (inst != nullptr) {
                 offsetFrom = inst->addr;
@@ -560,13 +560,14 @@ bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
             // Don't preview anything for a small scale
             if (getViewScale() >= 0.8) {
                 if (Config()->getGraphPreview()
-                     && DisassemblyPreview::showDisasPreview(this, pointOfEvent, offsetFrom)) {
+                    && DisassemblyPreview::showDisasPreview(this, pointOfEvent, offsetFrom)) {
                     return true;
                 }
                 if (Config()->getShowVarTooltips() && inst) {
                     auto token = getToken(inst, pos.x());
-                    if (token && DisassemblyPreview::showDebugValueTooltip(
-                            this, pointOfEvent, token->content, offsetFrom)) {
+                    if (token
+                        && DisassemblyPreview::showDebugValueTooltip(this, pointOfEvent,
+                                                                     token->content, offsetFrom)) {
                         return true;
                     }
                 }

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -534,33 +534,43 @@ GraphView::EdgeConfiguration DisassemblerGraphView::edgeConfiguration(GraphView:
 
 bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
 {
-    if (event->type() == QEvent::Type::ToolTip && Config()->getGraphPreview()) {
+    if ((Config()->getGraphPreview() || Config()->getShowVarTooltips())
+        && event->type() == QEvent::Type::ToolTip ) {
 
         QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
         QPoint pointOfEvent = helpEvent->globalPos();
         QPoint point = viewToLogicalCoordinates(helpEvent->pos());
 
-        GraphBlock *block = getBlockContaining(point);
+        if (auto block = getBlockContaining(point)) {
+            // Get pos relative to start of block
+            QPoint pos = point - QPoint(block->x, block->y);
 
-        if (block == nullptr) {
-            return false;
-        }
+            // offsetFrom is the address which on top the cursor triggered this
+            RVA offsetFrom = RVA_INVALID;
 
-        // offsetFrom is the address which on top the cursor triggered this
-        RVA offsetFrom = RVA_INVALID;
+            /*
+            * getAddrForMouseEvent() doesn't work for jmps, like
+            * getInstrForMouseEvent() with false as a 3rd argument.
+            */
+            Instr *inst = getInstrForMouseEvent(*block, &pos, true);
+            if (inst != nullptr) {
+                offsetFrom = inst->addr;
+            }
 
-        /*
-         * getAddrForMouseEvent() doesn't work for jmps, like
-         * getInstrForMouseEvent() with false as a 3rd argument.
-         */
-        Instr *inst = getInstrForMouseEvent(*block, &point, true);
-        if (inst != nullptr) {
-            offsetFrom = inst->addr;
-        }
-
-        // Don't preview anything for a small scale
-        if (getViewScale() >= 0.8) {
-            return DisassemblyPreview::showDisasPreview(this, pointOfEvent, offsetFrom);
+            // Don't preview anything for a small scale
+            if (getViewScale() >= 0.8) {
+                if (Config()->getGraphPreview()
+                     && DisassemblyPreview::showDisasPreview(this, pointOfEvent, offsetFrom)) {
+                    return true;
+                }
+                if (Config()->getShowVarTooltips() && inst) {
+                    auto token = getToken(inst, pos.x());
+                    if (token && DisassemblyPreview::showDebugValueTooltip(
+                            this, pointOfEvent, token->content, offsetFrom)) {
+                        return true;
+                    }
+                }
+            }
         }
     }
     return CutterGraphView::eventFilter(obj, event);

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -636,17 +636,26 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 
             return true;
         }
-    } else if (Config()->getPreviewValue()
-            && event->type() == QEvent::ToolTip
-            && obj == mDisasTextEdit->viewport()) {
+    } else if (
+        (Config()->getPreviewValue() || Config()->getShowVarTooltips())
+        && event->type() == QEvent::ToolTip
+        && obj == mDisasTextEdit->viewport())
+    {
         QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
-
         auto cursorForWord = mDisasTextEdit->cursorForPosition(helpEvent->pos());
         cursorForWord.select(QTextCursor::WordUnderCursor);
 
         RVA offsetFrom = DisassemblyPreview::readDisassemblyOffset(cursorForWord);
 
-        return DisassemblyPreview::showDisasPreview(this, helpEvent->globalPos(), offsetFrom);
+        if (Config()->getPreviewValue()
+            && DisassemblyPreview::showDisasPreview(this, helpEvent->globalPos(), offsetFrom)) {
+                return true;
+        }
+        if (Config()->getShowVarTooltips()
+            && DisassemblyPreview::showDebugValueTooltip(
+                this, helpEvent->globalPos(), cursorForWord.selectedText(), offsetFrom)) {
+            return true;
+        }
     }
 
     return MemoryDockWidget::eventFilter(obj, event);

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -636,11 +636,8 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 
             return true;
         }
-    } else if (
-        (Config()->getPreviewValue() || Config()->getShowVarTooltips())
-        && event->type() == QEvent::ToolTip
-        && obj == mDisasTextEdit->viewport())
-    {
+    } else if ((Config()->getPreviewValue() || Config()->getShowVarTooltips())
+               && event->type() == QEvent::ToolTip && obj == mDisasTextEdit->viewport()) {
         QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
         auto cursorForWord = mDisasTextEdit->cursorForPosition(helpEvent->pos());
         cursorForWord.select(QTextCursor::WordUnderCursor);
@@ -649,11 +646,11 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 
         if (Config()->getPreviewValue()
             && DisassemblyPreview::showDisasPreview(this, helpEvent->globalPos(), offsetFrom)) {
-                return true;
+            return true;
         }
         if (Config()->getShowVarTooltips()
             && DisassemblyPreview::showDebugValueTooltip(
-                this, helpEvent->globalPos(), cursorForWord.selectedText(), offsetFrom)) {
+                    this, helpEvent->globalPos(), cursorForWord.selectedText(), offsetFrom)) {
             return true;
         }
     }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

This adds tooltips when hovering over a register or variable to the disassembly and disassembly graph views as requested in https://github.com/rizinorg/cutter/issues/2532

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

Enable the setting "Show known variable values when hovering" in the preferences. Start a debug or emulation session and hover over various registers / variables and check the tooltip.

**Closing issues**

Does not implement everything in https://github.com/rizinorg/cutter/issues/2532 but it is a start. 

Any feedback/suggestions on improving the tooltips is welcome. Thank you!
