### PR TITLE
Fix CI ubuntu system deps build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             cxx-override: default
           - name: linux-x86_64-system-deps # ensure that Cutter can be built at least in basic config on Ubuntu 22.04 using sytem libraries
             image: ubuntu:22.04
-            python-version: 3.10.x
+            python-version: 3.11.x
             system-deps: true
             package: false
             tarball: false
@@ -310,7 +310,7 @@ jobs:
       artifact_linux: ${{ steps.output_setup.outputs.artifact_name }}
   build-linux-old:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # only a host environement, actual building happens in a docker image
     strategy:
       matrix:
         name: [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,10 +161,13 @@ jobs:
                              g++-12
         fi
     - uses: actions/setup-python@v5
+      if: matrix.system-deps == false
       with:
         python-version: ${{ matrix.python-version }}
     - name: py dependencies
       run: |
+        python3 --version
+        which python3
         # https://github.com/rizinorg/cutter/runs/7170222817?check_suite_focus=true
         python3 -m pip install meson==0.61.5
     - name: Prepare package id


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Seems like the python versions provided by GHA currently doesn't work properly in Ubuntu 22.04 images  for some reason.

For now use the system python, system-deps job was supposed to use it anyways. 

**Test plan (required)**

CI is green 

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

closes #3401
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
