### PR TITLE
Update rizin and string search API usage

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -4199,15 +4199,17 @@ QList<SearchDescription> CutterCore::getAllSearch(QString searchFor, SearchKind 
         break;
     }
     case SearchKind::String:
-        hits = rz_core_search_string(core, userOpts.get(), searchFor.toUtf8().constData(),
-                                     RZ_REGEX_DEFAULT, RZ_STRING_ENC_GUESS);
+    case SearchKind::StringCaseInsensitive: {
+        const auto str = searchFor.toUtf8();
+        hits = rz_core_search_string(core, userOpts.get(), str.constData(), str.size(),
+                                     kind == SearchKind::StringCaseInsensitive
+                                             ? RZ_REGEX_CASELESS | RZ_REGEX_LITERAL
+                                             : RZ_REGEX_LITERAL,
+                                     RZ_STRING_ENC_GUESS);
         break;
-    case SearchKind::StringCaseInsensitive:
-        hits = rz_core_search_string(core, userOpts.get(), searchFor.toUtf8().constData(),
-                                     RZ_REGEX_CASELESS | RZ_REGEX_LITERAL, RZ_STRING_ENC_GUESS);
-        break;
+    }
     case SearchKind::StringRegexExtended:
-        hits = rz_core_search_string(core, userOpts.get(), searchFor.toUtf8().constData(),
+        hits = rz_core_search_string(core, userOpts.get(), searchFor.toUtf8().constData(), 0,
                                      RZ_REGEX_EXTENDED, RZ_STRING_ENC_GUESS);
         break;
     case SearchKind::CryptographicMaterial:


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Relevant API change in Rizin:
fe36e213e2ed4c463daa65d8ad8c819d46e8da72

This also fixes string literals to be searched as literals rather than regex.

**Test plan (required)**

build with latest rizin and search string literals, both case-sensitive and insensitive.
