### PR TITLE
Exit crash

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -25,7 +25,7 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
       offset(0),
       canCopy(false),
       mainWindow(mainWindow),
-      ioModesController(mainWindow),
+      ioModesController(this),
       actionEditInstruction(this),
       actionNopInstruction(this),
       actionJmpReverse(this),

--- a/src/widgets/ConsoleWidget.h
+++ b/src/widgets/ConsoleWidget.h
@@ -100,6 +100,7 @@ private:
     FILE *origStdout = nullptr;
     FILE *origStdin = nullptr;
     QLocalSocket *pipeSocket = nullptr;
+    bool hasOutputRedirection = false;
 #ifdef Q_OS_WIN
     HANDLE hRead;
     HANDLE hWrite;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Turns out there were 2 bugs, with error message from one triggering the other.

**Test plan (required)**

In case of linux run in debugger, on macOS doing it the normal way should work
* Open cutter, open an executable, make sure there were no errors during exit

Testing the redirection fix requires some output during final exit process. Initially the output was caused by error from bad `free` call. After fixing first problem, I added some `qDebug() << "test"` to IoModesController desctructor but MainWindow will probably also work.

**Closing issues**

Closes #3463
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
