### PR TITLE
Improve disassembly arrow position accuracy.

### DIFF
--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -212,9 +212,9 @@ QString DisassemblyWidget::getWidgetType()
     return "Disassembly";
 }
 
-QFontMetrics DisassemblyWidget::getFontMetrics()
+QFontMetricsF DisassemblyWidget::getFontMetrics()
 {
-    return QFontMetrics(mDisasTextEdit->font());
+    return QFontMetricsF(mDisasTextEdit->font());
 }
 
 QList<DisassemblyLine> DisassemblyWidget::getLines()
@@ -992,8 +992,7 @@ void DisassemblyLeftPanel::paintEvent(QPaintEvent *event)
     constexpr int arrowWidth = 5;
     int rightOffset = size().rwidth();
     auto tEdit = qobject_cast<DisassemblyTextEdit *>(disas->getTextWidget());
-    int topOffset = int(tEdit->contentsMargins().top() + tEdit->textOffset());
-    int lineHeight = disas->getFontMetrics().height();
+    int lineHeight = qCeil(disas->getFontMetrics().lineSpacing());
     QColor arrowColorDown = ConfigColor("flow");
     QColor arrowColorUp = ConfigColor("cflow");
     QPainter p(this);
@@ -1006,6 +1005,14 @@ void DisassemblyLeftPanel::paintEvent(QPaintEvent *event)
     if (lines.size() == 0) {
         // No line to print, abort early
         return;
+    }
+
+    std::vector<int> lineY(tEdit->document()->lineCount());
+    QTextCursor cursor(tEdit->document());
+    for (auto &line : lineY) {
+        auto rect = tEdit->cursorRect(cursor);
+        line = rect.top();
+        cursor.movePosition(QTextCursor::Down);
     }
 
     using LineInfo = std::pair<RVA, int>;
@@ -1137,7 +1144,12 @@ void DisassemblyLeftPanel::paintEvent(QPaintEvent *event)
 
         auto lineToPixels = [&](int i) {
             int offset = int(arrow.up ? std::floor(pixelRatio) : -std::floor(pixelRatio));
-            return i * lineHeight + lineHeight / 2 + topOffset + offset;
+            int clampedLine = std::max(0, std::min(i, ((int)lineY.size()) - 1));
+            int pos0 = 0;
+            if (lineY.size() > 0) {
+                pos0 = lineY[clampedLine];
+            }
+            return pos0 + (i - clampedLine) * lineHeight + lineHeight / 2 + offset;
         };
 
         int lineStartNumber = offsetToLine(arrow.jmpFromOffset());

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -14,7 +14,7 @@
 #include <QJsonObject>
 #include <QVBoxLayout>
 #include <QRegularExpression>
-#include <QToolTip>
+#include <QtMath>
 #include <QTextBlockUserData>
 #include <QPainter>
 #include <QPainterPath>

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -47,7 +47,7 @@ public slots:
     void scrollInstructions(int count);
     void seekPrev();
     void setPreviewMode(bool previewMode);
-    QFontMetrics getFontMetrics();
+    QFontMetricsF getFontMetrics();
     QList<DisassemblyLine> getLines();
 
 protected slots:


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Query line position from textEdit instead of doing naive lineHeight*row. Any differences in rounding logic betwen Qt and Cutter is sufficient to offset arrow by a line or more.


**Test plan (required)**

Test environments:
* Linux Qt6 :heavy_check_mark: 
* Linux Qt5 build :heavy_check_mark: (no bug before changes)
* Windows :heavy_check_mark: 
* macOS :heavy_check_mark: (before fix wasn't good even at default 100% zoom)

In each environment:
* open an executable in cutter
* select disassembly line containing jump instruction (line highlight helps spotting when arrow starts at wrong line)
* open appearance settings
* change font zoom from 30% to 200% pay attention to highlighted line and arrow

First test 2.4 release and make sure bug is repeatable. It's possible that bug is only observable only at very specific zoom levels. Then confirm it's fixed by changes.

Ideally test with multiple desktop scaling factors.


**Closing issues**

Closes #3477

Partially address #2539 (horizontal positioning is still not quite right)
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
