### PR TITLE
Allow packagers to manually override CUTTER_VERSION_FULL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ execute_process(COMMAND git log --pretty=format:'%h' -n 1
 # Check whether we got any revision (which isn't
 # always the case, e.g. when someone downloaded a zip file
 if ("${GIT_REV}" STREQUAL "")
-    set(CUTTER_VERSION_FULL "${CUTTER_VERSION}")
+    set(CUTTER_VERSION_FULL "" CACHE STRING "${CUTTER_VERSION}")
 else()
     execute_process(
         COMMAND git rev-parse --abbrev-ref HEAD
@@ -57,7 +57,7 @@ else()
     string(STRIP "${GIT_REV}" GIT_REV)
     string(SUBSTRING "${GIT_REV}" 1 7 GIT_REV)
     string(STRIP "${GIT_BRANCH}" GIT_BRANCH)
-    set(CUTTER_VERSION_FULL "${CUTTER_VERSION}-${GIT_BRANCH}-${GIT_REV}")
+    set(CUTTER_VERSION_FULL "" CACHE STRING "${CUTTER_VERSION}-${GIT_BRANCH}-${GIT_REV}")
 endif()
 
 project(Cutter VERSION "${CUTTER_VERSION}")


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The git revision check doesn't always work. For example, when building cutter as an Arch Linux package (namely `extra/rz-cutter` in the Arch Linux repository), the `CUTTER_VERSION_FULL` is set to a strange value:

![image](https://github.com/user-attachments/assets/a118d8ee-b4ce-4e6a-9056-5f19eccf3e7d)

Therefore we should allow packages to manually override `CUTTER_VERSION_FULL`.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

- Use `-DCUTTER_VERSION_FULL=<version>` in cmake command to test changes.

Before:
![image](https://github.com/user-attachments/assets/1b139034-cec9-411e-b070-5364c9dad249)

After:
![image](https://github.com/user-attachments/assets/429c5923-69b2-4f76-ba23-c6e1a7d7b730)

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
