### PR TITLE
remember IO mode for recent files

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -808,31 +808,60 @@ void Configuration::setGraphBlockEntryOffset(bool enabled)
     s.setValue("graphBlockEntryOffset", enabled);
 }
 
-QStringList Configuration::getRecentFiles() const
+QList<RecentFileEntry> Configuration::getRecentFiles() const
 {
-    return s.value("recentFileList").toStringList();
+    QList<RecentFileEntry> recentFiles;
+
+    const QStringList list = s.value("recentFiles").toStringList();
+    for (const QString &file : list) {
+        int sep = file.indexOf("://");
+        if (sep != -1) {
+            QString ioMode = file.left(sep + 3);
+            QString path = file.mid(sep + 3);
+            recentFiles.append({ ioMode, path });
+        } else {
+            recentFiles.append({ "file://", file });
+        }
+    }
+
+    return recentFiles;
 }
 
-void Configuration::setRecentFiles(const QStringList &list)
+void Configuration::setRecentFiles(const QList<RecentFileEntry> &list)
 {
-    s.setValue("recentFileList", list);
+    QStringList recentFiles;
+    for (const RecentFileEntry &file : list) {
+        recentFiles.append(file.ioMode + file.path);
+    }
+    s.setValue("recentFiles", recentFiles);
 }
 
-QStringList Configuration::getRecentProjects() const
+QList<RecentFileEntry> Configuration::getRecentProjects() const
 {
-    return s.value("recentProjectsList").toStringList();
+    QList<RecentFileEntry> recentProjects;
+    const QStringList list = s.value("recentProjectsList").toStringList();
+    for (const QString &project : list) {
+        recentProjects.append(
+                { "", project }); // recent projects don’t include ioMode, so just leave it empty
+    }
+    return recentProjects;
 }
 
