### PR TITLE
Addressable context menu improvements

### DIFF
--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -20,6 +20,9 @@ XrefsDialog::XrefsDialog(MainWindow *parent, bool hideXrefFrom)
     ui->toTreeWidget->setModel(&toModel);
     ui->fromTreeWidget->setModel(&fromModel);
 
+    ui->toTreeWidget->getItemContextMenu()->toggleBreakpointAction(true);
+    ui->fromTreeWidget->getItemContextMenu()->toggleBreakpointAction(true);
+
     // Modify the splitter's location to show more Disassembly instead of empty space. Not possible
     // via Designer
     ui->splitter->setSizes(QList<int>() << 300 << 400);

--- a/src/menus/AddressableItemContextMenu.cpp
+++ b/src/menus/AddressableItemContextMenu.cpp
@@ -16,7 +16,7 @@ AddressableItemContextMenu::AddressableItemContextMenu(QWidget *parent, MainWind
     actionShowInMenu = new QAction(tr("Show in"), this);
     actionCopyAddress = new QAction(tr("Copy address"), this);
     actionShowXrefs = new QAction(tr("Show X-Refs"), this);
-    actionAddcomment = new QAction(tr("Add comment"), this);
+    actionAddComment = new QAction(tr("Add Comment"), this);
 
     connect(actionCopyAddress, &QAction::triggered, this,
             &AddressableItemContextMenu::onActionCopyAddress);
@@ -28,16 +28,16 @@ AddressableItemContextMenu::AddressableItemContextMenu(QWidget *parent, MainWind
     actionShowXrefs->setShortcut({ Qt::Key_X });
     actionShowXrefs->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
 
-    connect(actionAddcomment, &QAction::triggered, this,
+    connect(actionAddComment, &QAction::triggered, this,
             &AddressableItemContextMenu::onActionAddComment);
-    actionAddcomment->setShortcut({ Qt::Key_Semicolon });
-    actionAddcomment->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+    actionAddComment->setShortcut({ Qt::Key_Semicolon });
+    actionAddComment->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
 
     addAction(actionShowInMenu);
     addAction(actionCopyAddress);
     addAction(actionShowXrefs);
     addSeparator();
-    addAction(actionAddcomment);
+    addAction(actionAddComment);
 
     addSeparator();
     pluginMenu = mainWindow->getContextMenuExtensions(MainWindow::ContextMenuType::Addressable);
@@ -98,6 +98,11 @@ void AddressableItemContextMenu::onActionAddComment()
 
 void AddressableItemContextMenu::aboutToShowSlot()
 {
+    if (QString comment = Core()->getCommentAt(offset); comment.isEmpty() || comment.isNull()) {
+        actionAddComment->setText(tr("Add Comment"));
+    } else {
+        actionAddComment->setText(tr("Edit Comment"));
+    }
     if (actionShowInMenu->menu()) {
         actionShowInMenu->menu()->deleteLater();
     }
@@ -115,5 +120,5 @@ void AddressableItemContextMenu::setHasTarget(bool hasTarget)
     actionShowInMenu->setEnabled(hasTarget);
     actionCopyAddress->setEnabled(hasTarget);
     actionShowXrefs->setEnabled(hasTarget);
-    actionAddcomment->setEnabled(hasTarget);
+    actionAddComment->setEnabled(hasTarget);
 }

--- a/src/menus/AddressableItemContextMenu.cpp
+++ b/src/menus/AddressableItemContextMenu.cpp
@@ -83,6 +83,8 @@ void AddressableItemContextMenu::clearTarget()
 void AddressableItemContextMenu::toggleBreakpointAction(bool enabled)
 {
     breakpointActionEnabled = enabled;
+    // Update actionToggleBreakpoint visibility
+    setHasTarget(hasTarget);
 }
 
 void AddressableItemContextMenu::onActionCopyAddress()

--- a/src/menus/AddressableItemContextMenu.cpp
+++ b/src/menus/AddressableItemContextMenu.cpp
@@ -117,7 +117,7 @@ void AddressableItemContextMenu::onActionToggleBreakpoint()
 
 void AddressableItemContextMenu::aboutToShowSlot()
 {
-    if (QString comment = Core()->getCommentAt(offset); comment.isEmpty() || comment.isNull()) {
+    if (Core()->getCommentAt(offset).isEmpty()) {
         actionAddComment->setText(tr("Add Comment"));
     } else {
         actionAddComment->setText(tr("Edit Comment"));

--- a/src/menus/AddressableItemContextMenu.cpp
+++ b/src/menus/AddressableItemContextMenu.cpp
@@ -80,6 +80,11 @@ void AddressableItemContextMenu::clearTarget()
     setHasTarget(false);
 }
 
+void AddressableItemContextMenu::toggleBreakpointAction(bool enabled)
+{
+    breakpointActionEnabled = enabled;
+}
+
 void AddressableItemContextMenu::onActionCopyAddress()
 {
     auto clipboard = QApplication::clipboard();
@@ -140,5 +145,6 @@ void AddressableItemContextMenu::setHasTarget(bool hasTarget)
     actionCopyAddress->setEnabled(hasTarget);
     actionShowXrefs->setEnabled(hasTarget);
     actionAddComment->setEnabled(hasTarget);
-    actionToggleBreakpoint->setEnabled(hasTarget);
+    actionToggleBreakpoint->setEnabled(hasTarget && breakpointActionEnabled);
+    actionToggleBreakpoint->setVisible(hasTarget && breakpointActionEnabled);
 }

--- a/src/menus/AddressableItemContextMenu.cpp
+++ b/src/menus/AddressableItemContextMenu.cpp
@@ -17,6 +17,7 @@ AddressableItemContextMenu::AddressableItemContextMenu(QWidget *parent, MainWind
     actionCopyAddress = new QAction(tr("Copy address"), this);
     actionShowXrefs = new QAction(tr("Show X-Refs"), this);
     actionAddComment = new QAction(tr("Add Comment"), this);
+    actionToggleBreakpoint = new QAction(tr("Add Breakpoint"), this);
 
     connect(actionCopyAddress, &QAction::triggered, this,
             &AddressableItemContextMenu::onActionCopyAddress);
@@ -33,11 +34,17 @@ AddressableItemContextMenu::AddressableItemContextMenu(QWidget *parent, MainWind
     actionAddComment->setShortcut({ Qt::Key_Semicolon });
     actionAddComment->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
 
+    connect(actionToggleBreakpoint, &QAction::triggered, this,
+            &AddressableItemContextMenu::onActionToggleBreakpoint);
+    actionToggleBreakpoint->setShortcut({ Qt::Key_F2 });
+    actionToggleBreakpoint->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+
     addAction(actionShowInMenu);
     addAction(actionCopyAddress);
     addAction(actionShowXrefs);
     addSeparator();
     addAction(actionAddComment);
+    addAction(actionToggleBreakpoint);
 
     addSeparator();
     pluginMenu = mainWindow->getContextMenuExtensions(MainWindow::ContextMenuType::Addressable);
@@ -96,6 +103,11 @@ void AddressableItemContextMenu::onActionAddComment()
     CommentsDialog::addOrEditComment(offset, this);
 }
 
+void AddressableItemContextMenu::onActionToggleBreakpoint()
+{
+    Core()->toggleBreakpoint(offset);
+}
+
 void AddressableItemContextMenu::aboutToShowSlot()
 {
     if (QString comment = Core()->getCommentAt(offset); comment.isEmpty() || comment.isNull()) {
@@ -103,6 +115,13 @@ void AddressableItemContextMenu::aboutToShowSlot()
     } else {
         actionAddComment->setText(tr("Edit Comment"));
     }
+
+    if (Core()->breakpointIndexAt(offset) < 0) {
+        actionToggleBreakpoint->setText(tr("Add Breakpoint"));
+    } else {
+        actionToggleBreakpoint->setText(tr("Remove Breakpoint"));
+    }
+
     if (actionShowInMenu->menu()) {
         actionShowInMenu->menu()->deleteLater();
     }
@@ -121,4 +140,5 @@ void AddressableItemContextMenu::setHasTarget(bool hasTarget)
     actionCopyAddress->setEnabled(hasTarget);
     actionShowXrefs->setEnabled(hasTarget);
     actionAddComment->setEnabled(hasTarget);
+    actionToggleBreakpoint->setEnabled(hasTarget);
 }

--- a/src/menus/AddressableItemContextMenu.h
+++ b/src/menus/AddressableItemContextMenu.h
@@ -31,6 +31,7 @@ private:
     void onActionCopyAddress();
     void onActionShowXrefs();
     void onActionAddComment();
+    void onActionToggleBreakpoint();
 
     virtual void aboutToShowSlot();
 
@@ -47,6 +48,7 @@ protected:
     QAction *actionCopyAddress;
     QAction *actionShowXrefs;
     QAction *actionAddComment;
+    QAction *actionToggleBreakpoint;
 
     QString name;
     bool wholeFunction = false;

--- a/src/menus/AddressableItemContextMenu.h
+++ b/src/menus/AddressableItemContextMenu.h
@@ -46,7 +46,7 @@ protected:
     QAction *actionShowInMenu;
     QAction *actionCopyAddress;
     QAction *actionShowXrefs;
-    QAction *actionAddcomment;
+    QAction *actionAddComment;
 
     QString name;
     bool wholeFunction = false;

--- a/src/menus/AddressableItemContextMenu.h
+++ b/src/menus/AddressableItemContextMenu.h
@@ -24,6 +24,7 @@ public slots:
     void setOffset(RVA offset);
     void setTarget(RVA offset, QString name = QString());
     void clearTarget();
+    void toggleBreakpointAction(bool enabled);
 signals:
     void xrefsTriggered();
 
@@ -52,5 +53,6 @@ protected:
 
     QString name;
     bool wholeFunction = false;
+    bool breakpointActionEnabled = false;
 };
 #endif // ADDRESSABLEITEMCONTEXTMENU_H

--- a/src/widgets/CallGraph.cpp
+++ b/src/widgets/CallGraph.cpp
@@ -41,6 +41,7 @@ CallGraphView::CallGraphView(CutterDockWidget *parent, MainWindow *main, bool gl
     : SimpleTextGraphView(parent, main), global(global), refreshDeferrer(nullptr, this)
 {
     enableAddresses(true);
+    addressableItemContextMenu.toggleBreakpointAction(true);
     refreshDeferrer.registerFor(parent);
     connect(&refreshDeferrer, &RefreshDeferrer::refreshNow, this, &CallGraphView::refreshView);
     connect(Core(), &CutterCore::refreshAll, this, &SimpleTextGraphView::refreshView);

--- a/src/widgets/ExportsWidget.cpp
+++ b/src/widgets/ExportsWidget.cpp
@@ -141,7 +141,23 @@ ExportsWidget::ExportsWidget(MainWindow *main) : ListDockWidget(main)
     exportsModel = new ExportsModel(&exports, this);
     exportsProxyModel = new ExportsProxyModel(exportsModel, this);
     setModels(exportsProxyModel);
-    ui->treeView->sortByColumn(ExportsModel::OffsetColumn, Qt::AscendingOrder);
+
+    AddressableItemList<> *treeView = ui->treeView;
+    treeView->sortByColumn(ExportsModel::OffsetColumn, Qt::AscendingOrder);
+    connect(treeView->selectionModel(), &QItemSelectionModel::selectionChanged, this, [this]() {
+        AddressableItemList<> *treeView = ui->treeView;
+        AddressableItemContextMenu *contextMenu = treeView->getItemContextMenu();
+        QModelIndex index = treeView->selectionModel()->currentIndex();
+        if (index.isValid()) {
+            QVariant variant = exportsProxyModel->data(index, ExportsModel::ExportDescriptionRole);
+            if (variant.canConvert<ExportDescription>()) {
+                auto exp = variant.value<ExportDescription>();
+                contextMenu->toggleBreakpointAction(exp.type == "FUNC");
+                return;
+            }
+        }
+        contextMenu->toggleBreakpointAction(false);
+    });
 
     QShortcut *toggle_shortcut = new QShortcut(widgetShortcuts["ExportsWidget"], main);
     connect(toggle_shortcut, &QShortcut::activated, this, [=]() { toggleDockWidget(true); });

--- a/src/widgets/ExportsWidget.cpp
+++ b/src/widgets/ExportsWidget.cpp
@@ -142,12 +142,10 @@ ExportsWidget::ExportsWidget(MainWindow *main) : ListDockWidget(main)
     exportsProxyModel = new ExportsProxyModel(exportsModel, this);
     setModels(exportsProxyModel);
 
-    AddressableItemList<> *treeView = ui->treeView;
-    treeView->sortByColumn(ExportsModel::OffsetColumn, Qt::AscendingOrder);
-    connect(treeView->selectionModel(), &QItemSelectionModel::selectionChanged, this, [this]() {
-        AddressableItemList<> *treeView = ui->treeView;
-        AddressableItemContextMenu *contextMenu = treeView->getItemContextMenu();
-        QModelIndex index = treeView->selectionModel()->currentIndex();
+    ui->treeView->sortByColumn(ExportsModel::OffsetColumn, Qt::AscendingOrder);
+    connect(ui->treeView->selectionModel(), &QItemSelectionModel::selectionChanged, this, [this]() {
+        AddressableItemContextMenu *contextMenu = ui->treeView->getItemContextMenu();
+        QModelIndex index = ui->treeView->selectionModel()->currentIndex();
         if (index.isValid()) {
             QVariant variant = exportsProxyModel->data(index, ExportsModel::ExportDescriptionRole);
             if (variant.canConvert<ExportDescription>()) {

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -528,13 +528,14 @@ FunctionsWidget::FunctionsWidget(MainWindow *main)
     connect(&actionUndefine, &QAction::triggered, this,
             &FunctionsWidget::onActionFunctionsUndefineTriggered);
 
-    auto itemConextMenu = ui->treeView->getItemContextMenu();
-    itemConextMenu->addSeparator();
-    itemConextMenu->addAction(&actionRename);
-    itemConextMenu->addAction(&actionUndefine);
-    itemConextMenu->setWholeFunction(true);
+    auto itemContextMenu = ui->treeView->getItemContextMenu();
+    itemContextMenu->toggleBreakpointAction(true);
+    itemContextMenu->addSeparator();
+    itemContextMenu->addAction(&actionRename);
+    itemContextMenu->addAction(&actionUndefine);
+    itemContextMenu->setWholeFunction(true);
 
-    ui->treeView->addActions(itemConextMenu->actions());
+    ui->treeView->addActions(itemContextMenu->actions());
 
     // Use a custom context menu on the dock title bar
     if (Config()->getFunctionsWidgetLayout() == "horizontal") {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [X] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Adds an "Add Breakpoint" action and shortcut to the addressable context menu, which can also remove a breakpoint if one is already present. Disabled by default, but enabled within the following widgets:

- XREF viewer
- Functions list
- Callgraph
- Exports (only on functions)

This PR also ensures that the "Add Comment" action is renamed to "Edit Comment" if a comment is already present.

**Test plan (required)**

- Observed that breakpoint action is present and functional in the XREF viewer, callgraph, and the functions list.

- Observed that breakpoint action is *not* present in stack, threads and registers widgets.

- Observed that breakpoint action is present and functional in the exports widget with many sort and filter combinations.


https://github.com/user-attachments/assets/5bec6c6f-ee72-411f-aafc-9abbb58334eb



<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

Closes #2658 and #2467.
