### PR TITLE
Remove unnessary mouse grab.

### DIFF
--- a/src/widgets/ColorPicker.cpp
+++ b/src/widgets/ColorPicker.cpp
@@ -286,7 +286,6 @@ void ColorPicker::startPickingFromScreen()
 {
     if (!pickingFromScreen) {
         setMouseTracking(true);
-        grabMouse(Qt::CursorShape::CrossCursor);
         pickingFromScreen = true;
         bufferColor = currColor;
     }
@@ -298,7 +297,6 @@ void ColorPicker::mouseReleaseEvent(QMouseEvent *event)
         setColor(getColorAtMouse());
         pickingFromScreen = false;
         setMouseTracking(false);
-        releaseMouse();
     }
     QWidget::mouseReleaseEvent(event);
 }

--- a/src/widgets/GraphView.cpp
+++ b/src/widgets/GraphView.cpp
@@ -159,7 +159,6 @@ void GraphView::beginMouseDrag(QMouseEvent *event)
     scrollBase = event->pos();
     scroll_mode = true;
     setCursor(Qt::ClosedHandCursor);
-    viewport()->grabMouse();
 }
 
 void GraphView::setViewOffset(QPoint offset)
@@ -741,7 +740,6 @@ void GraphView::mouseReleaseEvent(QMouseEvent *event)
     if (scroll_mode && (event->buttons() & (Qt::LeftButton | Qt::MiddleButton)) == 0) {
         scroll_mode = false;
         setCursor(Qt::ArrowCursor);
-        viewport()->releaseMouse();
     }
 }
 


### PR DESCRIPTION


<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

* Causes warning spam with Qt wayland backend
* Can sometimes cause crash on wayland
* According to docs shouldn't be necesarry

At least today crash was more likely to happen after following steps:
* open graph widget
* open settings
* close settings with escape
* immediately  after closing settings (almost at the same time) start dragging with mouse in the graph widget -> crash



**Test plan (required)**

Testing process:
* test that dragging view with left click and middle mouse button works in graph widget
* test that dragging mouse across color selection widget within theme editor triggers an update
* try to do the previously described steps for triggering a crash

Test platforms:
* [x] CI Appimage build on Linux with desktop in X11 mode
* [x] CI Appimage build on Linux with  desktop in wayland mode
* [x] CI windows build
* [x] CI macOS build
* [x] QT5 build running with wayland backend
* [x] QT5 build running on wayland with QT_QPA_PLATFORM=xcb
* [x] QT5 build with desktop in X11 mode
* [x] QT6 build running with wayland backend
* [x] QT6 build running on wayland with QT_QPA_PLATFORM=xcb
* [x] QT6 build with desktop in X11 mode


Do not merge before all plaforms are fully tested !
<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
