### PR TITLE
Fix arrow line calculation when disasm line is has multiple newlines.

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -4143,11 +4143,20 @@ QList<DisassemblyLine> CutterCore::disassembleLines(RVA offset, int lines)
 
     QList<DisassemblyLine> r;
     for (const auto &t : CutterPVector<RzAnalysisDisasmText>(vec.get())) {
-        DisassemblyLine line;
-        line.offset = t->offset;
-        line.text = ansiEscapeToHtml(t->text);
-        line.arrow = t->arrow;
-        r << line;
+        QString text = t->text;
+        QStringList tokens = text.split('\n');
+        // text might contain multiple lines
+        // so we split them and keep only one
+        // arrow/jump to addr.
+        for (const auto &tok : tokens) {
+            DisassemblyLine line;
+            line.offset = t->offset;
+            line.text = ansiEscapeToHtml(tok);
+            line.arrow = t->arrow;
+            r << line;
+            // only the first one.
+            t->arrow = RVA_INVALID;
+        }
     }
     return r;
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

Fix #2615
Fix #3141

**Detailed description**

Before:
![image](https://github.com/rizinorg/cutter/assets/561184/322404b3-039f-4fd9-b4ae-ad4a9d715c68)

Now:
![image](https://github.com/rizinorg/cutter/assets/561184/18162f8e-cb35-4129-9a41-84e1575979c9)

Also images from the branch on the other bins related to this issue:
![image](https://github.com/rizinorg/cutter/assets/561184/d0ff7515-3921-49d0-92bb-d431b182c701)
![image](https://github.com/rizinorg/cutter/assets/561184/fcbc1565-2b29-4320-9f62-4bcff3ecaa2d)
