### PR TITLE
[WIP] Add Multiline Selections/Operations

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -2,6 +2,7 @@
 #include <QJsonObject>
 #include <QRegularExpression>
 #include <QDir>
+#include <QDebug>
 #include <QCoreApplication>
 #include <QVector>
 #include <QStringList>
@@ -772,6 +773,7 @@ void CutterCore::editBytesEndian(RVA addr, const QString &bytes)
 
 void CutterCore::setToCode(RVA addr)
 {
+    qDebug() << "setToCode" << addr << "\n";
     CORE_LOCK();
     rz_meta_del(core->analysis, RZ_META_TYPE_STRING, core->offset, 1);
     rz_meta_del(core->analysis, RZ_META_TYPE_DATA, core->offset, 1);
@@ -842,6 +844,7 @@ QString CutterCore::getMetaString(RVA addr)
 
 void CutterCore::setToData(RVA addr, int size, int repeat)
 {
+    qDebug() << "setToData" << addr << size << repeat << "\n";
     if (size <= 0 || repeat <= 0) {
         return;
     }

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -4,6 +4,8 @@
 #include "core/Cutter.h"
 #include "common/IOModesController.h"
 #include <QMenu>
+#include <QTextEdit>
+#include <QSet>
 #include <QKeySequence>
 
 class MainWindow;
@@ -22,6 +24,8 @@ signals:
 public slots:
     void setOffset(RVA offset);
     void setCanCopy(bool enabled);
+    void prepareMenu(const QList<QTextEdit::ExtraSelection>& selectedLines);
+
 
     /**
      * @brief Sets the value of curHighlightedWord
@@ -61,9 +65,13 @@ private slots:
     void on_actionContinueUntil_triggered();
     void on_actionSetPC_triggered();
 
+    void applySetToCode();
     void on_actionSetToCode_triggered();
+    void on_actionSetToCode_triggered(RVA offset);
     void on_actionSetAsString_triggered();
+    void on_actionSetAsString_triggered(RVA offset);
     void on_actionSetAsStringRemove_triggered();
+    void on_actionSetAsStringRemove_triggered(RVA offset);
     void on_actionSetAsStringAdvanced_triggered();
     void on_actionSetToData_triggered();
     void on_actionSetToDataEx_triggered();
@@ -100,6 +108,7 @@ private:
     bool canCopy;
     QString curHighlightedWord; // The current highlighted word
     MainWindow *mainWindow;
+    QList<QTextEdit::ExtraSelection> selectedLines;
     IOModesController ioModesController;
 
     QList<QAction *> anonymousActions;
@@ -189,12 +198,13 @@ private:
 
     void setBase(QString base);
     void setToData(int size, int repeat = 1);
+    void setToData(RVA offset, int size, int repeat = 1);
     void setBits(int bits);
-
     void addSetBaseMenu();
     void addSetBitsMenu();
     void addSetAsMenu();
     void addSetToDataMenu();
+    void applySetToData(int datasize);
     void addEditMenu();
     void addAddAtMenu();
     void addBreakpointMenu();

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -439,6 +439,29 @@ void DisassemblyWidget::highlightPCLine()
     mDisasTextEdit->setExtraSelections(currentSelections);
 }
 
+void DisassemblyWidget::highlightMultiLineSelections()
+{
+    QList<QTextEdit::ExtraSelection> extraSelections;
+    QTextEdit::ExtraSelection highlightSelection;
+    QColor highlightColor = ConfigColor("lineHighlight");
+
+    // Highlight each selection in the multilineSelections list
+    for (const QTextEdit::ExtraSelection &selection : mDisasTextEdit->getMultiLineSelections()) {
+        highlightSelection.format.setBackground(highlightColor);
+        highlightSelection.format.setProperty(QTextFormat::FullWidthSelection, true);
+        highlightSelection.cursor = mDisasTextEdit->textCursor();
+        highlightSelection.cursor.setPosition(selection.cursor.selectionStart());
+        highlightSelection.cursor.setPosition(selection.cursor.selectionEnd(),
+                                              QTextCursor::KeepAnchor);
+        extraSelections.append(highlightSelection);
+    }
+
+    // Don't override any extraSelections already set
+    QList<QTextEdit::ExtraSelection> currentSelections = mDisasTextEdit->extraSelections();
+    currentSelections.append(extraSelections);
+    mDisasTextEdit->setExtraSelections(currentSelections);
+}
+
 void DisassemblyWidget::showDisasContextMenu(const QPoint &pt)
 {
     mCtxMenu->exec(mDisasTextEdit->mapToGlobal(pt));
@@ -511,7 +534,7 @@ void DisassemblyWidget::updateCursorPosition()
     }
 
     highlightPCLine();
-
+    highlightMultiLineSelections();
     connectCursorPositionChanged(false);
 }
 
@@ -546,6 +569,7 @@ void DisassemblyWidget::cursorPositionChanged()
     seekFromCursor = false;
     highlightCurrentLine();
     highlightPCLine();
+    highlightMultiLineSelections();
     mCtxMenu->setCanCopy(mDisasTextEdit->textCursor().hasSelection());
     if (mDisasTextEdit->textCursor().hasSelection()) {
         // A word is selected so use it
@@ -615,6 +639,7 @@ void DisassemblyWidget::moveCursorRelative(bool up, bool page)
             seekable->seek(offset);
             highlightCurrentLine();
             highlightPCLine();
+            highlightMultiLineSelections();
         }
     }
 }
@@ -661,12 +686,25 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 
 void DisassemblyWidget::keyPressEvent(QKeyEvent *event)
 {
-    if (event->key() == Qt::Key_Return) {
+    if (event->key() == Qt::Key_Shift) {
+        qDebug() << "shift key pressed";
+        mDisasTextEdit->setMultiLineSelection(true);
+    } else if (event->key() == Qt::Key_Return) {
         const QTextCursor cursor = mDisasTextEdit->textCursor();
         jumpToOffsetUnderCursor(cursor);
     }
 
     MemoryDockWidget::keyPressEvent(event);
+}
+
+void DisassemblyWidget::keyReleaseEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Shift) {
+        qDebug() << "shift key released";
+        mDisasTextEdit->setMultiLineSelection(false);
+    }
+
+    MemoryDockWidget::keyReleaseEvent(event);
 }
 
 QString DisassemblyWidget::getWindowTitle() const
@@ -788,9 +826,64 @@ void DisassemblyTextEdit::keyPressEvent(QKeyEvent *event)
     Q_UNUSED(event)
     // QPlainTextEdit::keyPressEvent(event);
 }
-
 void DisassemblyTextEdit::mousePressEvent(QMouseEvent *event)
 {
+    if (event->button() == Qt::LeftButton && !multiLineSelection) {
+        multilineSelections.clear();
+    }
+
+    // Check for left button click and multiline individual selection mode (shift key pressed)
+    if (event->button() == Qt::LeftButton && multiLineSelection) {
+        // Use cursorForPosition to set the cursor to the exact click position
+        QTextCursor cursor = cursorForPosition(event->pos());
+        setTextCursor(cursor); // Update the text cursor to this position
+
+        int startPos = cursor.selectionStart();
+        int endPos = cursor.selectionEnd();
+
+        // Format selection
+        QTextEdit::ExtraSelection selection;
+        selection.format.setBackground(QColor("green"));
+        selection.format.setProperty(QTextFormat::FullWidthSelection, true);
+
+        // Move cursor to start of the line
+        cursor.movePosition(QTextCursor::StartOfLine);
+        startPos = cursor.position();
+
+        // Extend cursor to the end of the line
+        cursor.movePosition(QTextCursor::EndOfLine, QTextCursor::KeepAnchor);
+        endPos = cursor.position();
+
+        // Debug log
+        qDebug() << "Offset of line added: " << startPos << "-" << endPos;
+
+        // Check if line is already selected
+        auto it = std::find_if(multilineSelections.begin(), multilineSelections.end(),
+                               [startPos, endPos](const QTextEdit::ExtraSelection &s) {
+                                   return s.cursor.selectionStart() == startPos
+                                           && s.cursor.selectionEnd() == endPos;
+                               });
+
+        if (it != multilineSelections.end()) {
+            // Deselect if already selected
+            multilineSelections.erase(it);
+        } else {
+            // Add this line to the selections if not already selected
+            selection.cursor = cursor;
+            multilineSelections.append(selection);
+        }
+
+        // Apply the selections
+        setExtraSelections(multilineSelections);
+
+        // Debug log
+        qDebug() << "Multiline selections:";
+        for (const auto &selection : multilineSelections) {
+            qDebug() << "Start:" << selection.cursor.selectionStart()
+                     << "End:" << selection.cursor.selectionEnd();
+        }
+    }
+
     QPlainTextEdit::mousePressEvent(event);
 
     if (event->button() == Qt::RightButton && !textCursor().hasSelection()) {

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -464,6 +464,12 @@ void DisassemblyWidget::highlightMultiLineSelections()
 
 void DisassemblyWidget::showDisasContextMenu(const QPoint &pt)
 {
+    qDebug() << "showDisasContextMenu()" << "\n";
+    auto selectedLines = mDisasTextEdit->getMultiLineSelections();
+    if (selectedLines.size() > 1) {
+        mCtxMenu->prepareMenu(selectedLines);
+    }
+
     mCtxMenu->exec(mDisasTextEdit->mapToGlobal(pt));
 }
 
@@ -843,7 +849,7 @@ void DisassemblyTextEdit::mousePressEvent(QMouseEvent *event)
 
         // Format selection
         QTextEdit::ExtraSelection selection;
-        selection.format.setBackground(QColor("green"));
+        selection.format.setBackground(QColor("darkBlue"));
         selection.format.setProperty(QTextFormat::FullWidthSelection, true);
 
         // Move cursor to start of the line
@@ -881,6 +887,9 @@ void DisassemblyTextEdit::mousePressEvent(QMouseEvent *event)
         for (const auto &selection : multilineSelections) {
             qDebug() << "Start:" << selection.cursor.selectionStart()
                      << "End:" << selection.cursor.selectionEnd();
+            qDebug() << selection.cursor.block().text();
+            auto offset = DisassemblyPreview::readDisassemblyOffset(selection.cursor);
+            qDebug() << "Offset:" << offset << "\n";
         }
     }
 

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -41,6 +41,7 @@ public slots:
      * overrides all previous highlighting.
      */
     void highlightPCLine();
+    void highlightMultiLineSelections();
     void showDisasContextMenu(const QPoint &pt);
     void fontsUpdatedSlot();
     void colorsUpdatedSlot();
@@ -86,6 +87,7 @@ private:
     RVA readCurrentDisassemblyOffset();
     bool eventFilter(QObject *obj, QEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
+    void keyReleaseEvent(QKeyEvent *event) override;
     QString getWindowTitle() const override;
 
     int topOffsetHistoryPos = 0;
@@ -129,11 +131,16 @@ class DisassemblyTextEdit : public QPlainTextEdit
 
 public:
     explicit DisassemblyTextEdit(QWidget *parent = nullptr)
-        : QPlainTextEdit(parent), lockScroll(false)
+        : QPlainTextEdit(parent), lockScroll(false), multiLineSelection(false)
     {
     }
 
     void setLockScroll(bool lock) { this->lockScroll = lock; }
+    void setMultiLineSelection(bool multiLineSelection) { this->multiLineSelection = multiLineSelection; }
+    void setMultiLineSelections(const QList<QTextEdit::ExtraSelection> &selections) { multilineSelections = selections; }
+
+    bool getMultiLineSelection() const { return multiLineSelection; }
+    QList<QTextEdit::ExtraSelection> getMultiLineSelections() const { return multilineSelections; }
 
     qreal textOffset() const;
 
@@ -145,6 +152,8 @@ protected:
 
 private:
     bool lockScroll;
+    bool multiLineSelection;
+    QList<QTextEdit::ExtraSelection> multilineSelections;
 };
 
 /**


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The goal is to add the ability to perform multiline selections in the the Disassembly view, so that certain operations in the Disassembly Context Menu (i.e. Set as code, Set as data, Copy lines as text, Add Breakpoints) can be performed on multiple lines/instructions at once.

The main objectives include:

- [x] Implement multiline selection for individual lines with Shift + Left Click
- [ ] Implement rectangular selection for contiguous lines with Alt + Left Mouse Drag
- [ ] Refactor DisassemblyContextMenu to add the ability to perform operations on multiple selections


**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

Below is a GIF demonstrating the selection of individual lines using Shift + Left Click. The selection color is temporarily set to green for now for visibility during development.

![demo](https://github.com/rizinorg/cutter/assets/49572952/0579eb92-da50-4b9c-9eaf-2a51cb7c73bf)

Challenges faced with selections/highlights:

1. I have not found a way to retain multiline selections when scrolling. The qDebug logs show that the stored cursor positions seem to be invalidated when I scroll, causing all of the cursor offsets in the multiLineSelections list to default to a fallback value. I am thinking that a potential solution could involve storing line numbers instead of cursor positions, and for each line number, retrieve the instruction offset and calculate whether the instruction is visible within the frame upon each viewport update, highlighting the line if so.

2. Achieving full-line color for individual non-contiguous selections is hindered by QTextEdit's default behavior.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->

closes #2601