### PR TITLE
Fix: Globals Widget Edit and Delete Actions in Globals Widget

### DIFF
--- a/src/widgets/GlobalsWidget.cpp
+++ b/src/widgets/GlobalsWidget.cpp
@@ -128,7 +128,7 @@ void GlobalsWidget::editGlobal()
         return;
     }
 
-    RVA globalVariableAddress = globalsModel->address(index);
+    RVA globalVariableAddress = globalsProxyModel->address(index);
 
     GlobalVariableDialog dialog(globalVariableAddress, parentWidget());
     dialog.exec();
@@ -142,7 +142,7 @@ void GlobalsWidget::deleteGlobal()
         return;
     }
 
-    RVA globalVariableAddress = globalsModel->address(index);
+    RVA globalVariableAddress = globalsProxyModel->address(index);
     Core()->delGlobalVariable(globalVariableAddress);
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

### Your checklist for this pull request
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


### Detailed description

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
This pull request fixes the #3340. Using the globalsProxyModel instead of globalsModel to show/delete global variables. 
The Issue
#### BEFORE
![image](https://github.com/rizinorg/cutter/assets/54111579/6c70264f-49b9-45c0-82b5-2f237193028c)


### Test plan (required)

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


#### AFTER
![image](https://github.com/rizinorg/cutter/assets/54111579/91dd8330-ae20-48cf-a220-69bfa0f2bab0)


To check the globals can be sorted using different columns like Address, Types, Variable name and check whether then also edit is showing the same variable.


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->
Only a different variables used so formatting not changed.

### Closing issues

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
Closes #3340 
