### PR TITLE
Highlight matching braces in decompiler view

### DIFF
--- a/src/common/SelectionHighlight.cpp
+++ b/src/common/SelectionHighlight.cpp
@@ -23,14 +23,27 @@ QList<QTextEdit::ExtraSelection> createSameWordsSelections(QPlainTextEdit *textE
 
     highlightSelection.cursor = textEdit->textCursor();
 
-    if (word == "{") {
+    if (word == "{" || word == "}") {
+        int val;
+        if (word == "{") {
+            val = 0;
+        } else {
+            val = 1;
+        }
         selections.append(highlightSelection);
-        int val = 0;
+
         while (!highlightSelection.cursor.isNull() && !highlightSelection.cursor.atEnd()) {
-            highlightSelection.cursor =
-                    document->find(QRegularExpression("{|}"), highlightSelection.cursor);
+            if (word == "{") {
+                highlightSelection.cursor =
+                        document->find(QRegularExpression("{|}"), highlightSelection.cursor);
+            } else {
+                highlightSelection.cursor =
+                        document->find(QRegularExpression("{|}"), highlightSelection.cursor,
+                                       QTextDocument::FindBackward);
+            }
+
             if (!highlightSelection.cursor.isNull()) {
-                if (highlightSelection.cursor.selectedText() == "{") {
+                if (highlightSelection.cursor.selectedText() == word) {
                     val++;
                 } else {
                     val--;

--- a/src/common/SelectionHighlight.cpp
+++ b/src/common/SelectionHighlight.cpp
@@ -7,6 +7,7 @@
 #include <QColor>
 #include <QTextCursor>
 #include <QPlainTextEdit>
+#include <QRegularExpression>
 
 QList<QTextEdit::ExtraSelection> createSameWordsSelections(QPlainTextEdit *textEdit,
                                                            const QString &word)
@@ -21,6 +22,29 @@ QList<QTextEdit::ExtraSelection> createSameWordsSelections(QPlainTextEdit *textE
     }
 
     highlightSelection.cursor = textEdit->textCursor();
+
+    if (word == "{") {
+        selections.append(highlightSelection);
+        int val = 0;
+        while (!highlightSelection.cursor.isNull() && !highlightSelection.cursor.atEnd()) {
+            highlightSelection.cursor =
+                    document->find(QRegularExpression("{|}"), highlightSelection.cursor);
+            if (!highlightSelection.cursor.isNull()) {
+                if (highlightSelection.cursor.selectedText() == "{") {
+                    val++;
+                } else {
+                    val--;
+                }
+                if (val == 0) {
+                    highlightSelection.format.setBackground(highlightWordColor);
+                    selections.append(highlightSelection);
+                    break;
+                }
+            }
+        }
+        return selections;
+    }
+
     highlightSelection.cursor.movePosition(QTextCursor::Start, QTextCursor::MoveAnchor);
 
     while (!highlightSelection.cursor.isNull() && !highlightSelection.cursor.atEnd()) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

When you click on a `{` or `}` in the decompiler view, only the matching brace is highlighted (instead of highlighting all braces of the same type.

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

Open any binary that has braces in its decompiled view.

https://github.com/rizinorg/cutter/assets/116057817/71ac0fc9-f4a9-48e9-bc58-8ff8c2ab9f69

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #3255
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
