### PR TITLE
Use C api for search feature

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -4060,41 +4060,34 @@ QList<SearchDescription> CutterCore::getAllSearchCommand(QString searchFor, Sear
     return searchRef;
 }
 
-static bool cutterSearchProgressCancel(void *user, size_t n_hits,
-                                       RzSearchCancelReason invoke_reason)
+static UniquePtrC<RzSearchOpt, &rz_search_opt_free> cutterSetupSearchOptions(RzCore *core)
 {
-    return rz_cons_is_breaked();
-}
-
-static RzSearchOpt *cutterSetupSearchOptions(RzCore *core)
-{
-    RzSearchOpt *search_opts = rz_search_opt_new();
+    auto searchOpts = UniquePtrC<RzSearchOpt, &rz_search_opt_free>(rz_search_opt_new());
+    if (!searchOpts) {
+        return {};
+    }
     RzThreadNCores max_threads =
             (RzThreadNCores)rz_config_get_i(core->config, "search.max_threads");
     max_threads = rz_th_max_threads(max_threads);
     ut32 max_hits = rz_config_get_i(core->config, "search.maxhits");
     const char *show_progress = rz_config_get(core->config, "search.show_progress");
-    if (!(rz_search_opt_set_max_threads(search_opts, max_threads)
-          && rz_search_opt_set_max_hits(search_opts, max_hits)
-          && rz_search_opt_set_show_progress_from_str(search_opts, show_progress))) {
+    if (!(rz_search_opt_set_max_threads(searchOpts.get(), max_threads)
+          && rz_search_opt_set_max_hits(searchOpts.get(), max_hits)
+          && rz_search_opt_set_show_progress_from_str(searchOpts.get(), show_progress))) {
         RZ_LOG_ERROR("Failed setup find options.\n");
-        return nullptr;
+        return {};
     }
 
     RzSearchFindOpt *fopts = rz_core_setup_default_search_find_opts(core);
     if (!fopts) {
         RZ_LOG_ERROR("Failed init find options.\n");
-        return nullptr;
+        return {};
     }
-    if (!rz_search_opt_set_find_options(search_opts, fopts)) {
-        RZ_LOG_ERROR("Failed add find options to the search optoins.\n");
-        return nullptr;
+    if (!rz_search_opt_set_find_options(searchOpts.get(), fopts)) {
+        RZ_LOG_ERROR("Failed add find options to the search options.\n");
+        return {};
     }
-    if (!rz_search_opt_set_cancel_cb(search_opts, cutterSearchProgressCancel, nullptr)) {
-        RZ_LOG_ERROR("code: Failed to setup default search options.\n");
-        return nullptr;
-    }
-    return search_opts;
+    return searchOpts;
 }
 
 class CutterSearchLock
@@ -4130,12 +4123,10 @@ private:
 static QString cutterGetSearchHitData(RzCore *core, SearchKind kind, RzSearchHit *hit)
 {
     QString data = "";
-    size_t data_size = RZ_MAX(hit->size, 16);
-    ut8 *buffer = new ut8[data_size];
+    size_t dataSize = RZ_MAX(hit->size, 16);
+    std::vector<ut8> buffer(dataSize);
 
-    if (!buffer || !rz_io_read_at(core->io, hit->address, buffer, data_size)) {
-        // when fail, just return nothing.
-        delete[] buffer;
+    if (!rz_io_read_at(core->io, hit->address, buffer.data(), dataSize)) {
         return "";
     }
 
@@ -4156,7 +4147,7 @@ static QString cutterGetSearchHitData(RzCore *core, SearchKind kind, RzSearchHit
     case SearchKind::CryptographicMaterial:
         /* fall-thru */
     case SearchKind::MagicSignature: {
-        data = fromOwnedCharPtr(rz_hex_bin2strdup(buffer, data_size));
+        data = fromOwnedCharPtr(rz_hex_bin2strdup(buffer.data(), dataSize));
         break;
     }
     case SearchKind::String:
@@ -4173,11 +4164,11 @@ static QString cutterGetSearchHitData(RzCore *core, SearchKind kind, RzSearchHit
         }
 
         if (encoding == RZ_STRING_ENC_GUESS) {
-            encoding = rz_str_guess_encoding_from_buffer(buffer, data_size);
+            encoding = rz_str_guess_encoding_from_buffer(buffer.data(), dataSize);
         }
 
-        sopt.buffer = buffer;
-        sopt.length = data_size;
+        sopt.buffer = buffer.data();
+        sopt.length = dataSize;
         sopt.encoding = encoding;
         sopt.wrap_at = 0;
         sopt.escape_nl = false;
@@ -4191,7 +4182,6 @@ static QString cutterGetSearchHitData(RzCore *core, SearchKind kind, RzSearchHit
     }
     }
 
-    delete[] buffer;
     return data;
 }
 
@@ -4244,8 +4234,8 @@ QList<SearchDescription> CutterCore::getAllSearch(QString searchFor, SearchKind 
 
     QList<SearchDescription> searchRef;
     RzList /*<RzSearchHit *>*/ *hits = nullptr;
-    auto user_opts = fromOwned(cutterSetupSearchOptions(core), rz_search_opt_free);
-    if (!user_opts) {
+    auto userOpts = cutterSetupSearchOptions(core);
+    if (!userOpts) {
         return searchRef;
     }
 
@@ -4259,7 +4249,7 @@ QList<SearchDescription> CutterCore::getAllSearch(QString searchFor, SearchKind 
         if (!pattern) {
             return searchRef;
         }
-        hits = rz_core_search_bytes(core, user_opts.get(), pattern);
+        hits = rz_core_search_bytes(core, userOpts.get(), pattern);
         break;
     }
     case SearchKind::Value32BE: {
@@ -4269,7 +4259,7 @@ QList<SearchDescription> CutterCore::getAllSearch(QString searchFor, SearchKind 
         if (!pattern) {
             return searchRef;
         }
-        hits = rz_core_search_bytes(core, user_opts.get(), pattern);
+        hits = rz_core_search_bytes(core, userOpts.get(), pattern);
         break;
     }
     case SearchKind::Value32LE: {
@@ -4279,7 +4269,7 @@ QList<SearchDescription> CutterCore::getAllSearch(QString searchFor, SearchKind 
         if (!pattern) {
             return searchRef;
         }
-        hits = rz_core_search_bytes(core, user_opts.get(), pattern);
+        hits = rz_core_search_bytes(core, userOpts.get(), pattern);
         break;
     }
     case SearchKind::Value64BE: {
@@ -4289,7 +4279,7 @@ QList<SearchDescription> CutterCore::getAllSearch(QString searchFor, SearchKind 
         if (!pattern) {
             return searchRef;
         }
-        hits = rz_core_search_bytes(core, user_opts.get(), pattern);
+        hits = rz_core_search_bytes(core, userOpts.get(), pattern);
         break;
     }
     case SearchKind::Value64LE: {
@@ -4299,27 +4289,27 @@ QList<SearchDescription> CutterCore::getAllSearch(QString searchFor, SearchKind 
         if (!pattern) {
             return searchRef;
         }
-        hits = rz_core_search_bytes(core, user_opts.get(), pattern);
+        hits = rz_core_search_bytes(core, userOpts.get(), pattern);
         break;
     }
     case SearchKind::String:
-        hits = rz_core_search_string(core, user_opts.get(), searchFor.toUtf8().constData(),
+        hits = rz_core_search_string(core, userOpts.get(), searchFor.toUtf8().constData(),
                                      RZ_REGEX_DEFAULT, RZ_STRING_ENC_GUESS);
         break;
     case SearchKind::StringCaseInsensitive:
-        hits = rz_core_search_string(core, user_opts.get(), searchFor.toUtf8().constData(),
+        hits = rz_core_search_string(core, userOpts.get(), searchFor.toUtf8().constData(),
                                      RZ_REGEX_CASELESS | RZ_REGEX_LITERAL, RZ_STRING_ENC_GUESS);
         break;
     case SearchKind::StringRegexExtended:
-        hits = rz_core_search_string(core, user_opts.get(), searchFor.toUtf8().constData(),
+        hits = rz_core_search_string(core, userOpts.get(), searchFor.toUtf8().constData(),
                                      RZ_REGEX_EXTENDED, RZ_STRING_ENC_GUESS);
         break;
     case SearchKind::CryptographicMaterial:
-        hits = rz_core_search_cryptographic_material(core, user_opts.get(),
+        hits = rz_core_search_cryptographic_material(core, userOpts.get(),
                                                      RZ_SEARCH_COLLECTION_CRYPTOGRAPHIC_ALL);
         break;
     case SearchKind::MagicSignature:
-        hits = rz_core_search_magic(core, user_opts.get(), nullptr);
+        hits = rz_core_search_magic(core, userOpts.get(), nullptr);
         break;
     }
 

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3929,134 +3929,52 @@ QList<SearchDescription> CutterCore::getAllSearchCommand(QString searchFor, Sear
     }
 
     QString cmd, suffix;
-    if (kind == SearchKind::AsmCode || kind == SearchKind::ROPGadgets
-        || kind == SearchKind::ROPGadgetsRegex) {
-        // Those are the searches which don't follow the search hit standardization of the new
-        // search yet.
-        switch (kind) {
-        default:
-            qWarning() << tr("Error invalid search kind\n");
-            return searchRef;
-        case SearchKind::AsmCode:
-            cmd = "/acj";
-            break;
-        case SearchKind::ROPGadgets:
-            cmd = "/Rj";
-            break;
-        case SearchKind::ROPGadgetsRegex:
-            cmd = "/R/j";
-            break;
-        }
-        // Legacy commands don't get escaped arguments.
-        auto cstr = QString("%1 %2").arg(cmd, kind == SearchKind::AsmCode ? searchFor : arg);
-        searchArray = cmdj(cstr);
-        if (kind == SearchKind::ROPGadgets || kind == SearchKind::ROPGadgetsRegex) {
-            for (CutterJson searchObject : searchArray) {
-                SearchDescription exp;
-
-                exp.code.clear();
-                for (CutterJson gadget : searchObject[RJsonKey::opcodes]) {
-                    exp.code += gadget[RJsonKey::opcode].toString() + ";  ";
-                }
-
-                exp.offset = searchObject[RJsonKey::opcodes].first()[RJsonKey::offset].toRVA();
-                exp.size = searchObject[RJsonKey::size].toUt64();
-
-                searchRef << exp;
-            }
-            return searchRef;
-        }
+    // Those are the searches which don't follow the search hit standardization of the new
+    // search yet.
+    switch (kind) {
+    default:
+        qWarning() << tr("Error invalid search kind\n");
+        return searchRef;
+    case SearchKind::AsmCode:
+        cmd = "/acj";
+        break;
+    case SearchKind::ROPGadgets:
+        cmd = "/Rj";
+        break;
+    case SearchKind::ROPGadgetsRegex:
+        cmd = "/R/j";
+        break;
+    }
+    // Legacy commands don't get escaped arguments.
+    auto cstr = QString("%1 %2").arg(cmd, kind == SearchKind::AsmCode ? searchFor : arg);
+    searchArray = cmdj(cstr);
+    if (kind == SearchKind::ROPGadgets || kind == SearchKind::ROPGadgetsRegex) {
         for (CutterJson searchObject : searchArray) {
             SearchDescription exp;
 
-            exp.offset = searchObject[RJsonKey::offset].toRVA();
-            exp.size = searchObject[RJsonKey::len].toUt64();
-            exp.code = searchObject[RJsonKey::code].toString();
-            exp.data = searchObject[RJsonKey::data].toString();
+            exp.code.clear();
+            for (CutterJson gadget : searchObject[RJsonKey::opcodes]) {
+                exp.code += gadget[RJsonKey::opcode].toString() + ";  ";
+            }
+
+            exp.offset = searchObject[RJsonKey::opcodes].first()[RJsonKey::offset].toRVA();
+            exp.size = searchObject[RJsonKey::size].toUt64();
 
             searchRef << exp;
         }
         return searchRef;
     }
-    // These are the earches with the unified API.
-    switch (kind) {
-    default:
-        qWarning() << tr("Error invalid search kind\n");
-        return searchRef;
-    case SearchKind::HexString:
-        cmd = "/xj";
-        break;
-    case SearchKind::String:
-        cmd = "/zj";
-        break;
-    case SearchKind::StringCaseInsensitive:
-        cmd = "/zj";
-        suffix = "li";
-        break;
-    case SearchKind::StringRegexExtended:
-        cmd = "/zj";
-        suffix = "e";
-        break;
-    case SearchKind::Value32BE:
-        cmd = "/vj 4be";
-        break;
-    case SearchKind::Value32LE:
-        cmd = "/vj 4le";
-        break;
-    case SearchKind::Value64BE:
-        cmd = "/vj 8be";
-        break;
-    case SearchKind::Value64LE:
-        cmd = "/vj 8le";
-        break;
-    }
-    QString cstr;
-    if (kind == SearchKind::StringRegexExtended || kind == SearchKind::StringCaseInsensitive
-        || kind == SearchKind::String) {
-        // Quote the string since it might contain spaces.
-        cstr = QString("%1 \"%2\" %3").arg(cmd, arg, suffix);
-    } else {
-        cstr = QString("%1 %2").arg(cmd, arg);
-    }
-    searchArray = cmdj(cstr);
     for (CutterJson searchObject : searchArray) {
         SearchDescription exp;
 
-        exp.offset = searchObject[RJsonKey::address].toRVA();
-        exp.size = searchObject[RJsonKey::size].toUt64();
-        switch (kind) {
-        default:
-            qWarning() << tr("Error invalid search kind\n");
-            return searchRef;
-        case SearchKind::String:
-        case SearchKind::StringCaseInsensitive:
-        case SearchKind::StringRegexExtended: {
-            QString enc = searchObject[RJsonKey::flag].toString().section(".", 2, 2);
-            if (enc.isEmpty()) {
-                enc = "guess";
-            }
-            QString get_str_cmd =
-                    QString("ps %1 @ 0x%2 @!0x%3")
-                            .arg(enc, QString::number(searchObject[RJsonKey::address].toRVA(), 16),
-                                 QString::number(searchObject[RJsonKey::size].toRVA()
-                                                         * RZ_UNICODE_MAX_BYTES_PER_CHAR,
-                                                 16));
-            auto result = cmdRaw(get_str_cmd).trimmed();
-            exp.data = result;
-            break;
-        }
-        case SearchKind::HexString:
-        case SearchKind::Value32BE:
-        case SearchKind::Value32LE:
-        case SearchKind::Value64BE:
-        case SearchKind::Value64LE:
-            // Don't add any data for them.
-            // For now they are just reported as length + offset.
-            break;
-        }
+        exp.offset = searchObject[RJsonKey::offset].toRVA();
+        exp.size = searchObject[RJsonKey::len].toUt64();
+        exp.code = searchObject[RJsonKey::code].toString();
+        exp.data = searchObject[RJsonKey::data].toString();
+        exp.detail = rz_meta_get_string(core->analysis, RZ_META_TYPE_COMMENT, exp.offset);
+
         searchRef << exp;
     }
-
     return searchRef;
 }
 
@@ -4093,8 +4011,7 @@ static UniquePtrC<RzSearchOpt, &rz_search_opt_free> cutterSetupSearchOptions(RzC
 class CutterSearchLock
 {
 public:
-    CutterSearchLock(RzCore *core)
-        : core_(core)
+    CutterSearchLock(RzCore *core) : core_(core)
     {
         rz_cons_break_push(NULL, NULL);
         core_->in_search = true;
@@ -4315,7 +4232,8 @@ QList<SearchDescription> CutterCore::getAllSearch(QString searchFor, SearchKind 
         if (!detail.isEmpty()) {
             exp.detail += " (" + detail + ")";
         }
-        exp.detail += " " + Core()->getCommentAt(exp.offset);
+        exp.detail += " ";
+        exp.detail += rz_meta_get_string(core->analysis, RZ_META_TYPE_COMMENT, exp.offset);
         exp.detail = exp.detail.trimmed();
 
         searchRef << exp;

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -4095,12 +4095,7 @@ class CutterSearchLock
 public:
     CutterSearchLock(RzCore *core)
         : core_(core)
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-          ,
-          searchMutex(QMutex::Recursive)
-#endif
     {
-        searchMutex.lock();
         rz_cons_break_push(NULL, NULL);
         core_->in_search = true;
     }
@@ -4108,16 +4103,10 @@ public:
     {
         rz_cons_break_pop();
         core_->in_search = false;
-        searchMutex.unlock();
     }
 
 private:
     RzCore *core_ = nullptr;
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    QMutex searchMutex;
-#else
-    QRecursiveMutex searchMutex;
-#endif
 };
 
 static QString cutterGetSearchHitData(RzCore *core, SearchKind kind, RzSearchHit *hit)

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3914,14 +3914,12 @@ bool CutterCore::isAddressMapped(RVA addr)
     return rz_io_map_get(core->io, addr);
 }
 
-QList<SearchDescription> CutterCore::getAllSearch(QString searchFor, SearchKind kind, QString in)
+QList<SearchDescription> CutterCore::getAllSearchCommand(QString searchFor, SearchKind kind,
+                                                         QString in)
 {
     CORE_LOCK();
     QList<SearchDescription> searchRef;
 
-    if (searchFor.isEmpty()) {
-        return {};
-    }
     TempConfig cfg;
     cfg.set("search.in", in);
     CutterJson searchArray;
@@ -4059,6 +4057,292 @@ QList<SearchDescription> CutterCore::getAllSearch(QString searchFor, SearchKind 
         searchRef << exp;
     }
 
+    return searchRef;
+}
+
+static bool cutterSearchProgressCancel(void *user, size_t n_hits,
+                                       RzSearchCancelReason invoke_reason)
+{
+    return rz_cons_is_breaked();
+}
+
+static RzSearchOpt *cutterSetupSearchOptions(RzCore *core)
+{
+    RzSearchOpt *search_opts = rz_search_opt_new();
+    RzThreadNCores max_threads =
+            (RzThreadNCores)rz_config_get_i(core->config, "search.max_threads");
+    max_threads = rz_th_max_threads(max_threads);
+    ut32 max_hits = rz_config_get_i(core->config, "search.maxhits");
+    const char *show_progress = rz_config_get(core->config, "search.show_progress");
+    if (!(rz_search_opt_set_max_threads(search_opts, max_threads)
+          && rz_search_opt_set_max_hits(search_opts, max_hits)
+          && rz_search_opt_set_show_progress_from_str(search_opts, show_progress))) {
+        RZ_LOG_ERROR("Failed setup find options.\n");
+        return nullptr;
+    }
+
+    RzSearchFindOpt *fopts = rz_core_setup_default_search_find_opts(core);
+    if (!fopts) {
+        RZ_LOG_ERROR("Failed init find options.\n");
+        return nullptr;
+    }
+    if (!rz_search_opt_set_find_options(search_opts, fopts)) {
+        RZ_LOG_ERROR("Failed add find options to the search optoins.\n");
+        return nullptr;
+    }
+    if (!rz_search_opt_set_cancel_cb(search_opts, cutterSearchProgressCancel, nullptr)) {
+        RZ_LOG_ERROR("code: Failed to setup default search options.\n");
+        return nullptr;
+    }
+    return search_opts;
+}
+
+class CutterSearchLock
+{
+public:
+    CutterSearchLock(RzCore *core)
+        : core_(core)
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+          ,
+          searchMutex(QMutex::Recursive)
+#endif
+    {
+        searchMutex.lock();
+        rz_cons_break_push(NULL, NULL);
+        core_->in_search = true;
+    }
+    ~CutterSearchLock()
+    {
+        rz_cons_break_pop();
+        core_->in_search = false;
+        searchMutex.unlock();
+    }
+
+private:
+    RzCore *core_ = nullptr;
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    QMutex searchMutex;
+#else
+    QRecursiveMutex searchMutex;
+#endif
+};
+
+static QString cutterGetSearchHitData(RzCore *core, SearchKind kind, RzSearchHit *hit)
+{
+    QString data = "";
+    size_t data_size = RZ_MAX(hit->size, 16);
+    ut8 *buffer = new ut8[data_size];
+
+    if (!buffer || !rz_io_read_at(core->io, hit->address, buffer, data_size)) {
+        // when fail, just return nothing.
+        delete[] buffer;
+        return "";
+    }
+
+    switch (kind) {
+    default:
+        // for some kinds, we don't do anything.
+        break;
+    case SearchKind::Value32BE:
+        /* fall-thru */
+    case SearchKind::Value32LE:
+        /* fall-thru */
+    case SearchKind::Value64BE:
+        /* fall-thru */
+    case SearchKind::Value64LE:
+        /* fall-thru */
+    case SearchKind::HexString:
+        /* fall-thru */
+    case SearchKind::CryptographicMaterial:
+        /* fall-thru */
+    case SearchKind::MagicSignature: {
+        data = fromOwnedCharPtr(rz_hex_bin2strdup(buffer, data_size));
+        break;
+    }
+    case SearchKind::String:
+        /* fall-thru */
+    case SearchKind::StringCaseInsensitive:
+        /* fall-thru */
+    case SearchKind::StringRegexExtended: {
+        RzStrStringifyOpt sopt;
+        RzStrEnc encoding = RZ_STRING_ENC_GUESS;
+        QString enc = hit->hit_desc;
+        enc = enc.section(".", 1, 1);
+        if (!enc.isEmpty()) {
+            encoding = rz_str_enc_string_as_type(enc.toUtf8().constData());
+        }
+
+        if (encoding == RZ_STRING_ENC_GUESS) {
+            encoding = rz_str_guess_encoding_from_buffer(buffer, data_size);
+        }
+
+        sopt.buffer = buffer;
+        sopt.length = data_size;
+        sopt.encoding = encoding;
+        sopt.wrap_at = 0;
+        sopt.escape_nl = false;
+        sopt.json = false;
+        sopt.stop_at_nil = true;
+        sopt.stop_at_unprintable = false;
+        sopt.urlencode = false;
+
+        data = fromOwnedCharPtr(rz_str_stringify_raw_buffer(&sopt, nullptr));
+        break;
+    }
+    }
+
+    delete[] buffer;
+    return data;
+}
+
+static QString cutterValueAsHex(QString strVal, bool bigEndian, size_t size)
+{
+    ut64 value = rz_num_math(nullptr, strVal.toUtf8().constData());
+    ut8 buffer[sizeof(ut64)] = { 0 };
+    char output[64] = { 0 };
+    rz_write_ble(buffer, value, bigEndian, size);
+    rz_hex_bin2str(buffer, size == 32 ? 4 : 8, output);
+    return output;
+}
+
+QList<SearchDescription> CutterCore::getAllSearch(QString searchFor, SearchKind kind, QString in)
+{
+    if (searchFor.isEmpty() && kind != SearchKind::CryptographicMaterial
+        && kind != SearchKind::MagicSignature) {
+        return {};
+    }
+
+    // call the oldsyle command for this search.
+    // this must be done before CORE_LOCK() to avoid deadlocks.
+    switch (kind) {
+    case SearchKind::AsmCode:
+        /* fall-thru */
+    case SearchKind::ROPGadgets:
+        /* fall-thru */
+    case SearchKind::ROPGadgetsRegex:
+        // old style search
+        return getAllSearchCommand(searchFor, kind, in);
+    default:
+        // use C API
+        break;
+    }
+
+    CORE_LOCK();
+
+    if (core->in_search) {
+        // this is impossible to happen, unless the user runs
+        // search via terminal before calling the Qt UI
+        RZ_LOG_ERROR("cutter: recursive search detected, search aborted.\n");
+        return {};
+    }
+
+    // this takes ownership of the search lock
+    CutterSearchLock searchLock(core);
+
+    TempConfig cfg;
+    cfg.set("search.in", in);
+
+    QList<SearchDescription> searchRef;
+    RzList /*<RzSearchHit *>*/ *hits = nullptr;
+    auto user_opts = fromOwned(cutterSetupSearchOptions(core), rz_search_opt_free);
+    if (!user_opts) {
+        return searchRef;
+    }
+
+    switch (kind) {
+    default:
+        qWarning() << tr("Error invalid search kind\n");
+        return searchRef;
+    case SearchKind::HexString: {
+        RzSearchBytesPattern *pattern =
+                rz_search_parse_byte_pattern(searchFor.toUtf8().constData(), "bytes");
+        if (!pattern) {
+            return searchRef;
+        }
+        hits = rz_core_search_bytes(core, user_opts.get(), pattern);
+        break;
+    }
+    case SearchKind::Value32BE: {
+        searchFor = cutterValueAsHex(searchFor, true, 32);
+        RzSearchBytesPattern *pattern =
+                rz_search_parse_byte_pattern(searchFor.toUtf8().constData(), "value32.be");
+        if (!pattern) {
+            return searchRef;
+        }
+        hits = rz_core_search_bytes(core, user_opts.get(), pattern);
+        break;
+    }
+    case SearchKind::Value32LE: {
+        searchFor = cutterValueAsHex(searchFor, false, 32);
+        RzSearchBytesPattern *pattern =
+                rz_search_parse_byte_pattern(searchFor.toUtf8().constData(), "value32.le");
+        if (!pattern) {
+            return searchRef;
+        }
+        hits = rz_core_search_bytes(core, user_opts.get(), pattern);
+        break;
+    }
+    case SearchKind::Value64BE: {
+        searchFor = cutterValueAsHex(searchFor, true, 64);
+        RzSearchBytesPattern *pattern =
+                rz_search_parse_byte_pattern(searchFor.toUtf8().constData(), "value64.be");
+        if (!pattern) {
+            return searchRef;
+        }
+        hits = rz_core_search_bytes(core, user_opts.get(), pattern);
+        break;
+    }
+    case SearchKind::Value64LE: {
+        searchFor = cutterValueAsHex(searchFor, false, 64);
+        RzSearchBytesPattern *pattern =
+                rz_search_parse_byte_pattern(searchFor.toUtf8().constData(), "value64.le");
+        if (!pattern) {
+            return searchRef;
+        }
+        hits = rz_core_search_bytes(core, user_opts.get(), pattern);
+        break;
+    }
+    case SearchKind::String:
+        hits = rz_core_search_string(core, user_opts.get(), searchFor.toUtf8().constData(),
+                                     RZ_REGEX_DEFAULT, RZ_STRING_ENC_GUESS);
+        break;
+    case SearchKind::StringCaseInsensitive:
+        hits = rz_core_search_string(core, user_opts.get(), searchFor.toUtf8().constData(),
+                                     RZ_REGEX_CASELESS | RZ_REGEX_LITERAL, RZ_STRING_ENC_GUESS);
+        break;
+    case SearchKind::StringRegexExtended:
+        hits = rz_core_search_string(core, user_opts.get(), searchFor.toUtf8().constData(),
+                                     RZ_REGEX_EXTENDED, RZ_STRING_ENC_GUESS);
+        break;
+    case SearchKind::CryptographicMaterial:
+        hits = rz_core_search_cryptographic_material(core, user_opts.get(),
+                                                     RZ_SEARCH_COLLECTION_CRYPTOGRAPHIC_ALL);
+        break;
+    case SearchKind::MagicSignature:
+        hits = rz_core_search_magic(core, user_opts.get(), nullptr);
+        break;
+    }
+
+    RzListIter *it;
+    RzSearchHit *hit;
+    CutterRzListForeach (hits, it, RzSearchHit, hit) {
+        SearchDescription exp;
+        QString detail = fromOwnedCharPtr(rz_search_hit_detail_as_string(hit));
+
+        exp.offset = hit->address;
+        exp.size = hit->size;
+        exp.data = cutterGetSearchHitData(core, kind, hit).trimmed();
+        exp.detail = hit->hit_desc;
+        if (!detail.isEmpty()) {
+            exp.detail += " (" + detail + ")";
+        }
+        exp.detail += " " + Core()->getCommentAt(exp.offset);
+        exp.detail = exp.detail.trimmed();
+
+        searchRef << exp;
+    }
+
+    rz_list_free(hits);
     return searchRef;
 }
 

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -74,6 +74,8 @@ enum class SearchKind {
     Value32LE,
     Value64BE,
     Value64LE,
+    CryptographicMaterial,
+    MagicSignature,
 };
 
 class CUTTER_EXPORT CutterCore : public QObject
@@ -867,6 +869,7 @@ private:
 
     QVector<QString> getCutterRCFilePaths() const;
     QList<TypeDescription> getBaseType(RzBaseTypeKind kind, const char *category);
+    QList<SearchDescription> getAllSearchCommand(QString searchFor, SearchKind kind, QString in);
 };
 
 class CUTTER_EXPORT RzCoreLocked

--- a/src/core/CutterDescriptions.h
+++ b/src/core/CutterDescriptions.h
@@ -83,9 +83,10 @@ struct TypeDescription
 struct SearchDescription
 {
     RVA offset;
-    int size;
+    size_t size;
     QString code;
     QString data;
+    QString detail;
 };
 
 struct SymbolDescription

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -16,7 +16,7 @@ static const int kMaxTooltipHexdumpBytes = 64;
 
 }
 
-static const QMap<QString, QString> searchBoundaries {
+static const QVector<std::pair<QString, const char *>> searchBoundaries {
     { "io.maps", QT_TR_NOOP("All maps") },
     { "io.map", QT_TR_NOOP("Current map") },
     { "raw", QT_TR_NOOP("Whole file") },
@@ -31,7 +31,7 @@ static const QMap<QString, QString> searchBoundaries {
     { "analysis.bb", QT_TR_NOOP("Current basic block") },
 };
 
-static const QMap<QString, QString> searchBoundariesDebug {
+static const QVector<std::pair<QString, const char *>> searchBoundariesDebug {
     { "dbg.maps", QT_TR_NOOP("All memory maps") },
     { "dbg.map", QT_TR_NOOP("Memory map") },
     { "block", QT_TR_NOOP("Current block") },
@@ -39,6 +39,46 @@ static const QMap<QString, QString> searchBoundariesDebug {
     { "dbg.stack", QT_TR_NOOP("Stack") },
     { "dbg.heap", QT_TR_NOOP("Heap") }
 };
+
+struct SearchKindInfo
+{
+    SearchKind kind;
+    const char *name;
+    const char *textHint;
+    bool noInput = false;
+};
+
+static const SearchKindInfo searchKinds[] = {
+    { SearchKind::AsmCode, QT_TR_NOOP("asm code"), QT_TR_NOOP("jmp rax") },
+    { SearchKind::String, QT_TR_NOOP("string (literal)"), QT_TR_NOOP("foobar") },
+    { SearchKind::StringCaseInsensitive, QT_TR_NOOP("string (case insensitive)"),
+      QT_TR_NOOP("fOobaR") },
+    { SearchKind::StringRegexExtended, QT_TR_NOOP("string (extended regex)"),
+      QT_TR_NOOP("(foo){,4}[Bb]ar") },
+    { SearchKind::HexString, QT_TR_NOOP("hex string"), QT_TR_NOOP("ab01..23...1234ef") },
+    { SearchKind::ROPGadgets, QT_TR_NOOP("ROP gadgets"), QT_TR_NOOP("pop,,pop") },
+    { SearchKind::ROPGadgetsRegex, QT_TR_NOOP("ROP gadgets (regex)"), QT_TR_NOOP("mov e[abc]x") },
+    { SearchKind::Value32BE, QT_TR_NOOP("32bit big endian value"),
+      QT_TR_NOOP("0xdeadbeef (big endian)") },
+    { SearchKind::Value32LE, QT_TR_NOOP("32bit little endian value"),
+      QT_TR_NOOP("0xdeadbeef (little endian)") },
+    { SearchKind::Value64BE, QT_TR_NOOP("64bit big endian value"),
+      QT_TR_NOOP("0xfedcba9876543210 (big endian)") },
+    { SearchKind::Value64BE, QT_TR_NOOP("64bit little endian value"),
+      QT_TR_NOOP("0xfedcba9876543210 (little endian)") },
+    { SearchKind::CryptographicMaterial, QT_TR_NOOP("Cryptographic material"), nullptr, true },
+    { SearchKind::MagicSignature, QT_TR_NOOP("Magic signature"), nullptr, true },
+};
+
+static const SearchKindInfo &searchKindInfo(SearchKind kind)
+{
+    auto res = std::find_if(std::begin(searchKinds), std::end(searchKinds),
+                            [kind](const SearchKindInfo &info) { return info.kind == kind; });
+    if (res != std::end(searchKinds)) {
+        return *res;
+    }
+    return searchKinds[1];
+}
 
 SearchModel::SearchModel(QList<SearchDescription> *search, QObject *parent)
     : AddressableItemModel<QAbstractListModel>(parent), search(search)
@@ -225,8 +265,7 @@ SearchWidget::~SearchWidget() {}
 
 void SearchWidget::updateSearchBoundaries()
 {
-    QMap<QString, QString>::const_iterator mapIter;
-    QMap<QString, QString> boundaries;
+    QVector<std::pair<QString, const char *>> boundaries;
 
     if (Core()->currentlyDebugging && !Core()->currentlyEmulating) {
         boundaries = searchBoundariesDebug;
@@ -234,13 +273,12 @@ void SearchWidget::updateSearchBoundaries()
         boundaries = searchBoundaries;
     }
 
-    mapIter = boundaries.cbegin();
-    ui->searchInCombo->setCurrentIndex(ui->searchInCombo->findData(mapIter.key()));
+    ui->searchInCombo->setCurrentIndex(ui->searchInCombo->findData(boundaries[0].first));
 
     ui->searchInCombo->blockSignals(true);
     ui->searchInCombo->clear();
-    for (; mapIter != boundaries.cend(); ++mapIter) {
-        ui->searchInCombo->addItem(mapIter.value(), mapIter.key());
+    for (auto item : boundaries) {
+        ui->searchInCombo->addItem(tr(item.second), item.first);
     }
     ui->searchInCombo->blockSignals(false);
 
@@ -259,28 +297,9 @@ void SearchWidget::refreshSearchspaces()
         cur_idx = 0;
 
     ui->searchspaceCombo->clear();
-    ui->searchspaceCombo->addItem(tr("asm code"), static_cast<int>(SearchKind::AsmCode));
-    ui->searchspaceCombo->addItem(tr("string (literal)"), static_cast<int>(SearchKind::String));
-    ui->searchspaceCombo->addItem(tr("string (case insensitive)"),
-                                  static_cast<int>(SearchKind::StringCaseInsensitive));
-    ui->searchspaceCombo->addItem(tr("string (extended regex)"),
-                                  static_cast<int>(SearchKind::StringRegexExtended));
-    ui->searchspaceCombo->addItem(tr("hex string"), static_cast<int>(SearchKind::HexString));
-    ui->searchspaceCombo->addItem(tr("ROP gadgets"), static_cast<int>(SearchKind::ROPGadgets));
-    ui->searchspaceCombo->addItem(tr("ROP gadgets (regex)"),
-                                  static_cast<int>(SearchKind::ROPGadgetsRegex));
-    ui->searchspaceCombo->addItem(tr("32bit big endian value"),
-                                  static_cast<int>(SearchKind::Value32BE));
-    ui->searchspaceCombo->addItem(tr("32bit little endian value"),
-                                  static_cast<int>(SearchKind::Value32LE));
-    ui->searchspaceCombo->addItem(tr("64bit big endian value"),
-                                  static_cast<int>(SearchKind::Value64BE));
-    ui->searchspaceCombo->addItem(tr("64bit little endian value"),
-                                  static_cast<int>(SearchKind::Value64LE));
-    ui->searchspaceCombo->addItem(tr("Cryptographic material"),
-                                  static_cast<int>(SearchKind::CryptographicMaterial));
-    ui->searchspaceCombo->addItem(tr("Magic signature"),
-                                  static_cast<int>(SearchKind::MagicSignature));
+    for (auto &kind : searchKinds) {
+        ui->searchspaceCombo->addItem(tr(kind.name), static_cast<int>(kind.kind));
+    }
 
     if (cur_idx > 0)
         ui->searchspaceCombo->setCurrentIndex(cur_idx);
@@ -317,6 +336,10 @@ void SearchWidget::checkSearchResultEmpty()
         return;
 
     QString searchFor = ui->filterLineEdit->text();
+    auto searchSpace = static_cast<SearchKind>(ui->searchspaceCombo->currentData().toInt());
+    if (searchFor.isEmpty() && !searchKindInfo(searchSpace).noInput) {
+        return;
+    }
     QString noResultsMessage = "<b>";
     noResultsMessage.append(tr("No results found for:"));
     noResultsMessage.append("</b><br>");
@@ -336,57 +359,17 @@ void SearchWidget::setScrollMode()
 
 void SearchWidget::updatePlaceholderText(int)
 {
-    ui->filterLineEdit->setEnabled(true);
-
     // ensure we grab the correct kind.
     auto kind = static_cast<SearchKind>(ui->searchspaceCombo->currentData().toInt());
-    switch (kind) {
-    case SearchKind::AsmCode:
-        ui->filterLineEdit->setPlaceholderText("jmp rax");
-        break;
-    case SearchKind::HexString:
-        ui->filterLineEdit->setPlaceholderText("foobar");
-        break;
-    case SearchKind::ROPGadgets:
-        ui->filterLineEdit->setPlaceholderText("FooBar");
-        break;
-    case SearchKind::ROPGadgetsRegex:
-        ui->filterLineEdit->setPlaceholderText("(foo){,4}[Bb]ar");
-        break;
-    case SearchKind::String:
-        ui->filterLineEdit->setPlaceholderText("dead....beef");
-        break;
-    case SearchKind::StringCaseInsensitive:
-        ui->filterLineEdit->setPlaceholderText("pop,,pop");
-        break;
-    case SearchKind::StringRegexExtended:
-        ui->filterLineEdit->setPlaceholderText("mov e[abc]x");
-        break;
-    case SearchKind::Value32BE:
-        ui->filterLineEdit->setPlaceholderText("0xdeadbeef (big endian)");
-        break;
-    case SearchKind::Value32LE:
-        ui->filterLineEdit->setPlaceholderText("0xdeadbeef (little endian)");
-        break;
-    case SearchKind::Value64BE:
-        ui->filterLineEdit->setPlaceholderText("0xfedcba9876543210 (big endian)");
-        break;
-    case SearchKind::Value64LE:
-        ui->filterLineEdit->setPlaceholderText("0xfedcba9876543210 (little endian)");
-        break;
-    case SearchKind::CryptographicMaterial:
-        // this search kind does not take any input.
+    auto info = searchKindInfo(kind);
+    if (info.textHint) {
+        ui->filterLineEdit->setPlaceholderText(tr(info.textHint));
+    } else {
         ui->filterLineEdit->setPlaceholderText("");
-        ui->filterLineEdit->setEnabled(false);
-        break;
-    case SearchKind::MagicSignature:
-        // this search kind does not take any input.
-        ui->filterLineEdit->setPlaceholderText("");
-        ui->filterLineEdit->setEnabled(false);
-        break;
-    default:
-        ui->filterLineEdit->setPlaceholderText("<No preview defined>");
-        break;
+    }
+    ui->filterLineEdit->setDisabled(info.noInput);
+    if (info.noInput) {
+        ui->filterLineEdit->clear();
     }
 }
 

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -45,7 +45,7 @@ struct SearchKindInfo
     SearchKind kind;
     const char *name;
     const char *textHint;
-    bool noInput = false;
+    bool noInput;
 };
 
 static const SearchKindInfo searchKinds[] = {

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -17,19 +17,28 @@ static const int kMaxTooltipHexdumpBytes = 64;
 }
 
 static const QMap<QString, QString> searchBoundaries {
-    { "io.maps", "All maps" },
-    { "io.map", "Current map" },
-    { "raw", "Raw" },
-    { "block", "Current block" },
-    { "bin.section", "Current mapped section" },
-    { "bin.sections", "All mapped sections" },
+    { "io.maps", QT_TR_NOOP("All maps") },
+    { "io.map", QT_TR_NOOP("Current map") },
+    { "raw", QT_TR_NOOP("Whole file") },
+    { "block", QT_TR_NOOP("Current block") },
+    { "bin.section", QT_TR_NOOP("Current mapped section") },
+    { "bin.sections", QT_TR_NOOP("All mapped sections") },
+    { "bin.segment", QT_TR_NOOP("Current mapped segment") },
+    { "bin.segments", QT_TR_NOOP("All mapped segments") },
+    { "code", QT_TR_NOOP("All exec sections") },
+    { "io.sky", QT_TR_NOOP("All io.skyline") },
+    { "analysis.fcn", QT_TR_NOOP("Current function") },
+    { "analysis.bb", QT_TR_NOOP("Current basic block") },
 };
 
-static const QMap<QString, QString> searchBoundariesDebug { { "dbg.maps", "All memory maps" },
-                                                            { "dbg.map", "Memory map" },
-                                                            { "block", "Current block" },
-                                                            { "dbg.stack", "Stack" },
-                                                            { "dbg.heap", "Heap" } };
+static const QMap<QString, QString> searchBoundariesDebug {
+    { "dbg.maps", QT_TR_NOOP("All memory maps") },
+    { "dbg.map", QT_TR_NOOP("Memory map") },
+    { "block", QT_TR_NOOP("Current block") },
+    { "dbg.program", QT_TR_NOOP("All exec sections") },
+    { "dbg.stack", QT_TR_NOOP("Stack") },
+    { "dbg.heap", QT_TR_NOOP("Heap") }
+};
 
 SearchModel::SearchModel(QList<SearchDescription> *search, QObject *parent)
     : AddressableItemModel<QAbstractListModel>(parent), search(search)
@@ -54,6 +63,16 @@ QVariant SearchModel::data(const QModelIndex &index, int role) const
     const SearchDescription &exp = search->at(index.row());
 
     switch (role) {
+    case Qt::FontRole: {
+        switch (index.column()) {
+        case CODE:
+            return QFont("Inconsolata");
+        case DATA:
+            return QFont("Inconsolata");
+        default:
+            return QVariant();
+        }
+    }
     case Qt::DisplayRole:
         switch (index.column()) {
         case OFFSET:
@@ -64,8 +83,9 @@ QVariant SearchModel::data(const QModelIndex &index, int role) const
             return exp.code;
         case DATA:
             return exp.data;
-        case COMMENT:
-            return Core()->getCommentAt(exp.offset);
+        case COMMENT: {
+            return exp.detail;
+        }
         default:
             return QVariant();
         }
@@ -165,7 +185,7 @@ bool SearchSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelI
     case SearchModel::DATA:
         return left_search.data < right_search.data;
     case SearchModel::COMMENT:
-        return Core()->getCommentAt(left_search.offset) < Core()->getCommentAt(right_search.offset);
+        return left_search.detail < right_search.detail;
     default:
         break;
     }
@@ -257,6 +277,10 @@ void SearchWidget::refreshSearchspaces()
                                   static_cast<int>(SearchKind::Value64BE));
     ui->searchspaceCombo->addItem(tr("64bit little endian value"),
                                   static_cast<int>(SearchKind::Value64LE));
+    ui->searchspaceCombo->addItem(tr("Cryptographic material"),
+                                  static_cast<int>(SearchKind::CryptographicMaterial));
+    ui->searchspaceCombo->addItem(tr("Magic signature"),
+                                  static_cast<int>(SearchKind::MagicSignature));
 
     if (cur_idx > 0)
         ui->searchspaceCombo->setCurrentIndex(cur_idx);
@@ -289,13 +313,20 @@ void SearchWidget::refreshSearch()
 // Called by &QShortcut::activated and &QAbstractButton::clicked signals
 void SearchWidget::checkSearchResultEmpty()
 {
-    if (search.isEmpty()) {
-        QString noResultsMessage = "<b>";
-        noResultsMessage.append(tr("No results found for:"));
-        noResultsMessage.append("</b><br>");
+    if (!search.isEmpty())
+        return;
+
+    QString searchFor = ui->filterLineEdit->text();
+    QString noResultsMessage = "<b>";
+    noResultsMessage.append(tr("No results found for:"));
+    noResultsMessage.append("</b><br>");
+    if (searchFor.isEmpty()) {
+        noResultsMessage.append(ui->searchspaceCombo->currentText().toHtmlEscaped());
+    } else {
         noResultsMessage.append(ui->filterLineEdit->text().toHtmlEscaped());
-        QMessageBox::information(this, tr("No Results Found"), noResultsMessage);
     }
+
+    QMessageBox::information(this, tr("No Results Found"), noResultsMessage);
 }
 
 void SearchWidget::setScrollMode()
@@ -303,44 +334,59 @@ void SearchWidget::setScrollMode()
     qhelpers::setVerticalScrollMode(ui->searchTreeView);
 }
 
-void SearchWidget::updatePlaceholderText(int index)
+void SearchWidget::updatePlaceholderText(int)
 {
-    switch (index) {
-    case 0: // string
+    ui->filterLineEdit->setEnabled(true);
+
+    // ensure we grab the correct kind.
+    auto kind = static_cast<SearchKind>(ui->searchspaceCombo->currentData().toInt());
+    switch (kind) {
+    case SearchKind::AsmCode:
         ui->filterLineEdit->setPlaceholderText("jmp rax");
         break;
-    case 1: // string
+    case SearchKind::HexString:
         ui->filterLineEdit->setPlaceholderText("foobar");
         break;
-    case 2: // string (case insensitive)
+    case SearchKind::ROPGadgets:
         ui->filterLineEdit->setPlaceholderText("FooBar");
         break;
-    case 3: // string (extended regex)
+    case SearchKind::ROPGadgetsRegex:
         ui->filterLineEdit->setPlaceholderText("(foo){,4}[Bb]ar");
         break;
-    case 4: // hex string
-        ui->filterLineEdit->setPlaceholderText("deadbeef");
+    case SearchKind::String:
+        ui->filterLineEdit->setPlaceholderText("dead....beef");
         break;
-    case 5: // ROP gadgets
+    case SearchKind::StringCaseInsensitive:
         ui->filterLineEdit->setPlaceholderText("pop,,pop");
         break;
-    case 6: // ROP gadgets (regex)
+    case SearchKind::StringRegexExtended:
         ui->filterLineEdit->setPlaceholderText("mov e[abc]x");
         break;
-    case 7: // 32bit value be
-        ui->filterLineEdit->setPlaceholderText("0xdeadbeef");
+    case SearchKind::Value32BE:
+        ui->filterLineEdit->setPlaceholderText("0xdeadbeef (big endian)");
         break;
-    case 8: // 32bit value le
-        ui->filterLineEdit->setPlaceholderText("0xdeadbeef");
+    case SearchKind::Value32LE:
+        ui->filterLineEdit->setPlaceholderText("0xdeadbeef (little endian)");
         break;
-    case 9: // 64bit value be
-        ui->filterLineEdit->setPlaceholderText("0xfedcba9876543210");
+    case SearchKind::Value64BE:
+        ui->filterLineEdit->setPlaceholderText("0xfedcba9876543210 (big endian)");
         break;
-    case 10: // 64bit value le
-        ui->filterLineEdit->setPlaceholderText("0xfedcba9876543210");
+    case SearchKind::Value64LE:
+        ui->filterLineEdit->setPlaceholderText("0xfedcba9876543210 (little endian)");
+        break;
+    case SearchKind::CryptographicMaterial:
+        // this search kind does not take any input.
+        ui->filterLineEdit->setPlaceholderText("");
+        ui->filterLineEdit->setEnabled(false);
+        break;
+    case SearchKind::MagicSignature:
+        // this search kind does not take any input.
+        ui->filterLineEdit->setPlaceholderText("");
+        ui->filterLineEdit->setEnabled(false);
         break;
     default:
         ui->filterLineEdit->setPlaceholderText("<No preview defined>");
+        break;
     }
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

- Implements cryptographic & magic search.
- Search via C api with the exception of ROP and ASM (old code was kept but moved in a private method, but called by the public method).
- Changed font to `inconsolada` of `code` & `data` column.
- Added missing search locations (`bin.segment`, `bin.segments`, `code`, `io.sky`, `analysis.fcn`, `analysis.bb`, `dbg.program`)