### PR TITLE
Do not use removed Rizin APIs

### DIFF
--- a/src/common/BugReporting.cpp
+++ b/src/common/BugReporting.cpp
@@ -10,7 +10,8 @@ void openIssue()
 {
     RzCoreLocked core(Core());
     RzBinFile *bf = rz_bin_cur(core->bin);
-    RzBinInfo *info = rz_bin_get_info(core->bin);
+    RzBinObject *bobj = rz_bin_cur_object(core->bin);
+    const RzBinInfo *info = bobj ? rz_bin_object_get_info(bobj) : nullptr;
     RzBinPlugin *plugin = rz_bin_file_cur_plugin(bf);
 
     QString url, osInfo, format, arch, type;

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -187,7 +187,7 @@ public:
         return parseJson(name, res, cmd.isNull() ? nullptr : cmd.toLocal8Bit().constData());
     }
 
-    QStringList autocomplete(const QString &cmd, RzLinePromptType promptType, size_t limit = 4096);
+    QStringList autocomplete(const QString &cmd, RzLinePromptType promptType);
 
     /* Functions methods */
     void renameFunction(const RVA offset, const QString &newName);

--- a/src/dialogs/VersionInfoDialog.cpp
+++ b/src/dialogs/VersionInfoDialog.cpp
@@ -24,7 +24,11 @@ VersionInfoDialog::~VersionInfoDialog() {}
 void VersionInfoDialog::fillVersionInfo()
 {
     RzCoreLocked core(Core());
-    const RzBinInfo *info = rz_bin_get_info(core->bin);
+    RzBinObject *bobj = rz_bin_cur_object(core->bin);
+    if (!bobj) {
+        return;
+    }
+    const RzBinInfo *info = rz_bin_object_get_info(bobj);
     if (!info || !info->rclass) {
         return;
     }

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -52,7 +52,8 @@ void Dashboard::updateContents()
     }
 
     // Add file hashes, analysis info and libraries
-    RzBinInfo *binInfo = rz_bin_get_info(core->bin);
+    RzBinObject *bobj = rz_bin_cur_object(core->bin);
+    const RzBinInfo *binInfo = bobj ? rz_bin_object_get_info(bobj) : nullptr;
 
     setPlainText(ui->fileEdit, binInfo ? binInfo->file : "");
     setPlainText(ui->formatEdit, binInfo ? binInfo->rclass : "");
@@ -211,7 +212,7 @@ void Dashboard::setPlainText(QLineEdit *textBox, const QString &text)
  * @brief Setting boolean values of binary information in dashboard
  * @param RzBinInfo
  */
-void Dashboard::setRzBinInfo(RzBinInfo *binInfo)
+void Dashboard::setRzBinInfo(const RzBinInfo *binInfo)
 {
     setPlainText(ui->vaEdit, binInfo ? setBoolText(binInfo->has_va) : "");
     setPlainText(ui->canaryEdit, binInfo ? setBoolText(binInfo->has_canary) : "");

--- a/src/widgets/Dashboard.h
+++ b/src/widgets/Dashboard.h
@@ -33,7 +33,7 @@ private slots:
 private:
     std::unique_ptr<Ui::Dashboard> ui;
     void setPlainText(QLineEdit *textBox, const QString &text);
-    void setRzBinInfo(RzBinInfo *binInfo);
+    void setRzBinInfo(const RzBinInfo *binInfo);
     const char *setBoolText(bool value);
 
     QWidget *hashesWidget = nullptr;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Fixes the following errors:
```
 31.76 /root/cutter/src/core/Cutter.cpp: In member function ‘bool CutterCore::existsFileInfo()’:
#9 31.76 /root/cutter/src/core/Cutter.cpp:1380:29: error: ‘rz_bin_get_info’ was not declared in this scope; did you mean ‘rz_bp_get_in’?
#9 31.76  1380 |     const RzBinInfo *info = rz_bin_get_info(core->bin);
#9 31.76       |                             ^~~~~~~~~~~~~~~
#9 31.76       |                             rz_bp_get_in
#9 31.76 /root/cutter/src/core/Cutter.cpp: In member function ‘QList<SymbolDescription> CutterCore::getAllSymbols()’:
#9 31.76 /root/cutter/src/core/Cutter.cpp:3182:54: error: cannot convert ‘const RzPVector*’ {aka ‘const rz_pvector_t*’} to ‘const RzList*’ {aka ‘const rz_list_t*’} in initialization
#9 31.76  3182 |     const RzList *entries = rz_bin_object_get_entries(bf->o);
#9 31.76       |                             ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
#9 31.76       |                                                      |
#9 31.76       |                                                      const RzPVector* {aka const rz_pvector_t*}
#9 31.76 /root/cutter/src/core/Cutter.cpp: In member function ‘QList<EntrypointDescription> CutterCore::getAllEntrypoint()’:
#9 31.76 /root/cutter/src/core/Cutter.cpp:3499:54: error: cannot convert ‘const RzPVector*’ {aka ‘const rz_pvector_t*’} to ‘const RzList*’ {aka ‘const rz_list_t*’} in initialization
#9 31.76  3499 |     const RzList *entries = rz_bin_object_get_entries(bf->o);
#9 31.76       |                             ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
#9 31.76       |                                                      |
#9 31.76       |                                                      const RzPVector* {aka const rz_pvector_t*}
```

**Test plan (required)**

CI is green

**Closing issues**

Related to https://github.com/rizinorg/rz-ghidra/pull/346