### PR TITLE
Bump GHA runner Ubuntu version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,7 +587,7 @@ jobs:
         ]
         include:
           - name: linux-x86_64 
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             artifact-job: build-linux
             artifact-output: artifact_linux
           - name: macos-arm64


### PR DESCRIPTION
20.04 not available for direct usage anymore.

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Switch to 22.04 since 20.04 isn't available anymore.

The main appimage build job still using 20.04 docker image isn't affected. Not changing that to maximize compatibility. 
It's not worth the effort to set it up for plugin test job, since it prevents easily sharing steps between linux and non linux jobs.

**Test plan (required)**

Corresponding job succeeds. 

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
