### PR TITLE
Update Rizin to the latest `dev`

### DIFF
--- a/cmake/BundledRizin.cmake
+++ b/cmake/BundledRizin.cmake
@@ -59,10 +59,9 @@ endif()
 # instead of being hardcoded.
 set (Rizin_VERSION 0.8)
 
-set (RZ_LIBS rz_core rz_config rz_cons rz_io rz_util rz_flag rz_asm rz_debug
-        rz_hash rz_bin rz_lang rz_il rz_analysis rz_parse rz_bp rz_egg rz_reg
-        rz_search rz_syscall rz_socket rz_magic rz_crypto rz_type rz_diff rz_sign
-        rz_demangler)
+set (RZ_LIBS rz_core rz_config rz_cons rz_io rz_util rz_flag rz_arch rz_debug
+        rz_hash rz_bin rz_lang rz_il rz_bp rz_egg rz_reg rz_search rz_syscall
+        rz_socket rz_magic rz_crypto rz_type rz_diff rz_sign rz_demangler)
 set (RZ_EXTRA_LIBS rz_main)
 set (RZ_BIN rz-bin rizin rz-diff rz-find rz-gg rz-hash rz-run rz-asm rz-ax)
 

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1641,7 +1641,7 @@ QVector<Chunk> CutterCore::getHeapChunks(RVA arena_addr)
             rz_list_free(arenas);
             return chunks_vector;
         }
-        m_arena = ((RzArenaListItem *)rz_list_last(arenas))->addr;
+        m_arena = ((RzArenaListItem *)rz_list_first(arenas))->addr;
         rz_list_free(arenas);
     } else {
         m_arena = arena_addr;

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1295,7 +1295,7 @@ RVA CutterCore::getLastFunctionInstruction(RVA addr)
     if (!fcn) {
         return RVA_INVALID;
     }
-    RzAnalysisBlock *lastBB = (RzAnalysisBlock *)rz_list_last(fcn->bbs);
+    RzAnalysisBlock *lastBB = (RzAnalysisBlock *)rz_pvector_tail(fcn->bbs);
     return lastBB ? rz_analysis_block_get_op_addr(lastBB, lastBB->ninstr - 1) : RVA_INVALID;
 }
 
@@ -1641,7 +1641,7 @@ QVector<Chunk> CutterCore::getHeapChunks(RVA arena_addr)
             rz_list_free(arenas);
             return chunks_vector;
         }
-        m_arena = ((RzArenaListItem *)rz_list_get_head_data(arenas))->addr;
+        m_arena = ((RzArenaListItem *)rz_list_last(arenas))->addr;
         rz_list_free(arenas);
     } else {
         m_arena = arena_addr;
@@ -3061,7 +3061,7 @@ QList<FunctionDescription> CutterCore::getAllFunctions()
         function.linearSize = rz_analysis_function_linear_size(fcn);
         function.nargs = rz_analysis_arg_count(fcn);
         function.nlocals = rz_analysis_var_local_count(fcn);
-        function.nbbs = rz_list_length(fcn->bbs);
+        function.nbbs = rz_pvector_len(fcn->bbs);
         function.calltype = fcn->cc ? QString::fromUtf8(fcn->cc) : QString();
         function.name = fcn->name ? QString::fromUtf8(fcn->name) : QString();
         function.edges = rz_analysis_function_count_edges(fcn, nullptr);
@@ -4334,10 +4334,9 @@ QString CutterCore::getVersionInformation()
         const char *name;
         const char *(*callback)();
     } vcs[] = {
-        { "rz_analysis", &rz_analysis_version },
+        { "rz_arch", &rz_arch_version },
         { "rz_lib", &rz_lib_version },
         { "rz_egg", &rz_egg_version },
-        { "rz_asm", &rz_asm_version },
         { "rz_bin", &rz_bin_version },
         { "rz_cons", &rz_cons_version },
         { "rz_flag", &rz_flag_version },
@@ -4350,7 +4349,6 @@ QString CutterCore::getVersionInformation()
 #if !USE_LIB_MAGIC
         { "rz_magic", &rz_magic_version },
 #endif
-        { "rz_parse", &rz_parse_version },
         { "rz_reg", &rz_reg_version },
         { "rz_sign", &rz_sign_version },
         { "rz_search", &rz_search_version },

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -225,7 +225,7 @@ void DisassemblerGraphView::loadCurrentGraph()
         return;
     }
 
