### PR TITLE
Small search UI fixes

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -4043,7 +4043,7 @@ QList<SearchDescription> CutterCore::getAllSearch(QString searchFor, SearchKind 
                                  QString::number(searchObject[RJsonKey::size].toRVA()
                                                          * RZ_UNICODE_MAX_BYTES_PER_CHAR,
                                                  16));
-            auto result = cmdRaw(get_str_cmd);
+            auto result = cmdRaw(get_str_cmd).trimmed();
             exp.data = result;
             break;
         }

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -193,21 +193,8 @@ SearchWidget::SearchWidget(MainWindow *main) : CutterDockWidget(main), ui(new Ui
     connect(Core(), &CutterCore::commentsChanged, this,
             [this]() { qhelpers::emitColumnChanged(search_model, SearchModel::COMMENT); });
 
-    QShortcut *enter_press = new QShortcut(QKeySequence(Qt::Key_Return), this);
-    connect(enter_press, &QShortcut::activated, this, [this]() {
-        disableSearch();
-        refreshSearch();
-        checkSearchResultEmpty();
-        enableSearch();
-    });
-    enter_press->setContext(Qt::WidgetWithChildrenShortcut);
-
-    connect(ui->searchButton, &QAbstractButton::clicked, this, [this]() {
-        disableSearch();
-        refreshSearch();
-        checkSearchResultEmpty();
-        enableSearch();
-    });
+    connect(ui->filterLineEdit, &QLineEdit::returnPressed, this, &SearchWidget::runSearch);
+    connect(ui->searchButton, &QAbstractButton::clicked, this, &SearchWidget::runSearch);
 
     connect(ui->searchspaceCombo,
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
@@ -275,6 +262,14 @@ void SearchWidget::refreshSearchspaces()
         ui->searchspaceCombo->setCurrentIndex(cur_idx);
 
     refreshSearch();
+}
+
+void SearchWidget::runSearch()
+{
+    disableSearch();
+    refreshSearch();
+    checkSearchResultEmpty();
+    enableSearch();
 }
 
 void SearchWidget::refreshSearch()

--- a/src/widgets/SearchWidget.h
+++ b/src/widgets/SearchWidget.h
@@ -67,6 +67,7 @@ private slots:
     void searchChanged();
     void updateSearchBoundaries();
     void refreshSearchspaces();
+    void runSearch();
 
 private:
     std::unique_ptr<Ui::SearchWidget> ui;


### PR DESCRIPTION


<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

* trim extra newline from string search results
* limit the scope of enter to search shortcut #3439

**Test plan (required)**

* open executable, set appropriate search range
* do a string search -> make sure most results take single line
* change search query don't submit
* select an entry in search results
* press enter -> expected seeking to selected item instead of running search with new query

Before:
![image](https://github.com/user-attachments/assets/90cbe272-763d-49b1-aa85-10089a252f2e)
After:
![image](https://github.com/user-attachments/assets/dd56de9c-b071-4963-bb4a-9857d6d3763c)


**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
