### PR TITLE
DisAsm: double-click and tripple-click should select text at cursor.

### DIFF
--- a/docs/source/user-docs/menus/disassembly-context-menu.rst
+++ b/docs/source/user-docs/menus/disassembly-context-menu.rst
@@ -13,9 +13,15 @@ Copy
 ----------------------------------------
 **Description:** Copy the selected text.  
 
-**Steps:**  Right-click on a selected text and choose ``Copy``  
+**Steps:**  Double click to select word or triple click to select line under cursor.
 
-**Shortcut:** :kbd:`Ctrl` + :kbd:`C`  
+**Shortcut:** :kbd:`Ctrl` + :kbd:`C`
+
+Jump to address
+----------------------------------------
+**Description** Jump to the address or function
+
+**Steps** Hold :kbd:`Ctrl` and double click
 
 Copy Address
 ----------------------------------------

--- a/src/menus/AddressableItemContextMenu.cpp
+++ b/src/menus/AddressableItemContextMenu.cpp
@@ -14,9 +14,12 @@ AddressableItemContextMenu::AddressableItemContextMenu(QWidget *parent, MainWind
     : QMenu(parent), mainWindow(mainWindow)
 {
     actionShowInMenu = new QAction(tr("Show in"), this);
+    actionCopyWord = new QAction(tr("Copy word"), this);
     actionCopyAddress = new QAction(tr("Copy address"), this);
     actionShowXrefs = new QAction(tr("Show X-Refs"), this);
     actionAddcomment = new QAction(tr("Add comment"), this);
+
+    connect(actionCopyWord, &QAction::triggered, this, &AddressableItemContextMenu::onActionCopyWord);
 
     connect(actionCopyAddress, &QAction::triggered, this,
             &AddressableItemContextMenu::onActionCopyAddress);
@@ -71,6 +74,13 @@ void AddressableItemContextMenu::setTarget(RVA offset, QString name)
 void AddressableItemContextMenu::clearTarget()
 {
     setHasTarget(false);
+}
+
+void AddressableItemContextMenu::onActionCopyWord()
+{
+    auto clipboard = QApplication::clipboard();
+    qDebug() << "copy";
+//    clipboard->setText()
 }
 
 void AddressableItemContextMenu::onActionCopyAddress()

--- a/src/menus/AddressableItemContextMenu.cpp
+++ b/src/menus/AddressableItemContextMenu.cpp
@@ -76,13 +76,6 @@ void AddressableItemContextMenu::clearTarget()
     setHasTarget(false);
 }
 
-void AddressableItemContextMenu::onActionCopyWord()
-{
-    auto clipboard = QApplication::clipboard();
-    qDebug() << "copy";
-//    clipboard->setText()
-}
-
 void AddressableItemContextMenu::onActionCopyAddress()
 {
     auto clipboard = QApplication::clipboard();

--- a/src/menus/AddressableItemContextMenu.h
+++ b/src/menus/AddressableItemContextMenu.h
@@ -28,6 +28,7 @@ signals:
     void xrefsTriggered();
 
 private:
+    void onActionCopyWord();
     void onActionCopyAddress();
     void onActionShowXrefs();
     void onActionAddComment();
@@ -44,6 +45,7 @@ private:
 protected:
     void setHasTarget(bool hasTarget);
     QAction *actionShowInMenu;
+    QAction *actionCopyWord;
     QAction *actionCopyAddress;
     QAction *actionShowXrefs;
     QAction *actionAddcomment;

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -11,6 +11,7 @@
 #include "dialogs/EditStringDialog.h"
 #include "dialogs/BreakpointsDialog.h"
 #include "MainWindow.h"
+#include "DisassemblyWidget.h"
 
 #include <QtCore>
 #include <QShortcut>
@@ -23,13 +24,13 @@
 DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *mainWindow)
     : QMenu(parent),
       offset(0),
-      canCopy(false),
+      canCopy(true),
       mainWindow(mainWindow),
       actionEditInstruction(this),
       actionNopInstruction(this),
       actionJmpReverse(this),
       actionEditBytes(this),
-      actionCopy(this),
+      actionCopyWord(this),
       actionCopyAddr(this),
       actionCopyInstrBytes(this),
       actionAddComment(this),
@@ -70,8 +71,11 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
       actionSetToDataQword(this),
       showInSubmenu(this)
 {
-    initAction(&actionCopy, tr("Copy"), SLOT(on_actionCopy_triggered()), getCopySequence());
-    addAction(&actionCopy);
+//    initAction(&actionCopy, tr("Copy"), SLOT(on_actionCopy_triggered()), getCopySequence());
+//    addAction(&actionCopy);
+//
+    initAction(&actionCopyWord, tr("Copy Word"), SLOT(on_actionCopyWord_triggered()), getCopySequence());
+    addAction(&actionCopyWord);
 
     initAction(&actionCopyAddr, tr("Copy address"), SLOT(on_actionCopyAddr_triggered()),
                getCopyAddressSequence());
@@ -578,8 +582,8 @@ void DisassemblyContextMenu::aboutToShowSlot()
         actionAddComment.setText(tr("Edit Comment"));
     }
 
-    actionCopy.setVisible(canCopy);
-    copySeparator->setVisible(canCopy);
+//    actionCopy.setVisible(canCopy);
+//    copySeparator->setVisible(canCopy);
 
     // Handle renaming of variable, function, flag, ...
     // Note: This might be useless if we consider setCurrentHighlightedWord is always called before
@@ -792,9 +796,19 @@ void DisassemblyContextMenu::on_actionEditBytes_triggered()
     }
 }
 
