### PR TITLE
Switch macos CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,7 +310,7 @@ jobs:
             system-deps: false
             python-version: 3.7.x
           - name: macos-x86_64
-            os: macos-latest
+            os: macos-14-large
             python-version: 3.7.x
             system-deps: false
             package: true


### PR DESCRIPTION

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

macos-latest currently is an arm64 machine so switch to macos-14-large which is supposed to be x86-64. 


Since github now provide arm64 macos machines the main arm64  builds should be moved there as well. I am planning to do that together with qt6 changes.


**Test plan (required)**