-void Configuration::setRecentProjects(const QStringList &list)
+void Configuration::setRecentProjects(const QList<RecentFileEntry> &list)
 {
-    s.setValue("recentProjectsList", list);
+    QStringList recentProjects;
+    for (const RecentFileEntry &project : list) {
+        recentProjects.append(project.path);
+    }
+    s.setValue("recentProjectsList", recentProjects);
 }
 
 void Configuration::addRecentProject(QString file)
 {
-    QStringList files = getRecentProjects();
-    files.removeAll(file);
-    files.prepend(file);
+    RecentFileEntry project = { "", file };
+    QList<RecentFileEntry> files = getRecentProjects();
+    files.removeAll(project);
+    files.prepend(project);
     setRecentProjects(files);
 }
 

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -812,7 +812,7 @@ QList<RecentFileEntry> Configuration::getRecentFiles() const
 {
     QList<RecentFileEntry> recentFiles;
 
-    const QStringList list = s.value("recentFiles").toStringList();
+    const QStringList list = s.value("recentFileList").toStringList();
     for (const QString &file : list) {
         int sep = file.indexOf("://");
         if (sep != -1) {
@@ -833,7 +833,7 @@ void Configuration::setRecentFiles(const QList<RecentFileEntry> &list)
     for (const RecentFileEntry &file : list) {
         recentFiles.append(file.ioMode + file.path);
     }
-    s.setValue("recentFiles", recentFiles);
+    s.setValue("recentFileList", recentFiles);
 }
 
 QList<RecentFileEntry> Configuration::getRecentProjects() const

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -30,6 +30,17 @@ struct CutterInterfaceTheme
     ColorFlags flag;
 };
 
+struct RecentFileEntry
+{
+    QString ioMode;
+    QString path;
+
+    bool operator==(const RecentFileEntry &other) const
+    {
+        return ioMode == other.ioMode && path == other.path;
+    }
+};
+
 class CUTTER_EXPORT Configuration : public QObject
 {
     Q_OBJECT
@@ -225,14 +236,14 @@ public:
     /**
      * @brief Recently opened binaries, as shown in NewFileDialog.
      */
-    QStringList getRecentFiles() const;
-    void setRecentFiles(const QStringList &list);
+    QList<RecentFileEntry> getRecentFiles() const;
+    void setRecentFiles(const QList<RecentFileEntry> &list);
 
     /**
      * @brief Recently opened projects, as shown in NewFileDialog.
      */
-    QStringList getRecentProjects() const;
-    void setRecentProjects(const QStringList &list);
+    QList<RecentFileEntry> getRecentProjects() const;
+    void setRecentProjects(const QList<RecentFileEntry> &list);
     void addRecentProject(QString file);
 
     // Functions Widget Layout

--- a/src/common/SettingsUpgrade.cpp
+++ b/src/common/SettingsUpgrade.cpp
@@ -30,7 +30,7 @@ static bool migrateSettingsPre18(QSettings &newSettings)
     return true;
 }
 
-#define CUTTER_SETTINGS_VERSION_CURRENT 6
+#define CUTTER_SETTINGS_VERSION_CURRENT 7
 #define CUTTER_SETTINGS_VERSION_KEY "version"
 
 /*
@@ -132,6 +132,15 @@ static void migrateSettingsTo6(QSettings &settings)
     settings.remove("dir.projects");
 }
 
+static void migrateSettingsTo7(QSettings &settings)
+{
+    auto list = settings.value("recentFileList").toStringList();
+    for (auto &file : list) {
+        file.prepend("file://");
+    }
+    settings.setValue("recentFileList", list);
+}
+
 void Cutter::initializeSettings()
 {
     QSettings::setDefaultFormat(QSettings::IniFormat);
@@ -166,6 +175,9 @@ void Cutter::initializeSettings()
                     break;
                 case 6:
                     migrateSettingsTo6(settings);
+                    break;
+                case 7:
+                    migrateSettingsTo7(settings);
                     break;
                 default:
                     break;
@@ -215,6 +227,7 @@ bool Cutter::shouldOfferSettingImport()
 {
     QSettings::setDefaultFormat(QSettings::IniFormat);
     QSettings settings;
+
     if (settings.contains("firstExecution")) {
         return false;
     }
@@ -225,7 +238,7 @@ bool Cutter::shouldOfferSettingImport()
         return false; // no Cutter <= 1.12 settings to import
     }
     int version = r2CutterSettings.value("version", -1).toInt();
-    if (version < 1 || version > 6) {
+    if (version < 1 || version > 7) {
         return false; // version too new maybe it's from r2Cutter fork instead of pre-rizin Cutter.
     }
     return true;

--- a/src/common/SettingsUpgrade.cpp
+++ b/src/common/SettingsUpgrade.cpp
@@ -222,6 +222,7 @@ void Cutter::migrateThemes()
 
 static const char PRE_RIZIN_ORG[] = "RadareOrg";
 static const char PRE_RIZIN_APP[] = "Cutter";
+const int LAST_R2_CUTTER_SETTING_VERSION = 6;
 
 bool Cutter::shouldOfferSettingImport()
 {
@@ -238,7 +239,7 @@ bool Cutter::shouldOfferSettingImport()
         return false; // no Cutter <= 1.12 settings to import
     }
     int version = r2CutterSettings.value("version", -1).toInt();
-    if (version < 1 || version > 7) {
+    if (version < 1 || version > LAST_R2_CUTTER_SETTING_VERSION) {
         return false; // version too new maybe it's from r2Cutter fork instead of pre-rizin Cutter.
     }
     return true;

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -51,24 +51,6 @@ static QIcon getIconFor(const QString &str, int pos)
     return QIcon(pixmap);
 }
 
-/*
- * @brief Get the ioPlugin index from scheme name.
- * @return ioPlugin index. SIZE_MAX if not found.
- */
-size_t NewFileDialog::getIOPluginIndexByScheme(const QString &scheme)
-{
-    QString fullScheme = scheme + "://";
-    int count = ui->ioPlugin->count();
-
-    for (int i = 0; i < count; ++i) {
-        if (ui->ioPlugin->itemText(i) == fullScheme) {
-            return i;
-        }
-    }
-
-    return SIZE_MAX;
-}
-
 NewFileDialog::NewFileDialog(MainWindow *main)
     : QDialog(nullptr), // no parent on purpose, using main causes weird positioning
       ui(new Ui::NewFileDialog),
@@ -154,15 +136,20 @@ void NewFileDialog::on_shellcodeButton_clicked()
 void NewFileDialog::on_recentsListWidget_itemClicked(QListWidgetItem *item)
 {
     QVariant data = item->data(Qt::UserRole);
-    QUrl url(data.toString());
+    QString sitem = data.toString();
 
-    ui->newFileEdit->setText(url.path());
-    ui->ioPlugin->setCurrentIndex(getIOPluginIndexByScheme(url.scheme()));
+    const size_t index = sitem.indexOf("//");
+    const QString ioMode = sitem.left(index + 2);
+    const QString path = sitem.mid(index + 2);
+
+    ui->newFileEdit->setText(path);
+    ui->ioPlugin->setCurrentIndex(getIOPluginIndexByName(ioMode));
 }
 
 void NewFileDialog::on_recentsListWidget_itemDoubleClicked(QListWidgetItem *item)
 {
-    loadFile(item->data(Qt::UserRole).toString());
+    const QString path = item->data(Qt::UserRole).toString();
+    loadFile(path.mid(path.indexOf("//") + 2)); // Remove ioMode
 }
 
 void NewFileDialog::on_projectFileEdit_textChanged()
@@ -263,21 +250,14 @@ static QStringList fillFilesList(QListWidget *widget, const QStringList &files)
     while (it.hasNext()) {
         // Get the file name
         const QString &fullpath = QDir::toNativeSeparators(it.next());
-        const QUrl url(fullpath);
-        const QString path = url.path();
+        const QString path = fullpath.mid(fullpath.indexOf("//") + 2); // Remove ioMode
         const QString homepath = QDir::homePath();
-        const QString basename = fullpath.section(QDir::separator(), -1);
+        const QString basename = path.section(QDir::separator(), -1);
+
         QString filenameHome = path;
         filenameHome.replace(homepath, "~");
         filenameHome.replace(basename, "");
         filenameHome.chop(1); // Remove last character that will be a path separator
-
-        // file:// is hidden by default
-        const QString scheme = url.scheme();
-        if (scheme != "file") {
-            filenameHome = scheme + "://" + filenameHome;
-        }
-
         // Get file info
         QFileInfo info(path);
         if (!info.exists()) {
@@ -338,6 +318,23 @@ void NewFileDialog::fillIOPluginsList()
     }
 }
 
+/*
+ * @brief Get the ioPlugin index from its name.
+ * @return ioPlugin index. SIZE_MAX if not found.
+ */
+size_t NewFileDialog::getIOPluginIndexByName(const QString &name)
+{
+    int count = ui->ioPlugin->count();
+
+    for (int i = 0; i < count; ++i) {
+        if (ui->ioPlugin->itemText(i) == name) {
+            return i;
+        }
+    }
+
+    return SIZE_MAX;
+}
+
 void NewFileDialog::updateLoadProjectButton()
 {
     ui->loadProjectButton->setEnabled(!ui->projectFileEdit->text().trimmed().isEmpty());
@@ -346,9 +343,6 @@ void NewFileDialog::updateLoadProjectButton()
 void NewFileDialog::loadFile(const QString &filename)
 {
     const QString &nativeFn = QDir::toNativeSeparators(filename);
-    const QString scheme = ui->ioPlugin->currentText();
-    const QString fullUri = scheme + nativeFn;
-
     if (ui->ioPlugin->currentIndex() == 0 && !Core()->tryFile(nativeFn, false)
         && !ui->checkBox_FilelessOpen->isChecked()) {
         QMessageBox msgBox(this);
@@ -357,21 +351,19 @@ void NewFileDialog::loadFile(const QString &filename)
         return;
     }
 
+    QString ioFile = ui->ioPlugin->currentText();
+    ioFile += nativeFn;
+
     // Add file to recent file list
     QSettings settings;
     QStringList files = Config()->getRecentFiles();
-    files.removeAll(fullUri);
-    files.prepend(fullUri);
+    files.removeAll(ioFile);
+    files.prepend(ioFile);
     while (files.size() > MaxRecentFiles)
         files.removeLast();
     Config()->setRecentFiles(files);
 
     // Close dialog and open MainWindow/InitialOptionsDialog
-    QString ioFile = "";
-    if (ui->ioPlugin->currentIndex()) {
-        ioFile = scheme;
-    }
-    ioFile += nativeFn;
     InitialOptions options;
     options.filename = ioFile;
     main->openNewFile(options, ui->checkBox_FilelessOpen->isChecked());

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -135,21 +135,16 @@ void NewFileDialog::on_shellcodeButton_clicked()
 
 void NewFileDialog::on_recentsListWidget_itemClicked(QListWidgetItem *item)
 {
-    QVariant data = item->data(Qt::UserRole);
-    QString sitem = data.toString();
+    QStringList sitem = item->data(Qt::UserRole).toStringList();
 
-    const size_t index = sitem.indexOf("//");
-    const QString ioMode = sitem.left(index + 2);
-    const QString path = sitem.mid(index + 2);
-
-    ui->newFileEdit->setText(path);
-    ui->ioPlugin->setCurrentIndex(getIOPluginIndexByName(ioMode));
+    ui->ioPlugin->setCurrentIndex(ui->ioPlugin->findText(sitem.at(0)));
+    ui->newFileEdit->setText(sitem.at(1));
 }
 
 void NewFileDialog::on_recentsListWidget_itemDoubleClicked(QListWidgetItem *item)
 {
-    const QString path = item->data(Qt::UserRole).toString();
-    loadFile(path.mid(path.indexOf("//") + 2)); // Remove ioMode
+    const QStringList sitem = item->data(Qt::UserRole).toStringList();
+    loadFile(sitem.at(1));
 }
 
 void NewFileDialog::on_projectFileEdit_textChanged()
@@ -159,12 +154,12 @@ void NewFileDialog::on_projectFileEdit_textChanged()
 
 void NewFileDialog::on_projectsListWidget_itemClicked(QListWidgetItem *item)
 {
-    ui->projectFileEdit->setText(item->data(Qt::UserRole).toString());
+    ui->projectFileEdit->setText(item->data(Qt::UserRole).toStringList().at(1));
 }
 
 void NewFileDialog::on_projectsListWidget_itemDoubleClicked(QListWidgetItem *item)
 {
-    loadProject(item->data(Qt::UserRole).toString());
+    loadProject(item->data(Qt::UserRole).toStringList().at(1));
 }
 
 void NewFileDialog::on_aboutButton_clicked()
@@ -181,9 +176,10 @@ void NewFileDialog::on_actionRemove_item_triggered()
     if (item == nullptr) {
         return;
     }
-    QString sitem = item->data(Qt::UserRole).toString();
-    QStringList files = Config()->getRecentFiles();
-    files.removeAll(sitem);
+    QStringList sitem = item->data(Qt::UserRole).toStringList();
+    RecentFileEntry file = { sitem.at(0), sitem.at(1) };
+    QList<RecentFileEntry> files = Config()->getRecentFiles();
+    files.removeAll(file);
     Config()->setRecentFiles(files);
     ui->recentsListWidget->takeItem(ui->recentsListWidget->currentRow());
     ui->newFileEdit->clear();
@@ -203,8 +199,9 @@ void NewFileDialog::on_actionRemove_project_triggered()
         return;
     }
     QString sitem = item->data(Qt::UserRole).toString();
-    QStringList files = Config()->getRecentProjects();
-    files.removeAll(sitem);
+    RecentFileEntry project = { "", sitem };
+    QList<RecentFileEntry> files = Config()->getRecentProjects();
+    files.removeAll(project);
     Config()->setRecentProjects(files);
     ui->projectsListWidget->takeItem(ui->projectsListWidget->currentRow());
     ui->projectFileEdit->clear();
@@ -241,16 +238,18 @@ void NewFileDialog::dropEvent(QDropEvent *event)
  * @brief Add the existing files from the list to the widget.
  * @return the list of files that actually exist
  */
-static QStringList fillFilesList(QListWidget *widget, const QStringList &files)
+static QList<RecentFileEntry> fillFilesList(QListWidget *widget,
+                                            const QList<RecentFileEntry> &files)
 {
-    QStringList updatedFiles = files;
+    QList<RecentFileEntry> updatedFiles = files;
 
-    QMutableListIterator<QString> it(updatedFiles);
+    QMutableListIterator<RecentFileEntry> it(updatedFiles);
     int i = 0;
     while (it.hasNext()) {
         // Get the file name
-        const QString &fullpath = QDir::toNativeSeparators(it.next());
-        const QString path = fullpath.mid(fullpath.indexOf("//") + 2); // Remove ioMode
+        const RecentFileEntry &file = it.next();
+        const QString &path = QDir::toNativeSeparators(file.path);
+        const QString &ioMode = file.ioMode;
         const QString homepath = QDir::homePath();
         const QString basename = path.section(QDir::separator(), -1);
 
@@ -263,11 +262,14 @@ static QStringList fillFilesList(QListWidget *widget, const QStringList &files)
         if (!info.exists()) {
             it.remove();
         } else {
-            // Format the text and add the item to the file list
+            // Format the text
             const QString text =
                     QString("%1\n%2\nSize: %3")
                             .arg(basename, filenameHome, qhelpers::formatBytecount(info.size()));
             QListWidgetItem *item = new QListWidgetItem(getIconFor(basename, i++), text);
+
+            // add the item to the file list
+            QStringList fullpath = { ioMode, path };
             item->setData(Qt::UserRole, fullpath);
             widget->addItem(item);
         }
@@ -277,7 +279,7 @@ static QStringList fillFilesList(QListWidget *widget, const QStringList &files)
 
 bool NewFileDialog::fillRecentFilesList()
 {
-    QStringList files = Config()->getRecentFiles();
+    QList<RecentFileEntry> files = Config()->getRecentFiles();
     files = fillFilesList(ui->recentsListWidget, files);
     // Removed files were deleted from the stringlist. Save it again.
     Config()->setRecentFiles(files);
@@ -286,7 +288,7 @@ bool NewFileDialog::fillRecentFilesList()
 
 bool NewFileDialog::fillProjectsList()
 {
-    QStringList files = Config()->getRecentProjects();
+    QList<RecentFileEntry> files = Config()->getRecentProjects();
     files = fillFilesList(ui->projectsListWidget, files);
     Config()->setRecentProjects(files);
     return !files.isEmpty();
@@ -318,23 +320,6 @@ void NewFileDialog::fillIOPluginsList()
     }
 }
 
-/*
- * @brief Get the ioPlugin index from its name.
- * @return ioPlugin index. SIZE_MAX if not found.
- */
-size_t NewFileDialog::getIOPluginIndexByName(const QString &name)
-{
-    int count = ui->ioPlugin->count();
-
-    for (int i = 0; i < count; ++i) {
-        if (ui->ioPlugin->itemText(i) == name) {
-            return i;
-        }
-    }
-
-    return SIZE_MAX;
-}
-
 void NewFileDialog::updateLoadProjectButton()
 {
     ui->loadProjectButton->setEnabled(!ui->projectFileEdit->text().trimmed().isEmpty());
@@ -351,14 +336,14 @@ void NewFileDialog::loadFile(const QString &filename)
         return;
     }
 
-    QString ioFile = ui->ioPlugin->currentText();
-    ioFile += nativeFn;
+    const QString ioMode = ui->ioPlugin->currentText();
+    const QString ioFile = ioMode + nativeFn;
 
     // Add file to recent file list
-    QSettings settings;
-    QStringList files = Config()->getRecentFiles();
-    files.removeAll(ioFile);
-    files.prepend(ioFile);
+    RecentFileEntry file = { ioMode, nativeFn };
+    QList<RecentFileEntry> files = Config()->getRecentFiles();
+    files.removeAll(file);
+    files.prepend(file);
     while (files.size() > MaxRecentFiles)
         files.removeLast();
     Config()->setRecentFiles(files);

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -51,6 +51,24 @@ static QIcon getIconFor(const QString &str, int pos)
     return QIcon(pixmap);
 }
 
+/*
+ * @brief Get the ioPlugin index from scheme name.
+ * @return ioPlugin index. SIZE_MAX if not found.
+ */
+size_t NewFileDialog::getIOPluginIndexByScheme(const QString &scheme)
+{
+    QString fullScheme = scheme + "://";
+    int count = ui->ioPlugin->count();
+
+    for (int i = 0; i < count; ++i) {
+        if (ui->ioPlugin->itemText(i) == fullScheme) {
+            return i;
+        }
+    }
+
+    return SIZE_MAX;
+}
+
 NewFileDialog::NewFileDialog(MainWindow *main)
     : QDialog(nullptr), // no parent on purpose, using main causes weird positioning
       ui(new Ui::NewFileDialog),
@@ -136,8 +154,10 @@ void NewFileDialog::on_shellcodeButton_clicked()
 void NewFileDialog::on_recentsListWidget_itemClicked(QListWidgetItem *item)
 {
     QVariant data = item->data(Qt::UserRole);
-    QString sitem = data.toString();
-    ui->newFileEdit->setText(sitem);
+    QUrl url(data.toString());
+
+    ui->newFileEdit->setText(url.path());
+    ui->ioPlugin->setCurrentIndex(getIOPluginIndexByScheme(url.scheme()));
 }
 
 void NewFileDialog::on_recentsListWidget_itemDoubleClicked(QListWidgetItem *item)
@@ -243,14 +263,23 @@ static QStringList fillFilesList(QListWidget *widget, const QStringList &files)
     while (it.hasNext()) {
         // Get the file name
         const QString &fullpath = QDir::toNativeSeparators(it.next());
+        const QUrl url(fullpath);
+        const QString path = url.path();
         const QString homepath = QDir::homePath();
         const QString basename = fullpath.section(QDir::separator(), -1);
-        QString filenameHome = fullpath;
+        QString filenameHome = path;
         filenameHome.replace(homepath, "~");
         filenameHome.replace(basename, "");
         filenameHome.chop(1); // Remove last character that will be a path separator
+
+        // file:// is hidden by default
+        const QString scheme = url.scheme();
+        if (scheme != "file") {
+            filenameHome = scheme + "://" + filenameHome;
+        }
+
         // Get file info
-        QFileInfo info(fullpath);
+        QFileInfo info(path);
         if (!info.exists()) {
             it.remove();
         } else {
@@ -317,6 +346,9 @@ void NewFileDialog::updateLoadProjectButton()
 void NewFileDialog::loadFile(const QString &filename)
 {
     const QString &nativeFn = QDir::toNativeSeparators(filename);
+    const QString scheme = ui->ioPlugin->currentText();
+    const QString fullUri = scheme + nativeFn;
+
     if (ui->ioPlugin->currentIndex() == 0 && !Core()->tryFile(nativeFn, false)
         && !ui->checkBox_FilelessOpen->isChecked()) {
         QMessageBox msgBox(this);
@@ -328,8 +360,8 @@ void NewFileDialog::loadFile(const QString &filename)
     // Add file to recent file list
     QSettings settings;
     QStringList files = Config()->getRecentFiles();
-    files.removeAll(nativeFn);
-    files.prepend(nativeFn);
+    files.removeAll(fullUri);
+    files.prepend(fullUri);
     while (files.size() > MaxRecentFiles)
         files.removeLast();
     Config()->setRecentFiles(files);
@@ -337,7 +369,7 @@ void NewFileDialog::loadFile(const QString &filename)
     // Close dialog and open MainWindow/InitialOptionsDialog
     QString ioFile = "";
     if (ui->ioPlugin->currentIndex()) {
-        ioFile = ui->ioPlugin->currentText();
+        ioFile = scheme;
     }
     ioFile += nativeFn;
     InitialOptions options;

--- a/src/dialogs/NewFileDialog.h
+++ b/src/dialogs/NewFileDialog.h
@@ -63,9 +63,9 @@ private:
     bool fillProjectsList();
     void fillIOPluginsList();
 
-    void updateLoadProjectButton();
+    size_t getIOPluginIndexByName(const QString &name);
 
-    size_t getIOPluginIndexByScheme(const QString &scheme);
+    void updateLoadProjectButton();
 
     void loadFile(const QString &filename);
     void loadProject(const QString &project);

--- a/src/dialogs/NewFileDialog.h
+++ b/src/dialogs/NewFileDialog.h
@@ -63,8 +63,6 @@ private:
     bool fillProjectsList();
     void fillIOPluginsList();
 
-    size_t getIOPluginIndexByName(const QString &name);
-
     void updateLoadProjectButton();
 
     void loadFile(const QString &filename);

--- a/src/dialogs/NewFileDialog.h
+++ b/src/dialogs/NewFileDialog.h
@@ -65,6 +65,8 @@ private:
 
     void updateLoadProjectButton();
 
+    size_t getIOPluginIndexByScheme(const QString &scheme);
+
     void loadFile(const QString &filename);
     void loadProject(const QString &project);
     void loadShellcode(const QString &shellcode, const int size);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Made it so that **Cutter** remembers IO mode of opened files by saving the mode `file:// , zip://` etc with the **URI** of the file. It also updates the `ioPlugin` text based on the IO mode of the file clicked. Does not break on `malloc://512` etc
![changes](https://github.com/user-attachments/assets/5e4eb10e-d803-4696-ae73-182c3e3fad2c)

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->
* Open any two files in **Cutter** with different IO modes
* re open **Cutter** and switch between the two files in recently opened widget
* Beforehand **Cutter** will show IO mode as `file://` for both 
* Now, files will show their original IO mode instead of the default `file://`

**Note:** the IO mode will be shown in the recently opened files widget before the `homepath` apart from the `file://` mode, as it is the most common so it will not be shown to keep the UI clean, It will however work as other IO modes.
<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #1681 