### PR TITLE
python: use proper way to return None

### DIFF
--- a/src/common/PythonAPI.cpp
+++ b/src/common/PythonAPI.cpp
@@ -32,7 +32,7 @@ PyObject *api_refresh(PyObject *self, PyObject *args)
     Q_UNUSED(self);
     Q_UNUSED(args);
     Core()->triggerRefreshAll();
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 PyObject *api_message(PyObject *self, PyObject *args, PyObject *kwargs)
@@ -46,8 +46,7 @@ PyObject *api_message(PyObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     }
     Core()->message(QString(message), debug);
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 PyMethodDef CutterMethods[] = {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

See:
- https://docs.python.org/3/c-api/none.html#c.Py_None
- Works since 2.4 version: https://docs.python.org/2.7/c-api/none.html#c.Py_None

**Closing issues**

Closes https://github.com/rizinorg/cutter/issues/3081