### PR TITLE
Seek to first call if multiple references

### DIFF
--- a/src/common/CutterSeekable.cpp
+++ b/src/common/CutterSeekable.cpp
@@ -65,7 +65,6 @@ void CutterSeekable::seekToReference(RVA offset)
         return;
     }
 
-    RVA target;
     QList<XrefDescription> refs = Core()->getXRefs(offset, false, false);
 
     if (refs.length()) {
@@ -73,10 +72,19 @@ void CutterSeekable::seekToReference(RVA offset)
             qWarning() << tr("More than one (%1) references here. Weird behaviour expected.")
                                   .arg(refs.length());
         }
-
-        target = refs.at(0).to;
-        if (target != RVA_INVALID) {
-            seek(target);
+        // Try first call
+        for (auto &ref : refs) {
+            if (ref.to != RVA_INVALID && ref.type == "CALL") {
+                seek(ref.to);
+                return;
+            }
+        }
+        // Fallback to first valid, if any
+        for (auto &ref : refs) {
+            if (ref.to != RVA_INVALID) {
+                seek(ref.to);
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

I'm working on a adding a C166 arch. For some (yet unknown) reason I sometimes get multiple references to a function that have a type of data. When clicking on a call it jumps to the random data location. This changes it to seek to the first call or fall back to the previous behavior.

**Test plan (required)**

There may be an easier way but to see the exact problem, try my [c166-dev rizin branch](https://github.com/frmdstryr/rizin/tree/c166-dev) and open a c166 firmware bin.

![image](https://github.com/rizinorg/cutter/assets/380158/eefe1cae-f642-4b09-bba5-0648663ae58f)


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
