### PR TITLE
build: do not install bundled Rizin in separate prefix

### DIFF
--- a/cmake/BundledRizin.cmake
+++ b/cmake/BundledRizin.cmake
@@ -8,10 +8,10 @@ if(WIN32)
         set(RIZIN_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>")
     endif()
     set(RIZIN_INSTALL_BINPATH ".")
-    set(MESON_OPTIONS "--prefix=${RIZIN_INSTALL_DIR}" "--bindir=${RIZIN_INSTALL_BINPATH}")
+    set(MESON_OPTIONS "--prefix=${CMAKE_INSTALL_PREFIX}" "--bindir=${RIZIN_INSTALL_BINPATH}")
 else()
     set(RIZIN_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/Rizin-prefix")
-    set(MESON_OPTIONS "--prefix=${RIZIN_INSTALL_DIR}" --libdir=lib)
+    set(MESON_OPTIONS "--prefix=${CMAKE_INSTALL_PREFIX}" --libdir=lib)
 endif()
 
 if (CUTTER_ENABLE_PACKAGING)
@@ -39,20 +39,20 @@ endif()
 ExternalProject_Add(Rizin-Bundled
         SOURCE_DIR "${RIZIN_SOURCE_DIR}"
         CONFIGURE_COMMAND "${MESON}" "<SOURCE_DIR>" ${MESON_OPTIONS} && "${MESON}" configure ${MESON_OPTIONS} --buildtype "$<$<CONFIG:Debug>:debug>$<$<NOT:$<CONFIG:Debug>>:release>"
-        BUILD_COMMAND "${NINJA}"
+        BUILD_COMMAND "${NINJA}" && "DESTDIR=${RIZIN_INSTALL_DIR}" "${NINJA}" install
         BUILD_ALWAYS TRUE
-        INSTALL_COMMAND "${NINJA}" install)
+        INSTALL_COMMAND cmake -E echo "Skipping install step for Rizin-Bundled")
 
-set(Rizin_INCLUDE_DIRS "${RIZIN_INSTALL_DIR}/include/librz" "${RIZIN_INSTALL_DIR}/include/librz/sdb")
+set(Rizin_INCLUDE_DIRS "${RIZIN_INSTALL_DIR}/${CMAKE_INSTALL_PREFIX}/include/librz" "${RIZIN_INSTALL_DIR}/${CMAKE_INSTALL_PREFIX}/include/librz/sdb")
 
 add_library(Rizin INTERFACE)
 add_dependencies(Rizin Rizin-Bundled)
 if(NOT (${CMAKE_VERSION} VERSION_LESS "3.13.0"))
     target_link_directories(Rizin INTERFACE
-        $<BUILD_INTERFACE:${RIZIN_INSTALL_DIR}/lib>
+        $<BUILD_INTERFACE:${RIZIN_INSTALL_DIR}/${CMAKE_INSTALL_PREFIX}/lib>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}>)
 else()
-    link_directories("${RIZIN_INSTALL_DIR}/lib")
+    link_directories("${RIZIN_INSTALL_DIR}/${CMAKE_INSTALL_PREFIX}/lib")
 endif()
 
 # TODO: This version number should be fetched automatically
@@ -76,17 +76,17 @@ target_include_directories(Rizin INTERFACE
 install(TARGETS Rizin EXPORT CutterTargets)
 if (WIN32)
     foreach(_lib ${RZ_LIBS} ${RZ_EXTRA_LIBS})
-        install(FILES "${RIZIN_INSTALL_DIR}/${_lib}-${Rizin_VERSION}.dll" DESTINATION "${CMAKE_INSTALL_BINDIR}")
+        install(FILES "${RIZIN_INSTALL_DIR}/${CMAKE_INSTALL_PREFIX}/${_lib}-${Rizin_VERSION}.dll" DESTINATION "${CMAKE_INSTALL_BINDIR}")
     endforeach()
     foreach(_exe ${RZ_BIN})
-        install(FILES "${RIZIN_INSTALL_DIR}/${_exe}.exe" DESTINATION "${CMAKE_INSTALL_BINDIR}")
+        install(FILES "${RIZIN_INSTALL_DIR}/${CMAKE_INSTALL_PREFIX}/${_exe}.exe" DESTINATION "${CMAKE_INSTALL_BINDIR}")
     endforeach()
-    install(DIRECTORY "${RIZIN_INSTALL_DIR}/share" DESTINATION ".")
-    install(DIRECTORY "${RIZIN_INSTALL_DIR}/include" DESTINATION "."
+    install(DIRECTORY "${RIZIN_INSTALL_DIR}/${CMAKE_INSTALL_PREFIX}/share" DESTINATION ".")
+    install(DIRECTORY "${RIZIN_INSTALL_DIR}/${CMAKE_INSTALL_PREFIX}/include" DESTINATION "."
         COMPONENT Devel)
-    install(DIRECTORY "${RIZIN_INSTALL_DIR}/lib" DESTINATION "."
+    install(DIRECTORY "${RIZIN_INSTALL_DIR}/${CMAKE_INSTALL_PREFIX}/lib" DESTINATION "."
         COMPONENT Devel
         PATTERN "*.pdb" EXCLUDE)
 else ()
-    install(DIRECTORY "${RIZIN_INSTALL_DIR}/" DESTINATION "." USE_SOURCE_PERMISSIONS)
+    install(DIRECTORY "${RIZIN_INSTALL_DIR}/${CMAKE_INSTALL_PREFIX}/" DESTINATION "." USE_SOURCE_PERMISSIONS)
 endif()


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

I was looking at https://github.com/rizinorg/cutter/issues/3229#issuecomment-1681480806 and I wanted to see how bundled Rizin worked. So I tried to build Cutter with bundled rizin and install everything in a `/tmp/cutter-install` directory to see what was actually installed. It turned out that I found a `/tmp/cutter-install/Users/ret2libc/cutter/build/Rizin-prefix` directory being installed. Not only that, but the rizin files were both there and in the actual cutter prefix, because they are "manually" copied [here](https://github.com/rizinorg/cutter/blob/dev/cmake/BundledRizin.cmake#L77).

The solution I'm proposing is to avoid the install step of rizin and just install Rizin in the build step, installing the data in a "temporary" location in the build directory. Then, at install time, the instructions in `BundledRizin.cmake` will copy the right files from the build dir into the install location. Moreover, rizin is compiled with the prefix being the same as cutter, so that rz_userconf.h will contain the right prefix and all the various rizin-specific directories will be correctly loaded.

Hope it makes sense :) 

**Test plan (required)**

```
$ git clone cutter
$ cmake -B build
$ cmake --build build
$ DESTDIR=/tmp/cutter-install cmake --install build
```

In `/tmp/cutter-install` there should be only the `/usr/local/...` dir and not other dirs for the rizin-specific prefix.