### PR TITLE
Append rizin results in plaintext to include tabs etc (fixes #3193)

### DIFF
--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -229,10 +229,10 @@ void ConsoleWidget::executeCommand(const QString &command)
 
     RVA oldOffset = Core()->getOffset();
     commandTask = QSharedPointer<CommandTask>(
-            new CommandTask(command, CommandTask::ColorMode::MODE_256, true));
+            new CommandTask(command, CommandTask::ColorMode::MODE_256, false));
     connect(commandTask.data(), &CommandTask::finished, this,
             [this, cmd_line, command, oldOffset](const QString &result) {
-                ui->outputTextEdit->appendHtml(result);
+                ui->outputTextEdit->appendPlainText(result);
                 scrollOutputToEnd();
                 historyAdd(command);
                 commandTask.clear();


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

See #3193 

The output of rizin was formatted as html, which caused \n to become `<br/>`, making it impossible to just use appendPlainText() as-is. We have to tell rizin not to give us html, so that we can use \t in the output.

Simply replacing \t with spaces, `&emsp;` or similar doesn't work, as the appendHtml() replaces multiple spaces with one.

**Test plan (required)**

Enter the commands from the issue and others which may generate spaces.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #3193 
