### PR TITLE
Make CutterCore::core API harder to misuse.

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -531,11 +531,12 @@ const QColor Configuration::getColor(const QString &name) const
 
 void Configuration::setColorTheme(const QString &theme)
 {
+    RzCoreLocked core = Core()->lock();
     if (theme == "default") {
-        rz_cons_pal_init(Core()->core()->cons->context);
+        rz_cons_pal_init(core->cons->context);
         s.setValue("theme", "default");
     } else {
-        rz_core_theme_load(Core()->core(), theme.toUtf8().constData());
+        rz_core_theme_load(core, theme.toUtf8().constData());
         s.setValue("theme", theme);
     }
 

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -133,7 +133,7 @@ bool DisassemblyPreview::showDebugValueTooltip(QWidget *parent, const QPoint &po
             mmio_lookup_context_t ctx;
             ctx.selected = selectedText;
             ctx.mmio_address = RVA_INVALID;
-            auto core = Core()->core();
+            auto core = Core()->lock();
             RzPlatformTarget *arch_target = core->analysis->arch_target;
             if (arch_target && arch_target->profile) {
                 ht_up_foreach(arch_target->profile->registers_mmio, lookup_mmio_addr_cb, &ctx);

--- a/src/common/RizinTask.cpp
+++ b/src/common/RizinTask.cpp
@@ -33,8 +33,9 @@ void RizinTask::taskFinished()
 
 RizinCmdTask::RizinCmdTask(const QString &cmd, bool transient)
 {
+    auto core = Core()->lock();
     task = rz_core_cmd_task_new(
-            Core()->core(), cmd.toLocal8Bit().constData(),
+            core, cmd.toLocal8Bit().constData(),
             static_cast<RzCoreCmdTaskFinished>(&RizinCmdTask::taskFinishedCallback), this);
     task->transient = transient;
     rz_core_task_incref(task);
@@ -75,8 +76,9 @@ const char *RizinCmdTask::getResultRaw()
 RizinFunctionTask::RizinFunctionTask(std::function<void *(RzCore *)> fcn, bool transient)
     : fcn(fcn), res(nullptr)
 {
+    auto core = Core()->lock();
     task = rz_core_function_task_new(
-            Core()->core(), static_cast<RzCoreTaskFunction>(&RizinFunctionTask::runner), this);
+            core, static_cast<RzCoreTaskFunction>(&RizinFunctionTask::runner), this);
     task->transient = transient;
     rz_core_task_incref(task);
 }

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -250,6 +250,11 @@ RzCoreLocked CutterCore::lock()
     return RzCoreLocked(this);
 }
 
+RzCoreLocked CutterCore::core()
+{
+    return lock();
+}
+
 QDir CutterCore::getCutterRCDefaultDirectory() const
 {
     return QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -154,12 +154,12 @@ RzCoreLocked::~RzCoreLocked()
     core->coreMutex.unlock();
 }
 
-RzCoreLocked::operator RzCore *() const
+RzCoreLocked::operator RzCore *() &
 {
     return core->core_;
 }
 
-RzCore *RzCoreLocked::operator->() const
+RzCore *RzCoreLocked::operator->() &
 {
     return core->core_;
 }
@@ -245,7 +245,7 @@ CutterCore::~CutterCore()
     uniqueInstance = nullptr;
 }
 
-RzCoreLocked CutterCore::core()
+RzCoreLocked CutterCore::lock()
 {
     return RzCoreLocked(this);
 }
@@ -528,7 +528,8 @@ QStringList CutterCore::autocomplete(const QString &cmd, RzLinePromptType prompt
     }
     buf.index = buf.length = std::min((int)(sizeof(buf.data) - 1), c);
 
-    RzLineNSCompletionResult *compr = rz_core_autocomplete_rzshell(core(), &buf, promptType);
+    CORE_LOCK();
+    RzLineNSCompletionResult *compr = rz_core_autocomplete_rzshell(core, &buf, promptType);
 
     QStringList r;
     auto optslen = rz_pvector_len(&compr->options);

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -713,6 +713,8 @@ public:
     QStringList getSectionList();
 
     RzCoreLocked lock();
+    CUTTER_DEPRECATED("Use CutterCore::lock instead")
+    RzCoreLocked core();
 
     static QString ansiEscapeToHtml(const QString &text);
     BasicBlockHighlighter *getBBHighlighter();

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -884,7 +884,7 @@ public:
     ~RzCoreLocked();
     operator RzCore *() &;
     RzCore *operator->() &;
-    // Reduce chance of following misuse of Core()->lock() 
+    // Reduce chance of following misuse of Core()->lock()
     // rizinStruct* foo = rizin_func(Core()->lock()->something, arg);
     operator RzCore *() && = delete;
     RzCore *operator->() && = delete;

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -712,7 +712,7 @@ public:
 
     QStringList getSectionList();
 
-    RzCoreLocked core();
+    RzCoreLocked lock();
 
     static QString ansiEscapeToHtml(const QString &text);
     BasicBlockHighlighter *getBBHighlighter();
@@ -882,8 +882,12 @@ public:
     RzCoreLocked &operator=(const RzCoreLocked &) = delete;
     RzCoreLocked(RzCoreLocked &&);
     ~RzCoreLocked();
-    operator RzCore *() const;
-    RzCore *operator->() const;
+    operator RzCore *() &;
+    RzCore *operator->() &;
+    // Reduce chance of following misuse of Core()->lock() 
+    // rizinStruct* foo = rizin_func(Core()->lock()->something, arg);
+    operator RzCore *() && = delete;
+    RzCore *operator->() && = delete;
 };
 
 #endif // CUTTER_H

