### PR TITLE
Remove twxs.cmake from VS Code recommended extensions list

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
 	"recommendations": [
 		"ms-vscode.cpptools",
-		"ms-vscode.cmake-tools",
-		"twxs.cmake"
+		"ms-vscode.cmake-tools"
 	]
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [X] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

`twxs.cmake` hasn't been updated in 8 years and has been essentially deprecated in favor of Microsoft's CMake Tools, now that it provides CMake language support. CMake Tools is already in the recommended extensions list, so there's no reason to recommend `twxs.cmake` as well.

**Test plan (required)**

Verified that VS Code no longer nags me to install an outdated extension.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

None.
