### PR TITLE
Allow loading user compiled plugins.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,7 @@ jobs:
             python-version: 3.12.x
             output-id: artifact_windows
           - name: macos-x86_64
-            os: macos-13
+            os: macos-12
             arch: x86_64
             package: true
           - name: macos-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,7 @@ jobs:
             python-version: 3.12.x
             output-id: artifact_windows
           - name: macos-x86_64
-            os: macos-12
+            os: macos-13
             arch: x86_64
             package: true
           - name: macos-arm64

--- a/dist/macos/Entitlements.plist
+++ b/dist/macos/Entitlements.plist
@@ -4,5 +4,7 @@
 <dict>
     <key>com.apple.security.cs.debugger</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
By default macOS only allows loading stuff signed by Apple or the same team.

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_disable-library-validation/

> This security-hardening feature prevents a program from loading frameworks, plug-ins, or libraries unless they’re either signed by Apple or signed with the same Team ID as the main executable.  ... Use the Disable Library Validation Entitlement if your program loads plug-ins that are signed by other third-party developers.

Kind of useless to have plugin system if user can't load third-party plugins or something they compiled themselves. 

Hopefully this won't cause any additional issues with gatekeeper.

**Test plan (required)**

* Build succeeds
* Ask person from https://github.com/rizinorg/cutter/issues/3383 if this helps

**Closing issues**

closes #3383 