### PR TITLE
Fix multiple crashes related to incorrect rz_iterator usage.

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -698,18 +698,16 @@ void CutterCore::delFlag(const QString &name)
     emit flagsChanged();
 }
 
-PRzAnalysisBytes CutterCore::getRzAnalysisBytesSingle(RVA addr)
+CutterRzIter<RzAnalysisBytes> CutterCore::getRzAnalysisBytesSingle(RVA addr)
 {
     CORE_LOCK();
     ut8 buf[128];
     rz_io_read_at(core->io, addr, buf, sizeof(buf));
 
-    auto seek = seekTemp(addr);
-    auto abiter = fromOwned(rz_core_analysis_bytes(core, addr, buf, sizeof(buf), 1));
-    auto ab =
-            abiter ? reinterpret_cast<RzAnalysisBytes *>(rz_iterator_next(abiter.get())) : nullptr;
-
-    return { ab, rz_analysis_bytes_free };
+    // Warning! only safe to use with stack buffer, due to instruction count being 1
+    auto result =
+            CutterRzIter<RzAnalysisBytes>(rz_core_analysis_bytes(core, addr, buf, sizeof(buf), 1));
+    return result;
 }
 
 QString CutterCore::getInstructionBytes(RVA addr)

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -62,8 +62,6 @@ struct CUTTER_EXPORT RegisterRef
     QString name;
 };
 
-using PRzAnalysisBytes = std::unique_ptr<RzAnalysisBytes, decltype(rz_analysis_bytes_free) *>;
-
 class CUTTER_EXPORT CutterCore : public QObject
 {
     Q_OBJECT
@@ -248,7 +246,7 @@ public:
     QString getGlobalVariableType(RVA offset);
 
     /* Edition functions */
-    PRzAnalysisBytes getRzAnalysisBytesSingle(RVA addr);
+    CutterRzIter<RzAnalysisBytes> getRzAnalysisBytesSingle(RVA addr);
     QString getInstructionBytes(RVA addr);
     QString getInstructionOpcode(RVA addr);
     void editInstruction(RVA addr, const QString &inst, bool fillWithNops = false);

--- a/src/core/RizinCpp.h
+++ b/src/core/RizinCpp.h
@@ -51,12 +51,6 @@ static inline auto fromOwned(RZ_OWN RzList *data) -> UniquePtrCP<decltype(data),
     return { data, {} };
 }
 
-static inline auto fromOwned(RZ_OWN RzIterator *data)
-        -> UniquePtrCP<decltype(data), &rz_iterator_free>
-{
-    return { data, {} };
-}
-
 // Rizin list iteration macros
 // deprecated, prefer using CutterPVector and CutterRzList instead
 #define CutterRzListForeach(list, it, type, x)                                                     \
@@ -168,6 +162,32 @@ public:
         return iterator(list->head);
     }
     iterator end() const { return iterator(nullptr); }
+};
+
+template<typename T>
+class CutterRzIter
+{
+    UniquePtrC<RzIterator, &rz_iterator_free> rzIter;
+
+public:
+    CutterRzIter(RzIterator *rzIter) : rzIter(rzIter)
+    {
+        // immediately attempt advancing by 1, otherwise it's hard to distinguish whether current
+        // element is null due to not having called next, or due to having run out of elements
+        if (rzIter) {
+            ++*this;
+        }
+    }
+
+    CutterRzIter<T> &operator++()
+    {
+        rz_iterator_next(rzIter.get());
+        return *this;
+    }
+    operator bool() { return rzIter && rzIter->cur; }
+    T &operator*() { return *reinterpret_cast<RzAnalysisBytes *>(rzIter->cur); }
+    T *get() { return reinterpret_cast<RzAnalysisBytes *>(rzIter->cur); }
+    T *operator->() { return reinterpret_cast<RzAnalysisBytes *>(rzIter->cur); }
 };
 
 #endif // RIZINCPP_H


### PR DESCRIPTION
RzAnalysisBytes are owned by the iterator, so returning analysis bytes while destroying iterator owning it is incorrect.

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

RzAnalysisBytes are owned by the iterator, so returning analysis bytes while destroying iterator owning it is incorrect. Previous version could cause use after free or attempts to free struct which shouldn't freed crashing either way.

Easiest methods to trigger the crash was opening right click context menu in disassembly or graph. And opening xrefs window on instruction with code xrefs (like the start of function). There might be others `getRzAnalysisBytesSingle` is indirectly used by quite a few places.

I am not too happy about the RzIter wrapper. But since it's already there I was thinking I could replace some of the places currently dealing  with RzAnalysisBytes to use  RzAnalysisOp instead, but not in this pull request.


Seems like 8574f0b0e42a1f0d12599548d9907a56dd236182 is also included in v2.3.3 so there is a high chance that it is  mostly unusable due to right click crash.

**Test plan (required)**

* right click in disassembly panel -> shouldn't crash
*  right click in function graph -> shouldn't crash
* click on function start and open xrefs window -> shouldn't crash


**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
