### PR TITLE
#3321 fix clang-format link in dev docs

### DIFF
--- a/docs/source/contributing/code/development-guidelines.rst
+++ b/docs/source/contributing/code/development-guidelines.rst
@@ -52,7 +52,7 @@ Coding Style
 ------------
 
 In general, we follow a slightly customized version of `the official Qt guidelines <https://wiki.qt.io/Qt_Coding_Style>`__ 
-to format the code. Before sending a pull request, you will need to use `clang-format`<https://clang.llvm.org/docs/ClangFormat.html>`__ (version 8 or newer)
+to format the code. Before sending a pull request, you will need to use `clang-format <https://clang.llvm.org/docs/ClangFormat.html>`__ (version 8 or newer)
 to format the code. The command line for formatting the code according
 to the style is:
 


### PR DESCRIPTION
fixes #3321 Broken clang format link in developer docs