--- a/src/dialogs/EditVariablesDialog.cpp
+++ b/src/dialogs/EditVariablesDialog.cpp
@@ -14,7 +14,8 @@ EditVariablesDialog::EditVariablesDialog(RVA offset, QString initialVar, QWidget
     connect<void (QComboBox::*)(int)>(ui->dropdownLocalVars, &QComboBox::currentIndexChanged, this,
                                       &EditVariablesDialog::updateFields);
 
-    RzAnalysisFunction *f = rz_analysis_get_function_at(Core()->core()->analysis, offset);
+    auto core = Core()->lock();
+    RzAnalysisFunction *f = rz_analysis_get_function_at(core->analysis, offset);
     QString fcnName = f->name;
     functionAddress = offset;
     setWindowTitle(tr("Edit Variables in Function: %1").arg(fcnName));

--- a/src/dialogs/GlobalVariableDialog.cpp
+++ b/src/dialogs/GlobalVariableDialog.cpp
@@ -14,8 +14,9 @@ GlobalVariableDialog::GlobalVariableDialog(RVA offset, QWidget *parent)
     // Setup UI
     ui->setupUi(this);
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
+    RzCoreLocked core = Core()->lock();
     RzAnalysisVarGlobal *globalVariable =
-            rz_analysis_var_global_get_byaddr_at(Core()->core()->analysis, offset);
+            rz_analysis_var_global_get_byaddr_at(core->analysis, offset);
     if (globalVariable) {
         globalVariableName = QString(globalVariable->name);
         globalVariableOffset = globalVariable->addr;

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -211,8 +211,9 @@ void DecompilerContextMenu::aboutToShowSlot()
             actionRenameThingHere.setText(
                     tr("Rename function %1").arg(QString(annotationHere->reference.name)));
         } else if (annotationHere->type == RZ_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE) {
+            RzCoreLocked  core = Core()->lock();
             RzFlagItem *flagDetails =
-                    rz_flag_get_i(Core()->core()->flags, annotationHere->reference.offset);
+                    rz_flag_get_i(core->flags, annotationHere->reference.offset);
             if (flagDetails) {
                 actionRenameThingHere.setText(tr("Rename %1").arg(QString(flagDetails->name)));
                 actionDeleteName.setText(tr("Remove %1").arg(QString(flagDetails->name)));
@@ -227,7 +228,8 @@ void DecompilerContextMenu::aboutToShowSlot()
     if (isReference()) {
         actionCopyReferenceAddress.setVisible(true);
         RVA referenceAddr = annotationHere->reference.offset;
-        RzFlagItem *flagDetails = rz_flag_get_i(Core()->core()->flags, referenceAddr);
+        RzCoreLocked  core = Core()->lock();
+        RzFlagItem *flagDetails = rz_flag_get_i(core->flags, referenceAddr);
         if (annotationHere->type == RZ_CODE_ANNOTATION_TYPE_FUNCTION_NAME) {
             actionCopyReferenceAddress.setText(tr("Copy address of %1 (%2)")
                                                        .arg(QString(annotationHere->reference.name),
@@ -400,7 +402,7 @@ void DecompilerContextMenu::actionRenameThingHereTriggered()
     if (!annotationHere || annotationHere->type == RZ_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE) {
         return;
     }
-    RzCoreLocked core = Core()->core();
+    RzCoreLocked core = Core()->lock();
     bool ok;
     auto type = annotationHere->type;
     if (type == RZ_CODE_ANNOTATION_TYPE_FUNCTION_NAME) {
@@ -568,7 +570,7 @@ void DecompilerContextMenu::updateTargetMenuActions()
         action->deleteLater();
     }
     showTargetMenuActions.clear();
-    RzCoreLocked core = Core()->core();
+    RzCoreLocked core = Core()->lock();
     if (isReference()) {
         QString name;
         QMenu *menu = nullptr;

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -211,9 +211,8 @@ void DecompilerContextMenu::aboutToShowSlot()
             actionRenameThingHere.setText(
                     tr("Rename function %1").arg(QString(annotationHere->reference.name)));
         } else if (annotationHere->type == RZ_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE) {
-            RzCoreLocked  core = Core()->lock();
-            RzFlagItem *flagDetails =
-                    rz_flag_get_i(core->flags, annotationHere->reference.offset);
+            RzCoreLocked core = Core()->lock();
+            RzFlagItem *flagDetails = rz_flag_get_i(core->flags, annotationHere->reference.offset);
             if (flagDetails) {
                 actionRenameThingHere.setText(tr("Rename %1").arg(QString(flagDetails->name)));
                 actionDeleteName.setText(tr("Remove %1").arg(QString(flagDetails->name)));
@@ -228,7 +227,7 @@ void DecompilerContextMenu::aboutToShowSlot()
     if (isReference()) {
         actionCopyReferenceAddress.setVisible(true);
         RVA referenceAddr = annotationHere->reference.offset;
-        RzCoreLocked  core = Core()->lock();
+        RzCoreLocked core = Core()->lock();
         RzFlagItem *flagDetails = rz_flag_get_i(core->flags, referenceAddr);
         if (annotationHere->type == RZ_CODE_ANNOTATION_TYPE_FUNCTION_NAME) {
             actionCopyReferenceAddress.setText(tr("Copy address of %1 (%2)")

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -387,8 +387,9 @@ void DisassemblyContextMenu::setCurHighlightedWord(const QString &text)
 DisassemblyContextMenu::ThingUsedHere DisassemblyContextMenu::getThingAt(ut64 address)
 {
     ThingUsedHere tuh;
+    auto core = Core()->lock();
     RzAnalysisFunction *fcn = Core()->functionAt(address);
-    RzFlagItem *flag = rz_flag_get_i(Core()->core()->flags, address);
+    RzFlagItem *flag = rz_flag_get_i(core->flags, address);
 
     // We will lookup through existing rizin types to find something relevant
 
@@ -1056,7 +1057,7 @@ void DisassemblyContextMenu::on_actionDeleteFunction_triggered()
 
 void DisassemblyContextMenu::on_actionEditFunction_triggered()
 {
-    RzCore *core = Core()->core();
+    auto core = Core()->lock();
     EditFunctionDialog dialog(parentForDialog());
     RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(core->analysis, offset, 0);
 

--- a/src/widgets/BacktraceWidget.cpp
+++ b/src/widgets/BacktraceWidget.cpp
@@ -44,7 +44,8 @@ void BacktraceWidget::updateContents()
 
 void BacktraceWidget::setBacktraceGrid()
 {
-    RzList *list = rz_core_debug_backtraces(Core()->core());
+    auto core = Core()->lock();
+    RzList *list = rz_core_debug_backtraces(core);
     int i = 0;
     RzListIter *iter;
     RzBacktrace *bt;

--- a/src/widgets/CallGraph.cpp
+++ b/src/widgets/CallGraph.cpp
@@ -112,8 +112,9 @@ void CallGraphView::loadCurrentGraph()
         addBlock(std::move(block), name, fcn->addr);
     };
 
+    auto core = Core()->lock();
     if (global) {
-        for (const auto &fcn : CutterRzList<RzAnalysisFunction>(Core()->core()->analysis->fcns)) {
+        for (const auto &fcn : CutterRzList<RzAnalysisFunction>(core->analysis->fcns)) {
             if (!isBetween(from, fcn->addr, to)) {
                 continue;
             }

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -251,8 +251,7 @@ void DebugActions::setButtonVisibleIfMainExists()
 {
     RzCoreLocked core = Core()->lock();
     // if main is not a flag we hide the continue until main button
-    if (!rz_flag_get(core->flags, "sym.main")
-        && !rz_flag_get(core->flags, "main")) {
+    if (!rz_flag_get(core->flags, "sym.main") && !rz_flag_get(core->flags, "main")) {
         actionContinueUntilMain->setVisible(false);
         continueUntilButton->setDefaultAction(actionContinueUntilCall);
     }

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -249,10 +249,10 @@ DebugActions::DebugActions(QToolBar *toolBar, MainWindow *main) : QObject(main),
 
 void DebugActions::setButtonVisibleIfMainExists()
 {
-    RzCoreLocked core(Core()->core());
+    RzCoreLocked core = Core()->lock();
     // if main is not a flag we hide the continue until main button
-    if (!rz_flag_get(Core()->core()->flags, "sym.main")
-        && !rz_flag_get(Core()->core()->flags, "main")) {
+    if (!rz_flag_get(core->flags, "sym.main")
+        && !rz_flag_get(core->flags, "main")) {
         actionContinueUntilMain->setVisible(false);
         continueUntilButton->setDefaultAction(actionContinueUntilCall);
     }
@@ -273,10 +273,10 @@ void DebugActions::showDebugWarning()
 
 void DebugActions::continueUntilMain()
 {
-    RzCoreLocked core(Core()->core());
-    RzFlagItem *main_flag = rz_flag_get(Core()->core()->flags, "sym.main");
+    RzCoreLocked core(Core()->lock());
+    RzFlagItem *main_flag = rz_flag_get(core->flags, "sym.main");
     if (!main_flag) {
-        main_flag = rz_flag_get(Core()->core()->flags, "main");
+        main_flag = rz_flag_get(core->flags, "main");
         if (!main_flag) {
             return;
         }

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -233,9 +233,10 @@ QVariant FunctionModel::data(const QModelIndex &index, int role) const
                 Core()->getDisassemblyPreview(function.offset, kMaxTooltipDisasmPreviewLines);
         QStringList summary {};
         {
+            auto core = Core()->lock();
             auto seeker = Core()->seekTemp(function.offset);
             auto strings = fromOwnedCharPtr(rz_core_print_disasm_strings(
-                    Core()->core(), RZ_CORE_DISASM_STRINGS_MODE_FUNCTION, 0, NULL));
+                    core, RZ_CORE_DISASM_STRINGS_MODE_FUNCTION, 0, NULL));
             summary = strings.split('\n', CUTTER_QT_SKIP_EMPTY_PARTS);
         }
 

--- a/src/widgets/TypesWidget.cpp
+++ b/src/widgets/TypesWidget.cpp
@@ -272,7 +272,8 @@ void TypesWidget::showTypesContextMenu(const QPoint &pt)
 
 void TypesWidget::on_actionExport_Types_triggered()
 {
-    char *str = rz_core_types_as_c_all(Core()->core(), true);
+    auto core = Core()->lock();
+    char *str = rz_core_types_as_c_all(core, true);
     if (!str) {
         return;
     }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Previously there were quite a few places doing something like:
```
rz_obj* foo = rz_func(Core()->core()->bar);
```
Extending the usage of rizin object past the lifetime of RzCoreLocked returned by `CutterCore::core`.

Less often but also wrong:
```
RzCore* foo = Core()->core();
```

Also rename `CutterCore::core` to `lock` partially to give hint about it's correct usage, partially  for aesthetic reason as  otherwise you end up with redundant lines like this:
`RzCoreLocked core = Core()->core()` or `auto core = Core()->core()`.

There were some cases where usage of `Core()->core()` as temporary expression wasn't incorrect, but the chance of misuse was too high.

Main change is in src/core/Cutter.h, the rest are fixes for problems detected by it. It makes it so that
`->` operator doesn't compile when used directly on temporary object returned by `Core()->core()` but works once the result is assigned to a variable.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
