### PR TITLE
Include instruction highlighter in python bindings.

### DIFF
--- a/src/bindings/bindings.xml.in
+++ b/src/bindings/bindings.xml.in
@@ -14,6 +14,7 @@
         <enum-type name="ContextMenuType" />
     </object-type>
     <object-type name="BasicBlockHighlighter" />
+    <object-type name="BasicInstructionHighlighter" />
     <object-type name="AddressableItemContextMenu" />
     <object-type name="CutterDockWidget" />
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Updated python binding config to allow accessing `core().getBIHighlighter`

**Test plan (required)**

In addition to checking generated binding file tested by slightly modifying the example python plugin.

```python
def handle_disassembler_action(self):
        # for actions in plugin menu Cutter sets data to address for current dissasembly line
        cutter.core().getBIHighlighter().clear(self.disas_action.data(), 8)
        cutter.message("Dissasembly menu action callback 0x{:x}".format(self.disas_action.data()))
```


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

Closes #2395
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