-void DisassemblyContextMenu::on_actionCopy_triggered()
+//void DisassemblyContextMenu::on_actionCopy_triggered()
+//{
+//    emit copy();
+//}
+
+void DisassemblyContextMenu::on_actionCopyWord_triggered()
 {
-    emit copy();
+    DisassemblyWidget* disassemblyWidget = dynamic_cast<DisassemblyWidget*>(parentWidget());
+    if (disassemblyWidget != nullptr) {
+        const QString& text = disassemblyWidget->getCurrentHighlightedWord();
+        QClipboard *clipboard = QApplication::clipboard();
+        clipboard->setText(text);
+    }
 }
 
 void DisassemblyContextMenu::on_actionCopyAddr_triggered()

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -74,7 +74,7 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
 //    initAction(&actionCopy, tr("Copy"), SLOT(on_actionCopy_triggered()), getCopySequence());
 //    addAction(&actionCopy);
 //
-    initAction(&actionCopyWord, tr("Copy Word"), SLOT(on_actionCopyWord_triggered()), getCopySequence());
+    initAction(&actionCopyWord, tr("Copy word"), SLOT(on_actionCopyWord_triggered()), getCopySequence());
     addAction(&actionCopyWord);
 
     initAction(&actionCopyAddr, tr("Copy address"), SLOT(on_actionCopyAddr_triggered()),

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -40,7 +40,8 @@ private slots:
     void on_actionEditBytes_triggered();
     void showReverseJmpQuery();
 
-    void on_actionCopy_triggered();
+//    void on_actionCopy_triggered();
+    void on_actionCopyWord_triggered();
     void on_actionCopyAddr_triggered();
     void on_actionCopyInstrBytes_triggered();
     void on_actionAddComment_triggered();
@@ -110,7 +111,8 @@ private:
     QAction actionJmpReverse;
     QAction actionEditBytes;
 
-    QAction actionCopy;
+//    QAction actionCopy;
+    QAction actionCopyWord;
     QAction *copySeparator;
     QAction actionCopyAddr;
     QAction actionCopyInstrBytes;

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -19,6 +19,7 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QSplitter>
+#include <QClipboard>
 
 #include <algorithm>
 #include <cmath>
@@ -785,8 +786,25 @@ void DisassemblyTextEdit::scrollContentsBy(int dx, int dy)
 
 void DisassemblyTextEdit::keyPressEvent(QKeyEvent *event)
 {
-    Q_UNUSED(event)
+    qDebug() << "keypress";
+//    Q_UNUSED(event)
     // QPlainTextEdit::keyPressEvent(event);
+//    if (event->matches(QKeySequence::Copy)) {
+        QString selectedText = this->textCursor().selectedText();
+        QClipboard *clipboard = QApplication::clipboard();
+
+        auto parentDisassemblyWidget = dynamic_cast<DisassemblyWidget*>(this->parentWidget());
+
+        // Now check if the cast was successful to ensure the parent is indeed a DisassemblyWidget
+        if (parentDisassemblyWidget) {
+            // Call the getter to obtain the current highlighted word
+            QString highlightedWord = parentDisassemblyWidget->getCurrentHighlightedWord();
+
+            clipboard->setText(highlightedWord);
+            qDebug() << highlightedWord;
+        }
+//    }
+
 }
 
 void DisassemblyTextEdit::mousePressEvent(QMouseEvent *event)

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -169,6 +169,8 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main)
 
     ADD_ACTION(Qt::Key_Escape, Qt::WidgetWithChildrenShortcut, &DisassemblyWidget::seekPrev)
 
