### PR TITLE
Update disassembly color theme ligthness categories

### DIFF
--- a/src/common/ColorThemeWorker.cpp
+++ b/src/common/ColorThemeWorker.cpp
@@ -131,6 +131,9 @@ ColorThemeWorker::Theme ColorThemeWorker::getTheme(const QString &themeName) con
     if (Configuration::relevantThemes.contains(themeName)) {
         colorFlags = Configuration::relevantThemes[themeName];
     }
+    if (colorFlags == DualColor) {
+        colorFlags = Config()->windowColorIsDark() ? DarkFlag : LightFlag;
+    }
 
     for (auto &it : cutterSpecificOptions) {
         theme.insert(it, QColor(Configuration::cutterOptionColors[it][colorFlags]));

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -21,16 +21,20 @@
  * and for light - only light ones.
  */
 const QHash<QString, ColorFlags> Configuration::relevantThemes = {
-    { "ayu", DarkFlag },       { "basic", DarkFlag },     { "behelit", DarkFlag },
-    { "bold", DarkFlag },      { "bright", DarkFlag },    { "consonance", DarkFlag },
-    { "darkda", DarkFlag },    { "defragger", DarkFlag }, { "focus", DarkFlag },
-    { "gentoo", DarkFlag },    { "lima", DarkFlag },      { "monokai", DarkFlag },
-    { "ogray", DarkFlag },     { "onedark", DarkFlag },   { "pink", DarkFlag },
-    { "rasta", DarkFlag },     { "sepia", DarkFlag },     { "smyck", DarkFlag },
-    { "solarized", DarkFlag }, { "twilight", DarkFlag },  { "white2", DarkFlag },
-    { "xvilka", DarkFlag },    { "zenburn", DarkFlag },   { "cga", LightFlag },
-    { "cutter", LightFlag },   { "dark", LightFlag },     { "gb", LightFlag },
-    { "matrix", LightFlag },   { "tango", LightFlag },    { "white", LightFlag }
+    { "ayu", DarkFlag },        { "basic", DarkFlag },   { "behelit", DarkFlag },
+    { "bold", DarkFlag },       { "bright", DarkFlag },  { "cga", DarkFlag },
+    { "consonance", DarkFlag }, { "darkda", DarkFlag },  { "default", DarkFlag },
+    { "defragger", DarkFlag },  { "focus", DarkFlag },   { "gb", DarkFlag },
+    { "gentoo", DarkFlag },     { "lima", DarkFlag },    { "mars", DarkFlag },
+    { "monokai", DarkFlag },    { "nord", DarkFlag },    { "ogray", DarkFlag },
+    { "onedark", DarkFlag },    { "pink", DarkFlag },    { "rasta", DarkFlag },
+    { "sepia", DarkFlag },      { "smyck", DarkFlag },   { "solarized", DarkFlag },
+    { "twilight", DarkFlag },   { "xvilka", DarkFlag },  { "zenburn", DarkFlag },
+
+    { "dark", DualColor },      { "durian", DualColor }, { "tango", DualColor },
+    { "white2", DualColor },
+
+    { "cutter", LightFlag },    { "matrix", LightFlag }, { "white", LightFlag },
 };
 static const QString DEFAULT_LIGHT_COLOR_THEME = "cutter";
 static const QString DEFAULT_DARK_COLOR_THEME = "ayu";

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -21,6 +21,7 @@ class QTextDocument;
 enum ColorFlags {
     LightFlag = 1,
     DarkFlag = 2,
+    DualColor = LightFlag | DarkFlag,
 };
 
 struct CutterInterfaceTheme


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Update disassembly color theme categories. Related to observations from #2971 + the new rizin color themes.

* cga: light -> dark
* default: unspecified -> dark
* gb: light -> dark
* mars: dark (new)
* nord: dark (new)
* dark: light -> dual (equally bad in both)
* durian: dual(new)
* tango: light -> dual
* white2: dark -> dual (better in light)

Fix bug causing unrecognized color themes to have black background. Non rizin GUI color list contains only values for dark and light. Picking a color theme which is marked Dark+Light, resulted in use of missing color. For such color themes pick background based on Qt theme lightness.  Initially observed it for the themes I just assigned to dual, but it could have happened before for unrecognized themes which are also categorized as dual by default.

After rechecking the notes in #2971 seems like this bug was the cause for durian background problems I observed then.

**Test plan (required)**

Go through all the available disassembly color themes with dark and light theme active. Make sure the text is somewhat readable. 

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