-    for (const auto &bbi : CutterRzList<RzAnalysisBlock>(fcn->bbs)) {
+    for (const auto &bbi : CutterPVector<RzAnalysisBlock>(fcn->bbs)) {
         RVA bbiFail = bbi->fail;
         RVA bbiJump = bbi->jump;
 


### PR DESCRIPTION
Should fix the following errors: 
```
../src/core/Cutter.cpp: In member function 'RVA CutterCore::getLastFunctionInstruction(RVA)':
#9 23.42 ../src/core/Cutter.cpp:1298:68: error: cannot convert 'RzPVector*' {aka 'rz_pvector_t*'} to 'const RzList*' {aka 'const rz_list_t*'}
#9 23.42      RzAnalysisBlock *lastBB = (RzAnalysisBlock *)rz_list_last(fcn->bbs);
#9 23.42                                                                ~~~~~^~~
#9 23.42 In file included from /usr/include/librz/rz_diff.h:9,
#9 23.42                  from /usr/include/librz/rz_util.h:8,
#9 23.42                  from /usr/include/librz/rz_getopt.h:4,
#9 23.42                  from /usr/include/librz/rz_main.h:9,
#9 23.42                  from /usr/include/librz/rz_core.h:7,
#9 23.42                  from ../src/core/CutterCommon.h:8,
#9 23.42                  from ../src/common/TempConfig.h:5,
#9 23.42                  from ../src/core/Cutter.cpp:13:
#9 23.42 /usr/include/librz/rz_list.h:79:62: note:   initializing argument 1 of 'void* rz_list_last(const RzList*)'
#9 23.42  RZ_API RZ_BORROW void *rz_list_last(RZ_NONNULL const RzList *list);
#9 23.42                                                 ~~~~~~~~~~~~~~^~~~
#9 23.42 ../src/core/Cutter.cpp: In member function 'QVector<Chunk> CutterCore::getHeapChunks(RVA)':
#9 23.42 ../src/core/Cutter.cpp:1644:39: error: 'rz_list_get_head_data' was not declared in this scope
#9 23.42          m_arena = ((RzArenaListItem *)rz_list_get_head_data(arenas))->addr;
#9 23.42                                        ^~~~~~~~~~~~~~~~~~~~~
#9 23.42 ../src/core/Cutter.cpp:1644:39: note: suggested alternative: 'rz_list_delete_data'
#9 23.42          m_arena = ((RzArenaListItem *)rz_list_get_head_data(arenas))->addr;
#9 23.42                                        ^~~~~~~~~~~~~~~~~~~~~
#9 23.42                                        rz_list_delete_data
#9 23.42 ../src/core/Cutter.cpp: In member function 'QList<FunctionDescription> CutterCore::getAllFunctions()':
#9 23.42 ../src/core/Cutter.cpp:3064:45: error: cannot convert 'RzPVector*' {aka 'rz_pvector_t*'} to 'const RzList*' {aka 'const rz_list_t*'}
#9 23.42          function.nbbs = rz_list_length(fcn->bbs);
#9 23.42                                         ~~~~~^~~
#9 23.42 In file included from /usr/include/librz/rz_diff.h:9,
#9 23.42                  from /usr/include/librz/rz_util.h:8,
#9 23.42                  from /usr/include/librz/rz_getopt.h:4,
#9 23.42                  from /usr/include/librz/rz_main.h:9,
#9 23.42                  from /usr/include/librz/rz_core.h:7,
#9 23.42                  from ../src/core/CutterCommon.h:8,
#9 23.42                  from ../src/common/TempConfig.h:5,
#9 23.42                  from ../src/core/Cutter.cpp:13:
#9 23.42 /usr/include/librz/rz_list.h:77:53: note:   initializing argument 1 of 'unsigned int rz_list_length(const RzList*)'
#9 23.42  RZ_API ut32 rz_list_length(RZ_NONNULL const RzList *list);
#9 23.42                                        ~~~~~~~~~~~~~~^~~~
#9 23.42 ../src/core/Cutter.cpp: In member function 'QString CutterCore::getVersionInformation()':
#9 23.42 ../src/core/Cutter.cpp:4337:27: error: 'rz_analysis_version' was not declared in this scope
#9 23.42          { "rz_analysis", &rz_analysis_version },
#9 23.42                            ^~~~~~~~~~~~~~~~~~~
#9 23.42 ../src/core/Cutter.cpp:4337:27: note: suggested alternative: 'rz_analysis_var_size'
#9 23.42          { "rz_analysis", &rz_analysis_version },
#9 23.42                            ^~~~~~~~~~~~~~~~~~~
#9 23.42                            rz_analysis_var_size
#9 23.42 ../src/core/Cutter.cpp:4340:22: error: 'rz_asm_version' was not declared in this scope
#9 23.42          { "rz_asm", &rz_asm_version },
#9 23.42                       ^~~~~~~~~~~~~~
#9 23.42 ../src/core/Cutter.cpp:4340:22: note: suggested alternative: 'rz_hash_version'
#9 23.42          { "rz_asm", &rz_asm_version },
#9 23.42                       ^~~~~~~~~~~~~~
#9 23.42                       rz_hash_version
#9 23.42 ../src/core/Cutter.cpp:4353:24: error: 'rz_parse_version' was not declared in this scope
#9 23.42          { "rz_parse", &rz_parse_version },
#9 23.42                         ^~~~~~~~~~~~~~~~
#9 23.42 ../src/core/Cutter.cpp:4353:24: note: suggested alternative: 'rz_core_version'
#9 23.42          { "rz_parse", &rz_parse_version },
#9 23.42                         ^~~~~~~~~~~~~~~~
#9 23.42                         rz_core_version
#9 23.49 [33/187] Building CXX object src/CMakeFiles/Cutter.dir/Main.cpp.o
#9 24.21 [34/187] Building CXX object src/CMakeFiles/Cutter.dir/dialogs/WriteCommandsDialogs.cpp.o
#9 24.68 [35/187] Building CXX object src/CMakeFiles/Cutter.dir/widgets/OverviewView.cpp.o
#9 24.82 [36/187] Building CXX object src/CMakeFiles/Cutter.dir/widgets/DisassemblerGraphView.cpp.o
#9 24.82 FAILED: src/CMakeFiles/Cutter.dir/widgets/DisassemblerGraphView.cpp.o 
#9 24.82 /usr/bin/c++  -DCUTTER_SOURCE_BUILD -DCutter_EXPORTS -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_WIDGETS_LIB -Isrc -I../src -Isrc/Cutter_autogen/include -I../src/core -I../src/widgets -I../src/common -I../src/plugins -I../src/menus -I../src/. -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -isystem /usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtSvg -isystem /usr/include/x86_64-linux-gnu/qt5/QtNetwork -isystem /usr/include/librz -isystem /usr/include/librz/sdb -fvisibility=hidden   -Wall -Wextra -fPIC -std=gnu++11 -MD -MT src/CMakeFiles/Cutter.dir/widgets/DisassemblerGraphView.cpp.o -MF src/CMakeFiles/Cutter.dir/widgets/DisassemblerGraphView.cpp.o.d -o src/CMakeFiles/Cutter.dir/widgets/DisassemblerGraphView.cpp.o -c ../src/widgets/DisassemblerGraphView.cpp
#9 24.82 ../src/widgets/DisassemblerGraphView.cpp: In member function 'void DisassemblerGraphView::loadCurrentGraph()':
#9 24.82 ../src/widgets/DisassemblerGraphView.cpp:228:66: error: no matching function for call to 'CutterRzList<rz_analysis_bb_t>::CutterRzList(RzPVector*&)'
#9 24.82      for (const auto &bbi : CutterRzList<RzAnalysisBlock>(fcn->bbs)) {
#9 24.82                                                                   ^
#9 24.82 In file included from ../src/core/CutterCommon.h:10,
#9 24.82                  from ../src/core/Cutter.h:4,
#9 24.82                  from ../src/widgets/GraphView.h:18,
#9 24.82                  from ../src/widgets/CutterGraphView.h:11,
#9 24.82                  from ../src/widgets/DisassemblerGraphView.h:11,
#9 24.82                  from ../src/widgets/DisassemblerGraphView.cpp:2:
#9 24.82 ../src/core/RizinCpp.h:156:14: note: candidate: 'CutterRzList<T>::CutterRzList(const RzList*) [with T = rz_analysis_bb_t; RzList = rz_list_t]'
#9 24.82      explicit CutterRzList(const RzList *l) : list(l) {}
#9 24.82               ^~~~~~~~~~~~
#9 24.82 ../src/core/RizinCpp.h:156:14: note:   no known conversion for argument 1 from 'RzPVector*' {aka 'rz_pvector_t*'} to 'const RzList*' {aka 'const rz_list_t*'}
#9 24.82 ../src/core/RizinCpp.h:110:7: note: candidate: 'constexpr CutterRzList<rz_analysis_bb_t>::CutterRzList(const CutterRzList<rz_analysis_bb_t>&)'
#9 24.82  class CutterRzList
#9 24.82        ^~~~~~~~~~~~
#9 24.82 ../src/core/RizinCpp.h:110:7: note:   no known conversion for argument 1 from 'RzPVector*' {aka 'rz_pvector_t*'} to 'const CutterRzList<rz_analysis_bb_t>&'
#9 24.82 ../src/core/RizinCpp.h:110:7: note: candidate: 'constexpr CutterRzList<rz_analysis_bb_t>::CutterRzList(CutterRzList<rz_analysis_bb_t>&&)'
#9 24.82 ../src/core/RizinCpp.h:110:7: note:   no known conversion for argument 1 from 'RzPVector*' {aka 'rz_pvector_t*'} to 'CutterRzList<rz_analysis_bb_t>&&'
#9 25.04 [37/187] Building CXX object src/CMakeFiles/Cutter.dir/common/DisassemblyPreview.cpp.o
#9 25.04 ninja: build stopped: subcommand failed.
#9 ERROR: process "/bin/sh -c cd /root && \tgit clone --recurse-submodules --depth 1 https://github.com/rizinorg/cutter && \tcd cutter && \tcmake -Bbuild -GNinja -DCUTTER_USE_BUNDLED_RIZIN=OFF -DCMAKE_INSTALL_PREFIX=/usr && \tninja -C build && \tninja -C build install" did not complete successfully: exit code: 1
------
 > [5/5] RUN cd /root && 	git clone --recurse-submodules --depth 1 https://github.com/rizinorg/cutter && 	cd cutter && 	cmake -Bbuild -GNinja -DCUTTER_USE_BUNDLED_RIZIN=OFF -DCMAKE_INSTALL_PREFIX=/usr && 	ninja -C build && 	ninja -C build install:
24.82               ^~~~~~~~~~~~
24.82 ../src/core/RizinCpp.h:156:14: note:   no known conversion for argument 1 from 'RzPVector*' {aka 'rz_pvector_t*'} to 'const RzList*' {aka 'const rz_list_t*'}
24.82 ../src/core/RizinCpp.h:110:7: note: candidate: 'constexpr CutterRzList<rz_analysis_bb_t>::CutterRzList(const CutterRzList<rz_analysis_bb_t>&)'
24.82  class CutterRzList
24.82        ^~~~~~~~~~~~
24.82 ../src/core/RizinCpp.h:110:7: note:   no known conversion for argument 1 from 'RzPVector*' {aka 'rz_pvector_t*'} to 'const CutterRzList<rz_analysis_bb_t>&'
24.82 ../src/core/RizinCpp.h:110:7: note: candidate: 'constexpr CutterRzList<rz_analysis_bb_t>::CutterRzList(CutterRzList<rz_analysis_bb_t>&&)'
24.82 ../src/core/RizinCpp.h:110:7: note:   no known conversion for argument 1 from 'RzPVector*' {aka 'rz_pvector_t*'} to 'CutterRzList<rz_analysis_bb_t>&&'
25.04 [37/187] Building CXX object src/CMakeFiles/Cutter.dir/common/DisassemblyPreview.cpp.o
25.04 ninja: build stopped: subcommand failed.
```