### PR TITLE
python: disable deprecated API for newer versions

### DIFF
--- a/src/common/PythonManager.cpp
+++ b/src/common/PythonManager.cpp
@@ -77,7 +77,9 @@ void PythonManager::initialize()
 #endif
     Py_Initialize();
     // This function is deprecated does nothing starting from Python 3.9
+#if (PY_MAJOR_VERSION <= 3) && (PY_MICRO_VERSION < 9)
     PyEval_InitThreads();
+#endif
     pyThreadStateCounter = 1; // we have the thread now => 1
 
     RegQtResImporter();


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**
 
Do not call deprecated API since Python 3.9: 
- https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads
- https://docs.python.org/3/c-api/apiabiversion.html

**Test plan (required)**

CI is green

**Closing issues**

Closes https://github.com/rizinorg/cutter/issues/3208
