### PR TITLE
Add "Add Breakpoint" menu option and shortcut to the X-Ref viewer

### DIFF
--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -56,6 +56,37 @@ XrefsDialog::XrefsDialog(MainWindow *parent, bool hideXrefFrom)
         qhelpers::emitColumnChanged(&fromModel, XrefModel::COMMENT);
     });
 
+    auto makeBreakpointAction = [this](AddressableItemList<> *list, const XrefModel &model) {
+        QAction *actionToggleBreakpoint = new QAction(tr("Add Breakpoint"), this);
+        actionToggleBreakpoint->setShortcut({ Qt::Key_F2 });
+        actionToggleBreakpoint->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+        auto *contextMenu = list->getItemContextMenu();
+        contextMenu->addAction(actionToggleBreakpoint);
+        list->addAction(actionToggleBreakpoint);
+        connect(actionToggleBreakpoint, &QAction::triggered, this, [list, &model]() {
+            auto index = list->currentIndex();
+            if (!index.isValid()) {
+                return;
+            }
+            Core()->toggleBreakpoint(model.address(index));
+        });
+        connect(contextMenu, &AddressableItemContextMenu::aboutToShow, this,
+                [list, &model, actionToggleBreakpoint]() {
+                    auto index = list->currentIndex();
+                    if (!index.isValid()) {
+                        return;
+                    }
+                    if (Core()->breakpointIndexAt(model.address(index)) < 0) {
+                        actionToggleBreakpoint->setText(tr("Add Breakpoint"));
+                    } else {
+                        actionToggleBreakpoint->setText(tr("Remove Breakpoint"));
+                    }
+                });
+    };
+
+    makeBreakpointAction(ui->toTreeWidget, toModel);
+    makeBreakpointAction(ui->fromTreeWidget, fromModel);
+
     if (hideXrefFrom) {
         hideXrefFromSection();
     }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [X] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Adds an "Add Breakpoint" context menu option and shortcut for the X-Ref viewer, which is usable within the "to" and "from" widgets. The same shortcut and context menu option can remove breakpoints as well. Saves people the trouble of having to switch between the X-Ref viewer and disassembly viewer to toggle breakpoints.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

- Added and removed breakpoint using context menu option, observed that the breakpoint is placed at the correct address and the menu option changes accordingly.

- Added and removed breakpoint using shortcut, observed that the breakpoint is placed at the correct address and the menu option changes accordingly.

- Observed that everything works as expected while debugging.

https://github.com/user-attachments/assets/ed4b82d7-031d-4351-9e6e-21510e89ecf6

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

Closes #2658.
