### PR TITLE
Fix io.va checkbox

### DIFF
--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -317,6 +317,7 @@ void InitialOptionsDialog::setupAndStartAnalysis()
     options.os = getSelectedOS();
     options.writeEnabled = ui->writeCheckBox->isChecked();
     options.loadBinInfo = !ui->binCheckBox->isChecked();
+    options.useVA = ui->vaCheckBox->isChecked();
     QVariant forceBinPluginData = ui->formatComboBox->currentData();
     if (!forceBinPluginData.isNull()) {
         RzBinPluginDescription pluginDesc = forceBinPluginData.value<RzBinPluginDescription>();


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

The value of the checkbox was never used.

**Test plan (required)**

* Open a binary with VA disabled and analysis disabled in the options dialog. (There are bugs in rizin `aaa` that might set io.va=true)
* Check `e io.va` after the file is loaded