### PR TITLE
Processes/ThreadsWidget: fix ODR violations by moving Column enums into classes

### DIFF
--- a/src/widgets/ProcessesWidget.cpp
+++ b/src/widgets/ProcessesWidget.cpp
@@ -9,13 +9,6 @@
 
 #define DEBUGGED_PID (-1)
 
-enum ColumnIndex {
-    COLUMN_PID = 0,
-    COLUMN_UID,
-    COLUMN_STATUS,
-    COLUMN_PATH,
-};
-
 ProcessesWidget::ProcessesWidget(MainWindow *main)
     : CutterDockWidget(main), ui(new Ui::ProcessesWidget)
 {
@@ -23,10 +16,14 @@ ProcessesWidget::ProcessesWidget(MainWindow *main)
 
     // Setup processes model
     modelProcesses = new QStandardItemModel(1, 4, this);
-    modelProcesses->setHorizontalHeaderItem(COLUMN_PID, new QStandardItem(tr("PID")));
-    modelProcesses->setHorizontalHeaderItem(COLUMN_UID, new QStandardItem(tr("UID")));
-    modelProcesses->setHorizontalHeaderItem(COLUMN_STATUS, new QStandardItem(tr("Status")));
-    modelProcesses->setHorizontalHeaderItem(COLUMN_PATH, new QStandardItem(tr("Path")));
+    modelProcesses->setHorizontalHeaderItem(ProcessesWidget::COLUMN_PID,
+                                            new QStandardItem(tr("PID")));
+    modelProcesses->setHorizontalHeaderItem(ProcessesWidget::COLUMN_UID,
+                                            new QStandardItem(tr("UID")));
+    modelProcesses->setHorizontalHeaderItem(ProcessesWidget::COLUMN_STATUS,
+                                            new QStandardItem(tr("Status")));
+    modelProcesses->setHorizontalHeaderItem(ProcessesWidget::COLUMN_PATH,
+                                            new QStandardItem(tr("Path")));
     ui->viewProcesses->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     ui->viewProcesses->verticalHeader()->setVisible(false);
     ui->viewProcesses->setFont(Config()->getFont());
@@ -129,10 +126,10 @@ void ProcessesWidget::setProcessesGrid()
         rowStatus->setFont(font);
         rowPath->setFont(font);
 
-        modelProcesses->setItem(i, COLUMN_PID, rowPid);
-        modelProcesses->setItem(i, COLUMN_UID, rowUid);
-        modelProcesses->setItem(i, COLUMN_STATUS, rowStatus);
-        modelProcesses->setItem(i, COLUMN_PATH, rowPath);
+        modelProcesses->setItem(i, ProcessesWidget::COLUMN_PID, rowPid);
+        modelProcesses->setItem(i, ProcessesWidget::COLUMN_UID, rowUid);
+        modelProcesses->setItem(i, ProcessesWidget::COLUMN_STATUS, rowStatus);
+        modelProcesses->setItem(i, ProcessesWidget::COLUMN_PATH, rowPath);
         i++;
     }
 
@@ -155,7 +152,7 @@ void ProcessesWidget::onActivated(const QModelIndex &index)
     if (!index.isValid())
         return;
 
