### PR TITLE
Fix decompiler widget crash when starting unsynced

### DIFF
--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -347,8 +347,10 @@ void DecompilerWidget::decompilationFinished(RzAnnotatedCode *codeDecompiled)
         }
     }
 
-    ui->textEdit->horizontalScrollBar()->setSliderPosition(scrollHistory[historyPos].first);
-    ui->textEdit->verticalScrollBar()->setSliderPosition(scrollHistory[historyPos].second);
+    if (!scrollHistory.empty()) {
+        ui->textEdit->horizontalScrollBar()->setSliderPosition(scrollHistory[historyPos].first);
+        ui->textEdit->verticalScrollBar()->setSliderPosition(scrollHistory[historyPos].second);
+    }
 }
 
 void DecompilerWidget::setAnnotationsAtCursor(size_t pos)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Fix a crash that happens when opening binary and the layout contains unsynced decompiler widget.

**Test plan (required)**

Steps to reproduce the bug:
* open cutter with plugins disabled
* make sure there is a decompiler widget open
* unsync the decompiler widget
* close cutter
* make sure you have rz-ghidra decompiler plugin
* start cutter with plugins enabled and open a binary
* should not crash after analysis finishes

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
