### PR TITLE
Fix build failure against PySide >= 6.8

### DIFF
--- a/src/common/PythonManager.cpp
+++ b/src/common/PythonManager.cpp
@@ -133,7 +133,9 @@ void PythonManager::shutdown()
     Core()->setProperty("_PySideInvalidatePtr", QVariant());
 
     // see PySide::destroyQCoreApplication()
+#    if QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
     PySide::SignalManager::instance().clear();
+#    endif
     Shiboken::BindingManager &bm = Shiboken::BindingManager::instance();
     SbkObject *pyQApp = bm.retrieveWrapper(QCoreApplication::instance());
     PyTypeObject *pyQObjectType = Shiboken::Conversions::getPythonTypeObject("QObject*");


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Seems like some of the implementation details changed, removing the need for manual cleanup thus the function doesn't exist anymore. https://github.com/pyside/pyside-setup/commit/33bd61d13d8d9e3794b6049891be62f3351313d9

**Test plan (required)**

* Still compiles  against Pyside < 6.8 - should be covered by CI tests, and the effective code should be identical to before
* Compiles with Pyside 6.8 (need to use CUTTER_ENABLE_PYHON and CUTTER_ENABLE_PYTHON_BINDINGS)  - tested on ArchLinux  :heavy_check_mark: 
* With Pyside 6.8 Cutter exits cleanly without any crashes or new warning messages :heavy_check_mark: 

**Closing issues**

closes #3384 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
