### PR TITLE
Fix crash while editing asm.

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -4293,10 +4293,7 @@ QByteArray CutterCore::hexStringToBytes(const QString &hex)
 
 QString CutterCore::bytesToHexString(const QByteArray &bytes)
 {
-    QByteArray hex;
-    hex.resize(bytes.length() * 2);
-    rz_hex_bin2str(reinterpret_cast<const ut8 *>(bytes.constData()), bytes.size(), hex.data());
-    return QString::fromUtf8(hex);
+    return QString::fromUtf8(bytes.toHex());
 }
 
 void CutterCore::loadScript(const QString &scriptname)


### PR DESCRIPTION
Empty input field resulted in empty byteArray and constData pointing to null, which rz_hex_bin2str didn't expect.

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Thanks @ravenexp for testing and debugging the problem.

Not only the function didn't handle empty QByteArray, there was a second hidden problem. The function reserved memory for 2n bytes but rz_hex_bin2str writes a null terminated string thus requiring 2n+1 bytes of space.  The extra null byte write was probably also what caused the crash, just for non empty arrays single byte buffer overflow would most of the time not cause easily observable sideeffects.


**Test plan (required)**

1) open executable
2) enable cache mode
3) in disasm widget edit instruction 
    * change constant -> observe that there are no errors and byte preview updates
    * delete all text -> should not crash
    * write a different valid instruction for example nop -> bytes should be updated   

**Closing issues**

Closes #3374, closes #3356
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
