### PR TITLE
Use tags for jsdec instead of master.

### DIFF
--- a/dist/bundle_jsdec.ps1
+++ b/dist/bundle_jsdec.ps1
@@ -2,7 +2,7 @@ $dist = $args[0]
 $python = Split-Path((Get-Command python.exe).Path)
 
 if (-not (Test-Path -Path 'jsdec' -PathType Container)) {
-    git clone https://github.com/rizinorg/jsdec.git --depth 1 --branch master
+    git clone https://github.com/rizinorg/jsdec.git --depth 1 --branch "v0.6.0"
 }
 cd jsdec
 & meson.exe --buildtype=release -Dc_args=-DDUK_USE_DATE_NOW_WINDOWS -Djsc_folder=".." --prefix="$dist" p build

--- a/scripts/jsdec.sh
+++ b/scripts/jsdec.sh
@@ -7,7 +7,7 @@ SCRIPTPATH=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 cd "$SCRIPTPATH/.."
 
 if [[ ! -d jsdec ]]; then
-	git clone https://github.com/rizinorg/jsdec.git --depth 2 --branch master
+	git clone https://github.com/rizinorg/jsdec.git --depth 1 --branch "v0.6.0"
 fi
 
 cd jsdec


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

JSdec has been updated to use quickjs but should not be used for cutter yet. instead should run the tagged version.
