### PR TITLE
Added metainfo file to the installation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -618,8 +618,9 @@ endforeach()
 
 if(UNIX AND NOT APPLE)
     install(FILES "img/cutter.svg"
-        DESTINATION "share/icons/hicolor/scalable/apps/")
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps")
     install(FILES "re.rizin.cutter.desktop"
-        DESTINATION "share/applications"
-        COMPONENT Devel)
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
+    install(FILES "re.rizin.cutter.appdata.xml"
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/metainfo")
 endif()

--- a/src/re.rizin.cutter.desktop
+++ b/src/re.rizin.cutter.desktop
@@ -1,6 +1,8 @@
 [Desktop Entry]
 Type=Application
 Name=Cutter
+GenericName=Reverse Engineering Platform
+Comment=Reverse Engineering Platform powered by rizin
 Exec=cutter
 Icon=cutter
 Categories=Development;


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

- Added metainfo file to the installation because it is required by most modern Linux package managers and Flatpak.
- Switched from hardcoded directory name to `CMAKE_INSTALL_DATAROOTDIR` use.
- Removed the `COMPONENT` option from the desktop file installation entry since the file is not a development file and is always needed.
- Added missing `GenericName` and `Comment` to the desktop file.

**Test plan (required)**

Run the build and installation on any UNIX operating system. The desktop and metainfo files should be installed.

**Closing issues**

n/a