### PR TITLE
disable openssl for libyara on linux/mac builds and use tagged version

### DIFF
--- a/dist/bundle_rz_libyara.ps1
+++ b/dist/bundle_rz_libyara.ps1
@@ -3,7 +3,7 @@ $cmake_opts = $args[1]
 $python = Split-Path((Get-Command python.exe).Path)
 
 if (-not (Test-Path -Path 'rz_libyara' -PathType Container)) {
-    git clone https://github.com/rizinorg/rz-libyara.git --depth 1 rz_libyara
+    git clone https://github.com/rizinorg/rz-libyara.git --depth 1 --branch main rz_libyara
     git -C rz_libyara submodule init
     git -C rz_libyara submodule update
 }

--- a/scripts/rz-libyara.sh
+++ b/scripts/rz-libyara.sh
@@ -8,14 +8,14 @@ EXTRA_CMAKE_OPTS="$2"
 cd "$SCRIPTPATH/.."
 
 if [[ ! -d rz_libyara ]]; then
-	git clone https://github.com/rizinorg/rz-libyara.git --depth 1 rz_libyara
+    git clone https://github.com/rizinorg/rz-libyara.git --depth 1 --branch main rz_libyara
     git -C rz_libyara submodule init
     git -C rz_libyara submodule update
 fi
 
 cd rz_libyara
 
-meson --buildtype=release --pkg-config-path="$INSTALL_PREFIX/lib/pkgconfig" --prefix="$INSTALL_PREFIX" -Duse_sys_yara=disabled build
+meson --buildtype=release --pkg-config-path="$INSTALL_PREFIX/lib/pkgconfig" --prefix="$INSTALL_PREFIX" -Denable_openssl=false -Duse_sys_yara=disabled build
 ninja -C build install
 
 cd cutter-plugin

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3418,13 +3418,13 @@ QList<SectionDescription> CutterCore::getAllSections()
         section.size = sect->size;
         section.perm = rz_str_rwx_i(sect->perm);
         if (sect->size > 0) {
-            HtPP *digests = rz_core_bin_create_digests(core, sect->paddr, sect->size, hashnames);
+            HtSS *digests = rz_core_bin_create_digests(core, sect->paddr, sect->size, hashnames);
             if (!digests) {
                 continue;
             }
-            const char *entropy = (const char *)ht_pp_find(digests, "entropy", NULL);
+            const char *entropy = (const char *)ht_ss_find(digests, "entropy", NULL);
             section.entropy = rz_str_get(entropy);
-            ht_pp_free(digests);
+            ht_ss_free(digests);
         }
 
         sections << section;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

This will solve the issue with openssl till we fix it properly.