### PR TITLE
Initialize default environement for debugger.

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -23,6 +23,7 @@
 
 #include <rz_asm.h>
 #include <rz_cmd.h>
+#include <rz_socket.h>
 #include <sdb.h>
 
 static CutterCore *uniqueInstance;
@@ -200,6 +201,8 @@ void CutterCore::initialize(bool loadPlugins)
 
     rz_cons_new(); // initialize console
     core_ = rz_core_new();
+    char **env = rz_sys_get_environ();
+    core_->io->envprofile = rz_run_get_environ_profile(env);
     rz_core_task_sync_begin(&core_->tasks);
     coreBed = rz_cons_sleep_begin();
     CORE_LOCK();


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Initialize `io->envprofile` so that default environment variables during debugging aren't empty.  Rizin does more or less the same thing in `rz_main_rizin`. 

**Test plan (required)**

* open /usr/bin/env
* start debugging
* press continue a until program exits
* inspect output in console
* Expected-> the env executable printed a bunch of environment variables

**Closing issues**
Closes #3408 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
