### PR TITLE
Fix input target logic for non english languages.

### DIFF
--- a/src/widgets/ConsoleWidget.cpp
+++ b/src/widgets/ConsoleWidget.cpp
@@ -32,8 +32,7 @@
 #    define STDIN_PIPE_NAME "%1/cutter-stdin-%2"
 #endif
 
-#define CONSOLE_RIZIN_INPUT ("Rizin Console")
-#define CONSOLE_DEBUGEE_INPUT ("Debugee Input")
+enum InputTarget { RizinConsole = 0, Debugee = 1 };
 
 static const int invalidHistoryPos = -1;
 
@@ -141,7 +140,7 @@ ConsoleWidget::ConsoleWidget(MainWindow *main)
         } else {
             ui->inputCombo->setVisible(false);
             // Return to the rizin console
-            ui->inputCombo->setCurrentIndex(ui->inputCombo->findText(CONSOLE_RIZIN_INPUT));
+            ui->inputCombo->setCurrentIndex(InputTarget::RizinConsole);
         }
     });
 
@@ -263,11 +262,11 @@ void ConsoleWidget::sendToStdin(const QString &input)
 
 void ConsoleWidget::onIndexChange()
 {
-    QString console = ui->inputCombo->currentText();
-    if (console == CONSOLE_DEBUGEE_INPUT) {
+    int target = ui->inputCombo->currentIndex();
+    if (target == InputTarget::Debugee) {
         ui->rzInputLineEdit->setVisible(false);
         ui->debugeeInputLineEdit->setVisible(true);
-    } else if (console == CONSOLE_RIZIN_INPUT) {
+    } else if (target == InputTarget::RizinConsole) {
         ui->rzInputLineEdit->setVisible(true);
         ui->debugeeInputLineEdit->setVisible(false);
     }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

* open cutter
* switch language to non english
* restart cutter
* open an executable which reads stdin
* run a command in console widget, for example `?`
* start debugger and continue
* run `?` in console widget
* switch input target to `debugee input`
* make sure both choices are translated, if not restart the process using different language
* send input to debugged program
* switch input target to `rizin console`
* run `?`

Test program
```
#include <iostream>

using namespace std;
int main()
{
    int a, b;
    while (std::cin >> a >> b && a > 0) {
        std::cout << a + b << std::endl;
    }
}
```

**Closing issues**

Closes #2906
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
