### PR TITLE
Temporary fix for command output to console widget.

### DIFF
--- a/src/common/CommandTask.cpp
+++ b/src/common/CommandTask.cpp
@@ -2,8 +2,7 @@
 #include "CommandTask.h"
 #include "TempConfig.h"
 
-CommandTask::CommandTask(const QString &cmd, ColorMode colorMode, bool outFormatHtml)
-    : cmd(cmd), colorMode(colorMode), outFormatHtml(outFormatHtml)
+CommandTask::CommandTask(const QString &cmd, ColorMode colorMode) : cmd(cmd), colorMode(colorMode)
 {
 }
 
@@ -12,8 +11,5 @@ void CommandTask::runTask()
     TempConfig tempConfig;
     tempConfig.set("scr.color", colorMode);
     auto res = Core()->cmdTask(cmd);
-    if (outFormatHtml) {
-        res = CutterCore::ansiEscapeToHtml(res);
-    }
     emit finished(res);
 }

--- a/src/common/CommandTask.h
+++ b/src/common/CommandTask.h
@@ -17,8 +17,7 @@ public:
         MODE_16M = COLOR_MODE_16M
     };
 
-    CommandTask(const QString &cmd, ColorMode colorMode = ColorMode::DISABLED,
-                bool outFormatHtml = false);
+    CommandTask(const QString &cmd, ColorMode colorMode = ColorMode::DISABLED);
 
     QString getTitle() override { return tr("Running Command"); }
 
@@ -31,7 +30,6 @@ protected:
 private:
     QString cmd;
     ColorMode colorMode;
-    bool outFormatHtml;
 };
 
 #endif // COMMANDTASK_H

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -4451,11 +4451,13 @@ bool CutterCore::setColor(const QString &key, const QString &color)
 QString CutterCore::ansiEscapeToHtml(const QString &text)
 {
     int len;
-    char *html = rz_cons_html_filter(text.toUtf8().constData(), &len);
+    QString r = text;
+    r.replace("\t", "        ");
+    char *html = rz_cons_html_filter(r.toUtf8().constData(), &len);
     if (!html) {
         return {};
     }
-    QString r = QString::fromUtf8(html, len);
+    r = QString::fromUtf8(html, len);
     rz_mem_free(html);
     return r;
 }

--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -228,11 +228,11 @@ void ConsoleWidget::executeCommand(const QString &command)
     addOutput(cmd_line);
 
     RVA oldOffset = Core()->getOffset();
-    commandTask = QSharedPointer<CommandTask>(
-            new CommandTask(command, CommandTask::ColorMode::MODE_256, false));
+    commandTask =
+            QSharedPointer<CommandTask>(new CommandTask(command, CommandTask::ColorMode::MODE_16M));
     connect(commandTask.data(), &CommandTask::finished, this,
             [this, cmd_line, command, oldOffset](const QString &result) {
-                ui->outputTextEdit->appendPlainText(result);
+                ui->outputTextEdit->appendHtml(CutterCore::ansiEscapeToHtml(result));
                 scrollOutputToEnd();
                 historyAdd(command);
                 commandTask.clear();


### PR DESCRIPTION
* partially revert #3193 - printing the terminal escape sequences directly to text widget causes more issues than the tab problem it tried to fix
* move the conversation to html from command task to the console widget
* add hack converting tab to multiple spaces

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

#3193 fixed the tab issue but it broke handling of any formatting resulting in many commands look like this:
![image](https://github.com/rizinorg/cutter/assets/7101031/a233d72f-9b22-4869-8b0e-41c95a2a6507)

Which in my opinion is completely unusable.

Restored the ansi to html conversion and added a hack for handling '\t' so that there is at leas some indendation when used at the start of line.

I have plans for improving the terminal widget that I will hopefully find time to implement in next couple of months.

**Test plan (required)**

* [x] `!printf '\tabc\n'` should print abc with some indendtation
* [x] `?` should print help with correctly colored output instead of raw terminal codes as plaintext
* [x] `tc __div_t` should print the struct fields with some indendation

![image](https://github.com/rizinorg/cutter/assets/7101031/28b33ce9-34df-4504-913d-cc4ec7cc7ac8)
![image](https://github.com/rizinorg/cutter/assets/7101031/bd1e07c4-532d-4d60-9fd7-af42878d2fb9)

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
