### PR TITLE
ci: Drop macos-x86_64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,7 +394,6 @@ jobs:
     strategy:
       matrix:
         name: [
-            macos-x86_64,
             macos-arm64,
             windows-x86_64,
         ]
@@ -407,10 +406,6 @@ jobs:
             package: true
             python-version: 3.12.x
             output-id: artifact_windows
-          - name: macos-x86_64
-            os: macos-12
-            arch: x86_64
-            package: true
           - name: macos-arm64
             os: macos-14
             arch: arm64


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

As in rizinorg/rizin#4676, this pr drops the `macos-x86_64` build since Intel Macs have been discontinued and apparently Apple Silicon is exclusively the way of the future.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

The drop is appropriate.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

https://github.com/actions/runner-images/issues/10721
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
