### PR TITLE
Add 'Copy instruction bytes' to disassembly context menu

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -31,6 +31,7 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
       actionEditBytes(this),
       actionCopy(this),
       actionCopyAddr(this),
+      actionCopyInstrBytes(this),
       actionAddComment(this),
       actionAnalyzeFunction(this),
       actionEditFunction(this),
@@ -75,6 +76,10 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
     initAction(&actionCopyAddr, tr("Copy address"), SLOT(on_actionCopyAddr_triggered()),
                getCopyAddressSequence());
     addAction(&actionCopyAddr);
+
+    initAction(&actionCopyInstrBytes, tr("Copy instruction bytes"),
+               SLOT(on_actionCopyInstrBytes_triggered()), getCopyInstrBytesSequence());
+    addAction(&actionCopyInstrBytes);
 
     initAction(&showInSubmenu, tr("Show in"), nullptr);
     addAction(&showInSubmenu);
@@ -643,6 +648,11 @@ QKeySequence DisassemblyContextMenu::getCopyAddressSequence() const
     return { Qt::CTRL | Qt::SHIFT | Qt::Key_C };
 }
 
+QKeySequence DisassemblyContextMenu::getCopyInstrBytesSequence() const
+{
+    return { Qt::CTRL | Qt::ALT | Qt::Key_C };
+}
+
 QKeySequence DisassemblyContextMenu::getSetToCodeSequence() const
 {
     return { Qt::Key_C };
@@ -791,6 +801,12 @@ void DisassemblyContextMenu::on_actionCopyAddr_triggered()
 {
     QClipboard *clipboard = QApplication::clipboard();
     clipboard->setText(RzAddressString(offset));
+}
+
+void DisassemblyContextMenu::on_actionCopyInstrBytes_triggered()
+{
+    QClipboard *clipboard = QApplication::clipboard();
+    clipboard->setText(Core()->getInstructionBytes(offset));
 }
 
 void DisassemblyContextMenu::on_actionAddBreakpoint_triggered()

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -42,6 +42,7 @@ private slots:
 
     void on_actionCopy_triggered();
     void on_actionCopyAddr_triggered();
+    void on_actionCopyInstrBytes_triggered();
     void on_actionAddComment_triggered();
     void on_actionAnalyzeFunction_triggered();
     void on_actionRename_triggered();
@@ -79,6 +80,7 @@ private:
     QKeySequence getCopySequence() const;
     QKeySequence getCommentSequence() const;
     QKeySequence getCopyAddressSequence() const;
+    QKeySequence getCopyInstrBytesSequence() const;
     QKeySequence getGlobalVarSequence() const;
     QKeySequence getSetToCodeSequence() const;
     QKeySequence getSetAsStringSequence() const;
@@ -111,6 +113,7 @@ private:
     QAction actionCopy;
     QAction *copySeparator;
     QAction actionCopyAddr;
+    QAction actionCopyInstrBytes;
 
     QAction actionAddComment;
     QAction actionAnalyzeFunction;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

This adds a "Copy instruction bytes" to the disassembly widget's context menu. Mainly as a shortcut to search for uses of an instruction (in my case use of an IO port).  

![image](https://github.com/rizinorg/cutter/assets/380158/eece9b72-f740-463c-b3e3-53a6e96e6c01)


**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

Right click on an instruction and copy the bytes. Check that the asm matches.


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
