### PR TITLE
Add "Add Flag" menu option to the hex dump viewer's context menu

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1301,11 +1301,14 @@ RVA CutterCore::getLastFunctionInstruction(RVA addr)
     return lastBB ? rz_analysis_block_get_op_addr(lastBB, lastBB->ninstr - 1) : RVA_INVALID;
 }
 
-QString CutterCore::flagAt(RVA addr, bool exactAddrOnly)
+QString CutterCore::flagAt(RVA addr, bool getClosestFlag)
 {
     CORE_LOCK();
-    RzFlagItem *f = exactAddrOnly ? rz_flag_get_i(core->flags, addr)
-                                  : rz_flag_get_at(core->flags, addr, true);
+    // rz_flag_get_at and rz_flag_get_i can return different
+    // flags for the same address, so we must use rz_flag_get_i here
+    // instead of setting rz_flag_get_at's "closest" argument to false
+    RzFlagItem *f = getClosestFlag ? rz_flag_get_at(core->flags, addr, true)
+                                   : rz_flag_get_i(core->flags, addr);
     if (!f) {
         return {};
     }

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1305,7 +1305,7 @@ QString CutterCore::flagAt(RVA addr, bool getClosestFlag)
 {
     CORE_LOCK();
     // rz_flag_get_at and rz_flag_get_i can return different
-    // flags for the same address, so we must use rz_flag_get_i here
+    // flags for addresses containing multiple flags, so we must use rz_flag_get_i here
     // instead of setting rz_flag_get_at's "closest" argument to false
     RzFlagItem *f = getClosestFlag ? rz_flag_get_at(core->flags, addr, true)
                                    : rz_flag_get_i(core->flags, addr);

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1311,6 +1311,16 @@ QString CutterCore::flagAt(RVA addr)
     return core->flags->realnames && f->realname ? f->realname : f->name;
 }
 
+QString CutterCore::flagAtI(RVA addr)
+{
+    CORE_LOCK();
+    RzFlagItem *f = rz_flag_get_i(core->flags, addr);
+    if (!f) {
+        return {};
+    }
+    return core->flags->realnames && f->realname ? f->realname : f->name;
+}
+
 void CutterCore::createFunctionAt(RVA addr)
 {
     createFunctionAt(addr, "");

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1301,20 +1301,11 @@ RVA CutterCore::getLastFunctionInstruction(RVA addr)
     return lastBB ? rz_analysis_block_get_op_addr(lastBB, lastBB->ninstr - 1) : RVA_INVALID;
 }
 
-QString CutterCore::flagAt(RVA addr)
+QString CutterCore::flagAt(RVA addr, bool exactAddrOnly)
 {
     CORE_LOCK();
-    RzFlagItem *f = rz_flag_get_at(core->flags, addr, true);
-    if (!f) {
-        return {};
-    }
-    return core->flags->realnames && f->realname ? f->realname : f->name;
-}
-
-QString CutterCore::flagAtI(RVA addr)
-{
-    CORE_LOCK();
-    RzFlagItem *f = rz_flag_get_i(core->flags, addr);
+    RzFlagItem *f = exactAddrOnly ? rz_flag_get_i(core->flags, addr)
+                                  : rz_flag_get_at(core->flags, addr, true);
     if (!f) {
         return {};
     }

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -234,7 +234,7 @@ public:
     RVA getFunctionStart(RVA addr);
     RVA getFunctionEnd(RVA addr);
     RVA getLastFunctionInstruction(RVA addr);
-    QString flagAt(RVA addr, bool exactAddrOnly = false);
+    QString flagAt(RVA addr, bool getClosestFlag = true);
     void createFunctionAt(RVA addr);
     void createFunctionAt(RVA addr, QString name);
     QStringList getDisassemblyPreview(RVA address, int num_of_lines);

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -235,6 +235,7 @@ public:
     RVA getFunctionEnd(RVA addr);
     RVA getLastFunctionInstruction(RVA addr);
     QString flagAt(RVA addr);
+    QString flagAtI(RVA addr);
     void createFunctionAt(RVA addr);
     void createFunctionAt(RVA addr, QString name);
     QStringList getDisassemblyPreview(RVA address, int num_of_lines);

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -234,8 +234,7 @@ public:
     RVA getFunctionStart(RVA addr);
     RVA getFunctionEnd(RVA addr);
     RVA getLastFunctionInstruction(RVA addr);
-    QString flagAt(RVA addr);
-    QString flagAtI(RVA addr);
+    QString flagAt(RVA addr, bool exactAddrOnly = false);
     void createFunctionAt(RVA addr);
     void createFunctionAt(RVA addr, QString name);
     QStringList getDisassemblyPreview(RVA address, int num_of_lines);

--- a/src/dialogs/FlagDialog.cpp
+++ b/src/dialogs/FlagDialog.cpp
@@ -4,23 +4,31 @@
 #include <QIntValidator>
 #include "core/Cutter.h"
 
-FlagDialog::FlagDialog(RVA offset, QWidget *parent)
-    : QDialog(parent), ui(new Ui::FlagDialog), offset(offset), flagName(""), flagOffset(RVA_INVALID)
+FlagDialog::FlagDialog(RVA offset, QWidget *parent, QString flagNameHint)
+    : QDialog(parent),
+      ui(new Ui::FlagDialog),
+      offset(offset),
+      flagName(flagNameHint),
+      flagOffset(RVA_INVALID)
 {
     // Setup UI
     ui->setupUi(this);
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
-    RzFlagItem *flag = rz_flag_get_i(Core()->core()->flags, offset);
-    if (flag) {
-        flagName = QString(flag->name);
-        flagOffset = flag->offset;
+    if (!flagName.isEmpty()) {
+        flagOffset = offset;
+    } else {
+        RzFlagItem *flag = rz_flag_get_i(Core()->core()->flags, offset);
+        if (flag) {
+            flagName = QString(flag->name);
+            flagOffset = flag->offset;
+        }
     }
 
     auto size_validator = new QIntValidator(ui->sizeEdit);
     size_validator->setBottom(1);
     ui->sizeEdit->setValidator(size_validator);
-    if (flag) {
-        ui->nameEdit->setText(flag->name);
+    if (!flagName.isEmpty()) {
+        ui->nameEdit->setText(flagName);
         ui->labelAction->setText(tr("Edit flag at %1").arg(RzAddressString(offset)));
     } else {
         ui->labelAction->setText(tr("Add flag at %1").arg(RzAddressString(offset)));
@@ -41,7 +49,7 @@ void FlagDialog::buttonBoxAccepted()
     if (name.isEmpty()) {
         if (flagOffset != RVA_INVALID) {
             // Empty name and flag exists -> delete the flag
-            Core()->delFlag(flagOffset);
+            Core()->delFlag(flagName);
         } else {
             // Flag was not existing and we gave an empty name, do nothing
         }

--- a/src/dialogs/FlagDialog.cpp
+++ b/src/dialogs/FlagDialog.cpp
@@ -17,7 +17,8 @@ FlagDialog::FlagDialog(RVA offset, QWidget *parent, QString flagNameHint)
     if (!flagName.isEmpty()) {
         flagOffset = offset;
     } else {
-        RzFlagItem *flag = rz_flag_get_i(Core()->core()->flags, offset);
+        RzCoreLocked core(Core());
+        RzFlagItem *flag = rz_flag_get_i(core->flags, offset);
         if (flag) {
             flagName = QString(flag->name);
             flagOffset = flag->offset;

--- a/src/dialogs/FlagDialog.h
+++ b/src/dialogs/FlagDialog.h
@@ -14,7 +14,7 @@ class FlagDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit FlagDialog(RVA offset, QWidget *parent = nullptr);
+    explicit FlagDialog(RVA offset, QWidget *parent = nullptr, QString flagNameHint = {});
     ~FlagDialog();
 
 private slots:

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -137,8 +137,7 @@ HexWidget::HexWidget(QWidget *parent)
             new QAction(tr("Add flag at %1").arg(RzAddressString(getLocationAddress())), this);
     actionAddFlag->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
     actionAddFlag->setShortcut(Qt::Key_N);
-    connect(actionAddFlag, &QAction::triggered, this,
-            [this]() { onActionAddFlagTriggered(actionAddFlag->data().toString()); });
+    connect(actionAddFlag, &QAction::triggered, this, &HexWidget::onActionAddFlagTriggered);
     connect(this, &HexWidget::positionChanged, this, [this](RVA pos) {
         RzAnalysisFunction *fcn = Core()->functionAt(pos);
         if (fcn) {
@@ -1270,8 +1269,9 @@ void HexWidget::onActionDeleteCommentTriggered()
     refresh();
 }
 
-void HexWidget::onActionAddFlagTriggered(QString flagNameHint)
+void HexWidget::onActionAddFlagTriggered()
 {
+    QString flagNameHint = actionAddFlag->data().toString();
     if (FlagDialog(cursor.address, this, flagNameHint).exec()) {
         refresh();
     }

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -1232,6 +1232,7 @@ void HexWidget::onActionAddCommentTriggered()
 {
     uint64_t addr = cursor.address;
     CommentsDialog::addOrEditComment(addr, this);
+    refresh();
 }
 
 // slot for deleting comment action

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -3,6 +3,7 @@
 #include "Configuration.h"
 #include "dialogs/WriteCommandsDialogs.h"
 #include "dialogs/CommentsDialog.h"
+#include "dialogs/FlagDialog.h"
 
 #include <QPainter>
 #include <QPaintEvent>
@@ -130,6 +131,14 @@ HexWidget::HexWidget(QWidget *parent)
     actionComment->setShortcut(Qt::Key_Semicolon);
     connect(actionComment, &QAction::triggered, this, &HexWidget::onActionAddCommentTriggered);
     addAction(actionComment);
+
+    // Add flag option
+    actionAddFlag = new QAction(
+            tr("Add flag at %1 (used here)").arg(RzAddressString(getLocationAddress())), this);
+    actionAddFlag->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+    actionAddFlag->setShortcut(Qt::Key_N);
+    connect(actionAddFlag, &QAction::triggered, this, &HexWidget::onActionAddFlagTriggered);
+    addAction(actionAddFlag);
 
     // delete comment option
     actionDeleteComment = new QAction(tr("Delete Comment"), this);
@@ -1161,6 +1170,15 @@ void HexWidget::contextMenuEvent(QContextMenuEvent *event)
         actionComment->setText(tr("Edit Comment"));
     }
 
+    RzFlagItem *flag = rz_flag_get_i(Core()->core()->flags, cursor.address);
+
+    if (flag) {
+        actionAddFlag->setText(tr("Rename flag \"%1\" (used here)").arg(flag->name));
+    } else {
+        actionAddFlag->setText(
+                tr("Add flag at %1 (used here)").arg(RzAddressString(cursor.address)));
+    }
+
     if (!ioModesController.canWrite()) {
         actionKeyboardEdit->setChecked(false);
     }
@@ -1240,6 +1258,16 @@ void HexWidget::onActionDeleteCommentTriggered()
 {
     uint64_t addr = cursor.address;
     Core()->delComment(addr);
+}
+
+void HexWidget::onActionAddFlagTriggered()
+{
+    FlagDialog dialog(cursor.address, this);
+    bool ok = false;
+    ok = dialog.exec();
+    if (ok) {
+        refresh();
+    }
 }
 
 void HexWidget::onRangeDialogAccepted()

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -1178,19 +1178,13 @@ void HexWidget::contextMenuEvent(QContextMenuEvent *event)
         actionComment->setText(tr("Edit Comment"));
     }
 
-    RzFlagItem *flag = rz_flag_get_i(Core()->core()->flags, cursor.address);
+    QString flag = Core()->flagAtI(cursor.address);
 
-    if (flag) {
-        QString flagName;
-        if (Config()->getConfigBool("asm.flags.real") && flag->realname) {
-            flagName = flag->realname;
-        } else {
-            flagName = flag->name;
-        }
-        actionAddFlag->setText(tr("Rename flag \"%1\" (used here)").arg(flagName));
-    } else {
+    if (flag.isEmpty() || flag.isNull()) {
         actionAddFlag->setText(
                 tr("Add flag at %1 (used here)").arg(RzAddressString(cursor.address)));
+    } else {
+        actionAddFlag->setText(tr("Rename flag \"%1\" (used here)").arg(flag));
     }
 
     if (!ioModesController.canWrite()) {

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -137,7 +137,8 @@ HexWidget::HexWidget(QWidget *parent)
             new QAction(tr("Add flag at %1").arg(RzAddressString(getLocationAddress())), this);
     actionAddFlag->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
     actionAddFlag->setShortcut(Qt::Key_N);
-    connect(actionAddFlag, &QAction::triggered, this, &HexWidget::onActionAddFlagTriggered);
+    connect(actionAddFlag, &QAction::triggered, this,
+            [this]() { onActionAddFlagTriggered(actionAddFlag->data().toString()); });
     connect(this, &HexWidget::positionChanged, this, [this](RVA pos) {
         RzAnalysisFunction *fcn = Core()->functionAt(pos);
         if (fcn) {
@@ -1179,6 +1180,7 @@ void HexWidget::contextMenuEvent(QContextMenuEvent *event)
     }
 
     QString flag = Core()->flagAt(cursor.address, false);
+    actionAddFlag->setData(flag);
 
     if (flag.isEmpty()) {
         actionAddFlag->setText(tr("Add flag at %1").arg(RzAddressString(cursor.address)));
@@ -1268,7 +1270,7 @@ void HexWidget::onActionDeleteCommentTriggered()
     refresh();
 }
 
-void HexWidget::onActionAddFlagTriggered()
+void HexWidget::onActionAddFlagTriggered(QString flagNameHint)
 {
     if (FlagDialog(cursor.address, this).exec()) {
         refresh();

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -1186,7 +1186,7 @@ void HexWidget::contextMenuEvent(QContextMenuEvent *event)
             flagName = flag->realname;
         } else {
             flagName = flag->name;
-        };
+        }
         actionAddFlag->setText(tr("Rename flag \"%1\" (used here)").arg(flagName));
     } else {
         actionAddFlag->setText(

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -133,8 +133,8 @@ HexWidget::HexWidget(QWidget *parent)
     addAction(actionComment);
 
     // Add flag option
-    actionAddFlag = new QAction(
-            tr("Add flag at %1").arg(RzAddressString(getLocationAddress())), this);
+    actionAddFlag =
+            new QAction(tr("Add flag at %1").arg(RzAddressString(getLocationAddress())), this);
     actionAddFlag->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
     actionAddFlag->setShortcut(Qt::Key_N);
     connect(actionAddFlag, &QAction::triggered, this, &HexWidget::onActionAddFlagTriggered);
@@ -1170,7 +1170,7 @@ void HexWidget::contextMenuEvent(QContextMenuEvent *event)
 
     QString comment = Core()->getCommentAt(cursor.address);
 
-    if (comment.isNull() || comment.isEmpty()) {
+    if (comment.isEmpty()) {
         actionDeleteComment->setVisible(false);
         actionComment->setText(tr("Add Comment"));
     } else {
@@ -1180,9 +1180,8 @@ void HexWidget::contextMenuEvent(QContextMenuEvent *event)
 
     QString flag = Core()->flagAt(cursor.address, false);
 
-    if (flag.isEmpty() || flag.isNull()) {
-        actionAddFlag->setText(
-                tr("Add flag at %1").arg(RzAddressString(cursor.address)));
+    if (flag.isEmpty()) {
+        actionAddFlag->setText(tr("Add flag at %1").arg(RzAddressString(cursor.address)));
     } else {
         actionAddFlag->setText(tr("Rename flag \"%1\"").arg(flag));
     }

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -1178,7 +1178,7 @@ void HexWidget::contextMenuEvent(QContextMenuEvent *event)
         actionComment->setText(tr("Edit Comment"));
     }
 
-    QString flag = Core()->flagAtI(cursor.address);
+    QString flag = Core()->flagAt(cursor.address, true);
 
     if (flag.isEmpty() || flag.isNull()) {
         actionAddFlag->setText(

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -1181,7 +1181,13 @@ void HexWidget::contextMenuEvent(QContextMenuEvent *event)
     RzFlagItem *flag = rz_flag_get_i(Core()->core()->flags, cursor.address);
 
     if (flag) {
-        actionAddFlag->setText(tr("Rename flag \"%1\" (used here)").arg(flag->name));
+        QString flagName;
+        if (Config()->getConfigBool("asm.flags.real") && flag->realname) {
+            flagName = flag->realname;
+        } else {
+            flagName = flag->name;
+        };
+        actionAddFlag->setText(tr("Rename flag \"%1\" (used here)").arg(flagName));
     } else {
         actionAddFlag->setText(
                 tr("Add flag at %1 (used here)").arg(RzAddressString(cursor.address)));

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -1272,6 +1272,7 @@ void HexWidget::onActionDeleteCommentTriggered()
 {
     uint64_t addr = cursor.address;
     Core()->delComment(addr);
+    refresh();
 }
 
 void HexWidget::onActionAddFlagTriggered()

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -1272,7 +1272,7 @@ void HexWidget::onActionDeleteCommentTriggered()
 
 void HexWidget::onActionAddFlagTriggered(QString flagNameHint)
 {
-    if (FlagDialog(cursor.address, this).exec()) {
+    if (FlagDialog(cursor.address, this, flagNameHint).exec()) {
         refresh();
     }
 }

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -1178,7 +1178,7 @@ void HexWidget::contextMenuEvent(QContextMenuEvent *event)
         actionComment->setText(tr("Edit Comment"));
     }
 
-    QString flag = Core()->flagAt(cursor.address, true);
+    QString flag = Core()->flagAt(cursor.address, false);
 
     if (flag.isEmpty() || flag.isNull()) {
         actionAddFlag->setText(

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -134,7 +134,7 @@ HexWidget::HexWidget(QWidget *parent)
 
     // Add flag option
     actionAddFlag = new QAction(
-            tr("Add flag at %1 (used here)").arg(RzAddressString(getLocationAddress())), this);
+            tr("Add flag at %1").arg(RzAddressString(getLocationAddress())), this);
     actionAddFlag->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
     actionAddFlag->setShortcut(Qt::Key_N);
     connect(actionAddFlag, &QAction::triggered, this, &HexWidget::onActionAddFlagTriggered);
@@ -1182,9 +1182,9 @@ void HexWidget::contextMenuEvent(QContextMenuEvent *event)
 
     if (flag.isEmpty() || flag.isNull()) {
         actionAddFlag->setText(
-                tr("Add flag at %1 (used here)").arg(RzAddressString(cursor.address)));
+                tr("Add flag at %1").arg(RzAddressString(cursor.address)));
     } else {
-        actionAddFlag->setText(tr("Rename flag \"%1\" (used here)").arg(flag));
+        actionAddFlag->setText(tr("Rename flag \"%1\"").arg(flag));
     }
 
     if (!ioModesController.canWrite()) {
@@ -1271,10 +1271,7 @@ void HexWidget::onActionDeleteCommentTriggered()
 
 void HexWidget::onActionAddFlagTriggered()
 {
-    FlagDialog dialog(cursor.address, this);
-    bool ok = false;
-    ok = dialog.exec();
-    if (ok) {
+    if (FlagDialog(cursor.address, this).exec()) {
         refresh();
     }
 }

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -138,6 +138,14 @@ HexWidget::HexWidget(QWidget *parent)
     actionAddFlag->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
     actionAddFlag->setShortcut(Qt::Key_N);
     connect(actionAddFlag, &QAction::triggered, this, &HexWidget::onActionAddFlagTriggered);
+    connect(this, &HexWidget::positionChanged, this, [this](RVA pos) {
+        RzAnalysisFunction *fcn = Core()->functionAt(pos);
+        if (fcn) {
+            actionAddFlag->setVisible(false);
+        } else {
+            actionAddFlag->setVisible(true);
+        }
+    });
     addAction(actionAddFlag);
 
     // delete comment option

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -383,6 +383,7 @@ private slots:
     void onRangeDialogAccepted();
     void onActionAddCommentTriggered();
     void onActionDeleteCommentTriggered();
+    void onActionAddFlagTriggered();
 
     // Write command slots
     void w_writeString();
@@ -577,6 +578,7 @@ private:
     QAction *actionCopyAddress;
     QAction *actionComment;
     QAction *actionDeleteComment;
+    QAction *actionAddFlag;
     QAction *actionSelectRange;
     QAction *actionKeyboardEdit;
     QList<QAction *> actionsWriteString;

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -383,7 +383,7 @@ private slots:
     void onRangeDialogAccepted();
     void onActionAddCommentTriggered();
     void onActionDeleteCommentTriggered();
-    void onActionAddFlagTriggered(QString flagNameHint);
+    void onActionAddFlagTriggered();
 
     // Write command slots
     void w_writeString();

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -383,7 +383,7 @@ private slots:
     void onRangeDialogAccepted();
     void onActionAddCommentTriggered();
     void onActionDeleteCommentTriggered();
-    void onActionAddFlagTriggered();
+    void onActionAddFlagTriggered(QString flagNameHint);
 
     // Write command slots
     void w_writeString();


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [X] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Adds an "Add Flag" menu option to the hex dump viewer's context menu, with an associated shortcut (same shortcut as the disassembly viewer equivalent).

The menu option and shortcut are disabled if the current cursor position is on a function's address, since the flag editor behaves oddly in that case.

I also took the liberty of making the "Add/Delete Comment" menu options refresh the hex viewer, to provide immediate feedback for the user's actions.

**Test plan (required)**

- Set flag with context menu option.
- Set flag with shortcut.
- Edit flag with context menu option.
- Edit flag with shortcut.
- Verified that menu option doesn't appear and the shortcut does nothing while the cursor is pointing to a function's address.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

Closes #2932.