-    int pid = modelFilter->data(index.sibling(index.row(), COLUMN_PID)).toInt();
+    int pid = modelFilter->data(index.sibling(index.row(), ProcessesWidget::COLUMN_PID)).toInt();
     // Verify that the selected pid is still in the processes list since dp= will
     // attach to any given id. If it isn't found simply update the UI.
     for (const auto &value : Core()->getAllProcesses()) {
@@ -185,7 +182,7 @@ ProcessesFilterModel::ProcessesFilterModel(QObject *parent) : QSortFilterProxyMo
 bool ProcessesFilterModel::filterAcceptsRow(int row, const QModelIndex &parent) const
 {
     // All columns are checked for a match
-    for (int i = COLUMN_PID; i <= COLUMN_PATH; ++i) {
+    for (int i = ProcessesWidget::COLUMN_PID; i <= ProcessesWidget::COLUMN_PATH; ++i) {
         QModelIndex index = sourceModel()->index(row, i, parent);
         if (qhelpers::filterStringContains(sourceModel()->data(index).toString(), this)) {
             return true;

--- a/src/widgets/ProcessesWidget.h
+++ b/src/widgets/ProcessesWidget.h
@@ -31,6 +31,13 @@ class ProcessesWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
+    enum ColumnIndex {
+        COLUMN_PID = 0,
+        COLUMN_UID,
+        COLUMN_STATUS,
+        COLUMN_PATH,
+    };
+
     explicit ProcessesWidget(MainWindow *main);
     ~ProcessesWidget();
 

--- a/src/widgets/ThreadsWidget.cpp
+++ b/src/widgets/ThreadsWidget.cpp
@@ -9,21 +9,17 @@
 
 #define DEBUGGED_PID (-1)
 
-enum ColumnIndex {
-    COLUMN_PID = 0,
-    COLUMN_STATUS,
-    COLUMN_PATH,
-};
-
 ThreadsWidget::ThreadsWidget(MainWindow *main) : CutterDockWidget(main), ui(new Ui::ThreadsWidget)
 {
     ui->setupUi(this);
 
     // Setup threads model
     modelThreads = new QStandardItemModel(1, 3, this);
-    modelThreads->setHorizontalHeaderItem(COLUMN_PID, new QStandardItem(tr("PID")));
-    modelThreads->setHorizontalHeaderItem(COLUMN_STATUS, new QStandardItem(tr("Status")));
-    modelThreads->setHorizontalHeaderItem(COLUMN_PATH, new QStandardItem(tr("Path")));
+    modelThreads->setHorizontalHeaderItem(ThreadsWidget::COLUMN_PID, new QStandardItem(tr("PID")));
+    modelThreads->setHorizontalHeaderItem(ThreadsWidget::COLUMN_STATUS,
+                                          new QStandardItem(tr("Status")));
+    modelThreads->setHorizontalHeaderItem(ThreadsWidget::COLUMN_PATH,
+                                          new QStandardItem(tr("Path")));
     ui->viewThreads->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     ui->viewThreads->verticalHeader()->setVisible(false);
     ui->viewThreads->setFont(Config()->getFont());
@@ -120,9 +116,9 @@ void ThreadsWidget::setThreadsGrid()
         rowStatus->setFont(font);
         QStandardItem *rowPath = new QStandardItem(path);
         rowPath->setFont(font);
-        modelThreads->setItem(i, COLUMN_PID, rowPid);
-        modelThreads->setItem(i, COLUMN_STATUS, rowStatus);
-        modelThreads->setItem(i, COLUMN_PATH, rowPath);
+        modelThreads->setItem(i, ThreadsWidget::COLUMN_PID, rowPid);
+        modelThreads->setItem(i, ThreadsWidget::COLUMN_STATUS, rowStatus);
+        modelThreads->setItem(i, ThreadsWidget::COLUMN_PATH, rowPath);
         i++;
     }
 
@@ -146,7 +142,7 @@ void ThreadsWidget::onActivated(const QModelIndex &index)
     if (!index.isValid())
         return;
 
-    int tid = modelFilter->data(index.sibling(index.row(), COLUMN_PID)).toInt();
+    int tid = modelFilter->data(index.sibling(index.row(), ThreadsWidget::COLUMN_PID)).toInt();
 
     // Verify that the selected tid is still in the threads list since dpt= will
     // attach to any given id. If it isn't found simply update the UI.
@@ -169,7 +165,7 @@ ThreadsFilterModel::ThreadsFilterModel(QObject *parent) : QSortFilterProxyModel(
 bool ThreadsFilterModel::filterAcceptsRow(int row, const QModelIndex &parent) const
 {
     // All columns are checked for a match
-    for (int i = COLUMN_PID; i <= COLUMN_PATH; ++i) {
+    for (int i = ThreadsWidget::COLUMN_PID; i <= ThreadsWidget::COLUMN_PATH; ++i) {
         QModelIndex index = sourceModel()->index(row, i, parent);
         if (qhelpers::filterStringContains(sourceModel()->data(index).toString(), this)) {
             return true;

--- a/src/widgets/ThreadsWidget.h
+++ b/src/widgets/ThreadsWidget.h
@@ -31,6 +31,12 @@ class ThreadsWidget : public CutterDockWidget
     Q_OBJECT
 
 public:
+    enum ColumnIndex {
+        COLUMN_PID = 0,
+        COLUMN_STATUS,
+        COLUMN_PATH,
+    };
+
     explicit ThreadsWidget(MainWindow *main);
     ~ThreadsWidget();
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The ThreadsWidget and ProcessesWidget column index enumerators having the same name with differing definitions violates the C++ One Definition Rule. These patches move those enums into the respective classes of each of these widgets, happily allowing differing definitions with the same name, and brings these two widgets into alignments with other widgets that define the column indexes similarly.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

I've tested that the widgets touched here still function as expected.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
Closes #3316 