+    ADD_ACTION(Qt::CopyAction, Qt::WidgetWithChildrenShortcut, &DisassemblyWidget::copyHighlightedWord)
+
     ADD_ACTION(Qt::Key_J, Qt::WidgetWithChildrenShortcut,
                [this]() { moveCursorRelative(false, false); })
     ADD_ACTION(QKeySequence::MoveToNextLine, Qt::WidgetWithChildrenShortcut,
@@ -662,7 +664,14 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 
 void DisassemblyWidget::keyPressEvent(QKeyEvent *event)
 {
-    if (event->key() == Qt::Key_Return) {
+    qDebug() << event->key();
+    qDebug() << event->modifiers();
+    if (event->key() == Qt::Key_C && (event->modifiers() & Qt::ControlModifier)) {
+        // If there is selected text in the text edit, copy it
+        if (!mDisasTextEdit->textCursor().selectedText().isEmpty()) {
+            mDisasTextEdit->copy();
+        }
+    } else if (event->key() == Qt::Key_Return) {
         const QTextCursor cursor = mDisasTextEdit->textCursor();
         jumpToOffsetUnderCursor(cursor);
     }
@@ -786,25 +795,7 @@ void DisassemblyTextEdit::scrollContentsBy(int dx, int dy)
 
 void DisassemblyTextEdit::keyPressEvent(QKeyEvent *event)
 {
-    qDebug() << "keypress";
-//    Q_UNUSED(event)
-    // QPlainTextEdit::keyPressEvent(event);
-//    if (event->matches(QKeySequence::Copy)) {
-        QString selectedText = this->textCursor().selectedText();
-        QClipboard *clipboard = QApplication::clipboard();
-
-        auto parentDisassemblyWidget = dynamic_cast<DisassemblyWidget*>(this->parentWidget());
-
-        // Now check if the cast was successful to ensure the parent is indeed a DisassemblyWidget
-        if (parentDisassemblyWidget) {
-            // Call the getter to obtain the current highlighted word
-            QString highlightedWord = parentDisassemblyWidget->getCurrentHighlightedWord();
-
-            clipboard->setText(highlightedWord);
-            qDebug() << highlightedWord;
-        }
-//    }
-
+    Q_UNUSED(event)
 }
 
 void DisassemblyTextEdit::mousePressEvent(QMouseEvent *event)
@@ -819,6 +810,10 @@ void DisassemblyTextEdit::mousePressEvent(QMouseEvent *event)
 void DisassemblyWidget::seekPrev()
 {
     Core()->seekPrev();
+}
+
+void DisassemblyWidget::copyHighlightedWord() {
+    qDebug() << "success!";
 }
 
 /*********************

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -105,7 +105,8 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main)
     QTextDocument *asm_docu = mDisasTextEdit->document();
     asm_docu->setDocumentMargin(10);
 
-    // Event filter to intercept showing tooltips when hovering above those offsets
+    // Event filter to intercept double clicks in the textbox
+    // and showing tooltips when hovering above those offsets
     mDisasTextEdit->viewport()->installEventFilter(this);
 
     // Set Disas context menu
@@ -626,9 +627,19 @@ void DisassemblyWidget::jumpToOffsetUnderCursor(const QTextCursor &cursor)
 
 bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 {
-    if ((Config()->getPreviewValue() || Config()->getShowVarTooltips())
-        && event->type() == QEvent::ToolTip && obj == mDisasTextEdit->viewport()) {
-        auto *helpEvent = dynamic_cast<QHelpEvent *>(event);
+    if (event->type() == QEvent::MouseButtonDblClick
+        && (obj == mDisasTextEdit || obj == mDisasTextEdit->viewport())) {
+        QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+
+        if (mouseEvent->button() == Qt::LeftButton) {
+            const QTextCursor &cursor = mDisasTextEdit->cursorForPosition(mouseEvent->pos());
+            jumpToOffsetUnderCursor(cursor);
+
+            return true;
+        }
+    } else if ((Config()->getPreviewValue() || Config()->getShowVarTooltips())
+               && event->type() == QEvent::ToolTip && obj == mDisasTextEdit->viewport()) {
+        QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
         auto cursorForWord = mDisasTextEdit->cursorForPosition(helpEvent->pos());
         cursorForWord.select(QTextCursor::WordUnderCursor);
 
@@ -780,12 +791,6 @@ void DisassemblyTextEdit::keyPressEvent(QKeyEvent *event)
 
 void DisassemblyTextEdit::mousePressEvent(QMouseEvent *event)
 {
-    if (event->button() == Qt::LeftButton && event->modifiers() & Qt::ControlModifier) {
-        if (mDisassemblyWidget) {
-            mDisassemblyWidget->jumpToOffsetUnderCursor(textCursor());
-        }
-    }
-
     QPlainTextEdit::mousePressEvent(event);
 
     if (event->button() == Qt::RightButton && !textCursor().hasSelection()) {

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -627,7 +627,7 @@ void DisassemblyWidget::jumpToOffsetUnderCursor(const QTextCursor &cursor)
 bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 {
     if ((Config()->getPreviewValue() || Config()->getShowVarTooltips())
-               && event->type() == QEvent::ToolTip && obj == mDisasTextEdit->viewport()) {
+        && event->type() == QEvent::ToolTip && obj == mDisasTextEdit->viewport()) {
         auto *helpEvent = dynamic_cast<QHelpEvent *>(event);
         auto cursorForWord = mDisasTextEdit->cursorForPosition(helpEvent->pos());
         cursorForWord.select(QTextCursor::WordUnderCursor);

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -49,6 +49,7 @@ public slots:
     void setPreviewMode(bool previewMode);
     QFontMetrics getFontMetrics();
     QList<DisassemblyLine> getLines();
+    void jumpToOffsetUnderCursor(const QTextCursor &);
 
 protected slots:
     void on_seekChanged(RVA offset, CutterCore::SeekHistoryType type);
@@ -101,8 +102,6 @@ private:
     void connectCursorPositionChanged(bool disconnect);
 
     void moveCursorRelative(bool up, bool page);
-
-    void jumpToOffsetUnderCursor(const QTextCursor &);
 };
 
 class DisassemblyScrollArea : public QAbstractScrollArea
@@ -128,8 +127,8 @@ class DisassemblyTextEdit : public QPlainTextEdit
     Q_OBJECT
 
 public:
-    explicit DisassemblyTextEdit(QWidget *parent = nullptr)
-        : QPlainTextEdit(parent), lockScroll(false)
+    explicit DisassemblyTextEdit(DisassemblyWidget *parent = nullptr)
+        : QPlainTextEdit(parent), lockScroll(false), mDisassemblyWidget(parent)
     {
     }
 
@@ -145,6 +144,7 @@ protected:
 
 private:
     bool lockScroll;
+    DisassemblyWidget *mDisassemblyWidget;
 };
 
 /**

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -104,6 +104,7 @@ private:
     void moveCursorRelative(bool up, bool page);
 
     void jumpToOffsetUnderCursor(const QTextCursor &);
+    void copyHighlightedWord();
 };
 
 class DisassemblyScrollArea : public QAbstractScrollArea

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -49,7 +49,6 @@ public slots:
     void setPreviewMode(bool previewMode);
     QFontMetrics getFontMetrics();
     QList<DisassemblyLine> getLines();
-    void jumpToOffsetUnderCursor(const QTextCursor &);
 
 protected slots:
     void on_seekChanged(RVA offset, CutterCore::SeekHistoryType type);
@@ -102,6 +101,8 @@ private:
     void connectCursorPositionChanged(bool disconnect);
 
     void moveCursorRelative(bool up, bool page);
+
+    void jumpToOffsetUnderCursor(const QTextCursor &);
 };
 
 class DisassemblyScrollArea : public QAbstractScrollArea
@@ -127,8 +128,8 @@ class DisassemblyTextEdit : public QPlainTextEdit
     Q_OBJECT
 
 public:
-    explicit DisassemblyTextEdit(DisassemblyWidget *parent = nullptr)
-        : QPlainTextEdit(parent), lockScroll(false), mDisassemblyWidget(parent)
+    explicit DisassemblyTextEdit(QWidget *parent = nullptr)
+        : QPlainTextEdit(parent), lockScroll(false)
     {
     }
 
@@ -144,7 +145,6 @@ protected:
 
 private:
     bool lockScroll;
-    DisassemblyWidget *mDisassemblyWidget;
 };
 
 /**

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -25,6 +25,7 @@ class DisassemblyWidget : public MemoryDockWidget
 public:
     explicit DisassemblyWidget(MainWindow *main);
     QWidget *getTextWidget();
+    const QString& getCurrentHighlightedWord() const { return curHighlightedWord; }
 
     static QString getWidgetType();
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

I have implemented new feature for disassembly view. You can now double click to select word and triple click to select whole line, like most editor have this feature nowadays. It is now easier to select text and copy it. This does not eliminate feature to jump to address. You can do it by holding down Ctrl key and double click on address.

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

To test it just open disassembly view and double click or triple click on line. You can copy text with Ctrl + C. Also test double click on address or name of function that `call` instruction calls. You are able to select it now. Hold down Ctrl and double click on address or function name and you will be redirected to that address.


**Closing issues**

closes=#3097

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
