### PR TITLE
Debugger stepover and shortcut fixes

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -2422,17 +2422,13 @@ void CutterCore::stepOverDebug()
             return;
         }
     } else {
-        bool ret;
         asyncTask(
-                [&](RzCore *core) {
-                    ret = rz_core_debug_step_over(core, 1);
+                [](RzCore *core) {
+                    rz_core_debug_step_over(core, 1);
                     rz_core_dbg_follow_seek_register(core);
                     return nullptr;
                 },
                 debugTask);
-        if (!ret) {
-            return;
-        }
     }
 
     emit debugTaskStateChanged();
@@ -2453,17 +2449,13 @@ void CutterCore::stepOutDebug()
     }
 
     emit debugTaskStateChanged();
-    bool ret;
     asyncTask(
-            [&](RzCore *core) {
-                ret = rz_core_debug_step_until_frame(core);
+            [](RzCore *core) {
+                rz_core_debug_step_until_frame(core);
                 rz_core_dbg_follow_seek_register(core);
                 return nullptr;
             },
             debugTask);
-    if (!ret) {
-        return;
-    }
 
     connect(debugTask.data(), &RizinTask::finished, this, [this]() {
         debugTask.clear();
@@ -2492,17 +2484,13 @@ void CutterCore::stepBackDebug()
             return;
         }
     } else {
-        bool ret;
         asyncTask(
-                [&](RzCore *core) {
-                    ret = rz_core_debug_step_back(core, 1);
+                [](RzCore *core) {
+                    rz_core_debug_step_back(core, 1);
                     rz_core_dbg_follow_seek_register(core);
                     return nullptr;
                 },
                 debugTask);
-        if (!ret) {
-            return;
-        }
     }
     emit debugTaskStateChanged();
 

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -192,8 +192,7 @@ void MainWindow::initUI()
     connect(seek_to_func_start_shortcut, &QShortcut::activated, this,
             &MainWindow::seekToFunctionStart);
 
-    QShortcut *refresh_shortcut = new QShortcut(QKeySequence(QKeySequence::Refresh), this);
-    connect(refresh_shortcut, &QShortcut::activated, this, &MainWindow::refreshAll);
+    ui->actionRefresh_contents->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_R));
 
     connect(ui->actionZoomIn, &QAction::triggered, this, &MainWindow::onZoomIn);
     connect(ui->actionZoomOut, &QAction::triggered, this, &MainWindow::onZoomOut);
@@ -298,6 +297,7 @@ void MainWindow::initToolBar()
     ui->menuDebug->addAction(debugActions->actionStartEmul);
     ui->menuDebug->addAction(debugActions->actionAttach);
     ui->menuDebug->addAction(debugActions->actionStartRemote);
+    ui->menuDebug->addAction(debugActions->actionStop);
     ui->menuDebug->addSeparator();
     ui->menuDebug->addAction(debugActions->actionStep);
     ui->menuDebug->addAction(debugActions->actionStepOver);

--- a/src/dialogs/NativeDebugDialog.cpp
+++ b/src/dialogs/NativeDebugDialog.cpp
@@ -2,12 +2,16 @@
 #include "ui_NativeDebugDialog.h"
 
 #include <QMessageBox>
+#include <QShortcut>
 
 NativeDebugDialog::NativeDebugDialog(QWidget *parent)
     : QDialog(parent), ui(new Ui::NativeDebugDialog)
 {
     ui->setupUi(this);
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
+    auto shortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Return), ui->argEdit, nullptr,
+                                  nullptr, Qt::ShortcutContext::WidgetShortcut);
+    connect(shortcut, &QShortcut::activated, this, &QDialog::accept);
 }
 
 NativeDebugDialog::~NativeDebugDialog() {}


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

* F5 shortcut was used for both debug continue and "refresh all". Switch the refresh all to Ctrl/Cmd + R to avoid the conflict. That's what docs already said, it was just that `QKeySequence::Refresh` corresponded to Ctrl+R on some platforms but F5 on others.
* Accept the currently inputed text in debug arg dialog using "Ctrl+Enter"
* Add debug stop action, to Debug menu under the main menu bar
* Fix debug step over and and step out

**Test plan (required)**

Shortcuts
* open simple executable
* F9 start debugger
* Enter- to confirm the debugger beta message
* Ctrl+Enter to confirm the argument dialog
* set breakpoint few instruction ahead
* press F5 -> expected continue until the set breakpoint is hit

Step over/step out:
* start debugger
* reach a code just before call instruction
* when the debugger is stopped on call instruction use "step over"
* expected debugger to stop at the instruction after call instruction
* reach call instruction
* stepinto
* press step out -> expect returning to previous function


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
