### PR TITLE
Fix thread and process widget API usage to match dpT and dp behavior.

### DIFF
--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -443,7 +443,7 @@ public:
      * @param pid The pid of the process, -1 for the currently debugged process
      * @return List of ProcessDescription
      */
-    QList<ProcessDescription> getProcessThreads(int pid);
+    QList<ThreadDescription> getProcessThreads(int pid = -1);
     /**
      * @brief Get a list of heap chunks
      * Uses RZ_API rz_heap_chunks_list to get vector of chunks
@@ -652,7 +652,13 @@ public:
     QList<MemoryMapDescription> getMemoryMap();
     QList<SearchDescription> getAllSearch(QString searchFor, QString space, QString in);
     QList<BreakpointDescription> getBreakpoints();
-    QList<ProcessDescription> getAllProcesses();
+    /**
+     * @brief Get list of processes attachable by debugger
+     *
+     * @param pid 0 - all processes, -1 - currently debugged process
+     * @return QList<ProcessDescription>
+     */
+    QList<ProcessDescription> getProcesses(int pid = 0);
     /**
      * @brief Get the right RzReg object based on the cutter state (debugging vs emulating)
      */

--- a/src/core/CutterDescriptions.h
+++ b/src/core/CutterDescriptions.h
@@ -346,6 +346,18 @@ struct ProcessDescription
     QString path;
 };
 
+struct ThreadDescription
+{
+    bool current;
+    int pid;
+    int uid;
+    int ppid;
+    RzDebugPidState status;
+    QString path;
+    ut64 pc;
+    ut64 tls;
+};
+
 struct RefDescription
 {
     QString ref;

--- a/src/dialogs/AttachProcDialog.cpp
+++ b/src/dialogs/AttachProcDialog.cpp
@@ -19,7 +19,7 @@ void ProcessModel::updateData()
 {
     beginResetModel();
 
-    processes = Core()->getAllProcesses();
+    processes = Core()->getProcesses();
 
     endResetModel();
 }

--- a/src/widgets/ProcessesWidget.cpp
+++ b/src/widgets/ProcessesWidget.cpp
@@ -106,7 +106,7 @@ void ProcessesWidget::setProcessesGrid()
     int i = 0;
     QFont font;
 
-    for (const auto &processesItem : Core()->getProcessThreads(DEBUGGED_PID)) {
+    for (const auto &processesItem : Core()->getProcesses(DEBUGGED_PID)) {
         st64 pid = processesItem.pid;
         st64 uid = processesItem.uid;
         QString status = translateStatus(processesItem.status);
@@ -155,7 +155,7 @@ void ProcessesWidget::onActivated(const QModelIndex &index)
     int pid = modelFilter->data(index.sibling(index.row(), ProcessesWidget::COLUMN_PID)).toInt();
     // Verify that the selected pid is still in the processes list since dp= will
     // attach to any given id. If it isn't found simply update the UI.
-    for (const auto &value : Core()->getAllProcesses()) {
+    for (const auto &value : Core()->getProcesses(DEBUGGED_PID)) {
         if (pid == value.pid) {
             QMessageBox msgBox(this);
             switch (value.status) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Use same API as dpT and dp, for listing threads and processes. I am guessing that either there was a mistake during rizin command->C API migration or the behavior of rizin functions slightly changed.

Improve the content of thread widget -> add PC and TLS columns, with the usual address context menu.

**Test plan (required)**

Test all process list:
* open any executable
* Debug/Attach
* should see list of all currently running processes

Test threads:
* open executable which will spawn multiple threads
* start debugging
* continue until threads are created
* pause
* inspect thread widget -> should display the threads, compare against `dpT` and external task manager 
* switch between threads by double clicking, make sure that position in disassembly view matches displayed PC of selected thread
* right click on one of PC cells -> make sure correct address is used
* right click on one of TLS cells -> make sure correct address is used
* open process widget -> the threads shouldn't be displayed as processes

Test process widget
* open `/usr/bin/stress`
* start debugging with `--cpu 2` arguments
* continue until child processes are spawned pause if necessary, in my case cutter automatically paused when new process was created
* inspect process widget -> should display 3 processes 


![image](https://github.com/user-attachments/assets/78db235d-c2c4-40af-8557-a713aa6fafa9)

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

Closes #3409
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
Related #1859