### PR TITLE
Support translations with multiple langauge variants.

### DIFF
--- a/cmake/Translations.cmake
+++ b/cmake/Translations.cmake
@@ -1,29 +1,39 @@
+# Languages with 0% progress or low progress and alternatives are disabled
 set(TS_FILES
-    translations/ar/cutter_ar.ts
-    translations/bn/cutter_bn.ts
-    translations/ca/cutter_ca.ts
-    translations/de/cutter_de.ts
-    translations/es-ES/cutter_es.ts
-    translations/fa/cutter_fa.ts
-    translations/fi/cutter_fi.ts
-    translations/fr/cutter_fr.ts
-    translations/he/cutter_he.ts
-    translations/hi/cutter_hi.ts
-    translations/it/cutter_it.ts
-    translations/ja/cutter_ja.ts
-    translations/ko/cutter_ko.ts
-    translations/nl/cutter_nl.ts
-    translations/pl/cutter_pl.ts
-    translations/pt-PT/cutter_pt.ts
-    translations/ro/cutter_ro.ts
-    translations/ru/cutter_ru.ts
-    translations/tr/cutter_tr.ts
-    translations/uk/cutter_uk.ts
-    translations/ur-PK/cutter_ur.ts
-    translations/vi/cutter_vi.ts
-    translations/zh-CN/cutter_zh.ts
+#   translations/am/cutter_am_ET.ts
+    translations/ar/cutter_ar_SA.ts
+    translations/bn/cutter_bn_BD.ts
+    translations/ca/cutter_ca_ES.ts
+    translations/de/cutter_de_DE.ts
+    translations/es-ES/cutter_es_ES.ts
+    translations/fa/cutter_fa_IR.ts
+    translations/fi/cutter_fi_FI.ts
+#   translations/fil/cutter_fil_PH.ts
+    translations/fr/cutter_fr_FR.ts
+    translations/he/cutter_he_IL.ts
+    translations/hi/cutter_hi_IN.ts
+    translations/it/cutter_it_IT.ts
+    translations/ja/cutter_ja_JP.ts
+#   translations/km/cutter_km_KH.ts
+    translations/ko/cutter_ko_KR.ts
+    translations/nl/cutter_nl_NL.ts
+#   translations/pa-IN/cutter_pa_IN.ts
+    translations/pl/cutter_pl_PL.ts
+#   translations/pt-BR/cutter_pt_BR.ts
+    translations/pt-PT/cutter_pt_PT.ts
+    translations/ro/cutter_ro_RO.ts
+    translations/ru/cutter_ru_RU.ts
+#   translations/sv-SE/cutter_sv_SE.ts
+#   translations/sw/cutter_sw_KE.ts
+#   translations/th/cutter_th_TH.ts
+    translations/tr/cutter_tr_TR.ts
+    translations/uk/cutter_uk_UA.ts
+#   translations/ur-IN/cutter_ur_IN.ts
+    translations/ur-PK/cutter_ur_PK.ts
+    translations/vi/cutter_vi_VN.ts
+    translations/zh-CN/cutter_zh_CN.ts
+    translations/zh-TW/cutter_zh_TW.ts
 )
-# translations/pt-BR/cutter_pt.ts #2321 handling multiple versions of a language
 
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/translations)
 if (CUTTER_QT EQUAL 6)

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -5,6 +5,7 @@
 #include <QFontDatabase>
 #include <QFile>
 #include <QApplication>
+#include <qhash.h>
 
 #ifdef CUTTER_ENABLE_KSYNTAXHIGHLIGHTING
 #    include <KSyntaxHighlighting/Repository>
@@ -664,7 +665,7 @@ std::vector<Configuration::LangInfo> Configuration::getAvailableTranslations()
     std::sort(fileNames.begin(), fileNames.end());
     QString currLanguageName;
     std::vector<Configuration::LangInfo> result;
-    std::unordered_map<QString, int> langCount;
+    QHash<QString, int> langCount;
     for (const auto &translationFile : fileNames) {
         auto name = QFileInfo(translationFile).baseName();
         auto parts = name.split("_");

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -5,7 +5,7 @@
 #include <QFontDatabase>
 #include <QFile>
 #include <QApplication>
-#include <qhash.h>
+#include <QHash>
 
 #ifdef CUTTER_ENABLE_KSYNTAXHIGHLIGHTING
 #    include <KSyntaxHighlighting/Repository>

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -641,9 +641,9 @@ void Configuration::setConfig(const QString &key, const QVariant &value)
 
 /**
  * @brief this function will gather and return available translation for Cutter
- * @return a list of all available translations
+ * @return a list of locales and their names
  */
-QStringList Configuration::getAvailableTranslations()
+std::vector<Configuration::LangInfo> Configuration::getAvailableTranslations()
 {
     const auto &trDirs = Cutter::getTranslationsDirectories();
 
@@ -662,28 +662,49 @@ QStringList Configuration::getAvailableTranslations()
 
     QStringList fileNames = fileNamesSet.values();
     std::sort(fileNames.begin(), fileNames.end());
-    QStringList languages;
     QString currLanguageName;
-    auto allLocales =
-            QLocale::matchingLocales(QLocale::AnyLanguage, QLocale::AnyScript, QLocale::AnyCountry);
+    std::vector<Configuration::LangInfo> result;
+    std::unordered_map<QString, int> langCount;
+    for (const auto &translationFile : fileNames) {
+        auto name = QFileInfo(translationFile).baseName();
+        auto parts = name.split("_");
+        if (parts.length() < 2) {
+            continue;
+        }
+        auto langCode = parts[1];
+        ++langCount[langCode];
+    }
 
-    for (auto i : fileNames) {
-        QString localeName = i.mid(sizeof("cutter_") - 1, 2); // TODO:#2321 don't asume 2 characters
-        // language code is sometimes 3 characters, and there could also be language_COUNTRY. Qt
-        // supports that.
+    for (auto &i : fileNames) {
+        auto name = QFileInfo(i).baseName();
+        QString localeName = name.mid(sizeof("cutter_") - 1);
         QLocale locale(localeName);
-        if (locale.language() != QLocale::C) {
-            currLanguageName = locale.nativeLanguageName();
-            if (currLanguageName
-                        .isEmpty()) { // Qt doesn't have native language name for some languages
-                currLanguageName = QLocale::languageToString(locale.language());
-            }
-            if (!currLanguageName.isEmpty()) {
-                languages << currLanguageName;
+        if (locale.language() == QLocale::C) {
+            continue;
+        }
+        auto langCode = locale.name().split("_").first();
+        currLanguageName = locale.nativeLanguageName();
+        if (currLanguageName.isEmpty()) { // Qt doesn't have native language name for some languages
+            currLanguageName = QLocale::languageToString(locale.language());
+        }
+        // When there is single translation try to use generic language name without region name
+        if (langCount[langCode] <= 1
+            && locale.language() != QLocale::Chinese) { // Always distinguish Chinese Traditional,
+                                                        // Chinese simplified
+            QLocale localSimple(locale.language());
+            auto simpleName = localSimple.nativeLanguageName();
+            if (!simpleName.isEmpty()) {
+                currLanguageName = simpleName;
             }
         }
+        if (!currLanguageName.isEmpty()) {
+            result.push_back({ currLanguageName, locale });
+        }
     }
-    return languages << QLatin1String("English");
+    if (langCount["en"] == 0) {
+        result.push_back({ "English", QLocale("en") });
+    }
+    return result;
 }
 
 /**

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -86,7 +86,12 @@ public:
     QLocale getCurrLocale() const;
     void setLocale(const QLocale &l);
     bool setLocaleByName(const QString &language);
-    QStringList getAvailableTranslations();
+    struct LangInfo
+    {
+        QString name;
+        QLocale locale;
+    };
+    std::vector<LangInfo> getAvailableTranslations();
 
     // Fonts
 

--- a/src/dialogs/WelcomeDialog.cpp
+++ b/src/dialogs/WelcomeDialog.cpp
@@ -23,16 +23,31 @@ WelcomeDialog::WelcomeDialog(QWidget *parent) : QDialog(parent), ui(new Ui::Welc
     QSignalBlocker s(ui->updatesCheckBox);
     ui->updatesCheckBox->setChecked(Config()->getAutoUpdateEnabled());
 
-    QStringList langs = Config()->getAvailableTranslations();
-    ui->languageComboBox->addItems(langs);
-    QString curr = Config()->getCurrLocale().nativeLanguageName();
-    if (!langs.contains(curr)) {
-        curr = "English";
+    auto langs = Config()->getAvailableTranslations();
+    for (auto &lang : langs) {
+        ui->languageComboBox->addItem(lang.name, lang.locale);
     }
-    ui->languageComboBox->setCurrentText(curr);
+    // ui->languageComboBox->addItems(langs);
+
+    auto matchingLang =
+            std::find_if(langs.begin(), langs.end(), [](const Configuration::LangInfo &v) {
+                return v.locale == Config()->getCurrLocale();
+            });
+    if (matchingLang == langs.end()) {
+        matchingLang =
+                std::find_if(langs.begin(), langs.end(), [](const Configuration::LangInfo &v) {
+                    return v.locale.language() == QLocale::English;
+                });
+    }
+    if (matchingLang != langs.end()) {
+        ui->languageComboBox->setCurrentIndex(matchingLang - langs.begin());
+    } else {
+        ui->languageComboBox->setCurrentText("English");
+    }
+
     connect(ui->languageComboBox,
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
-            &WelcomeDialog::onLanguageComboBox_currentIndexChanged);
+            &WelcomeDialog::onLanguageCurrentIndexChanged);
 
     Config()->adjustColorThemeDarkness();
 }
@@ -61,10 +76,12 @@ void WelcomeDialog::on_themeComboBox_currentIndexChanged(int index)
  * @brief change Cutter's interface language as selected by the user
  * @param index - a Slot being called after language combo box value changes its index
  */
-void WelcomeDialog::onLanguageComboBox_currentIndexChanged(int index)
+void WelcomeDialog::onLanguageCurrentIndexChanged(int)
 {
-    QString language = ui->languageComboBox->itemText(index);
-    Config()->setLocaleByName(language);
+    QVariant language = ui->languageComboBox->currentData();
+    if (language.canConvert<QLocale>()) {
+        Config()->setLocale(language.toLocale());
+    }
 
     QMessageBox mb(this);
     mb.setWindowTitle(tr("Language settings"));

--- a/src/dialogs/WelcomeDialog.cpp
+++ b/src/dialogs/WelcomeDialog.cpp
@@ -27,7 +27,6 @@ WelcomeDialog::WelcomeDialog(QWidget *parent) : QDialog(parent), ui(new Ui::Welc
     for (auto &lang : langs) {
         ui->languageComboBox->addItem(lang.name, lang.locale);
     }
-    // ui->languageComboBox->addItems(langs);
 
     auto matchingLang =
             std::find_if(langs.begin(), langs.end(), [](const Configuration::LangInfo &v) {

--- a/src/dialogs/WelcomeDialog.h
+++ b/src/dialogs/WelcomeDialog.h
@@ -27,7 +27,7 @@ public:
 
 private slots:
     void on_themeComboBox_currentIndexChanged(int index);
-    void onLanguageComboBox_currentIndexChanged(int index);
+    void onLanguageCurrentIndexChanged(int index);
     void on_checkUpdateButton_clicked();
     void on_continueButton_clicked();
     void on_updatesCheckBox_stateChanged(int state);

--- a/src/dialogs/preferences/AppearanceOptionsWidget.cpp
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.cpp
@@ -245,7 +245,7 @@ void AppearanceOptionsWidget::on_renameButton_clicked()
     }
 }
 
-void AppearanceOptionsWidget::onLanguageComboBoxCurrentIndexChanged(int index)
+void AppearanceOptionsWidget::onLanguageComboBoxCurrentIndexChanged(int)
 {
     QVariant language = ui->languageComboBox->currentData();
     if (language.canConvert<QLocale>()) {

--- a/src/dialogs/preferences/AppearanceOptionsWidget.cpp
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.cpp
@@ -29,14 +29,26 @@ AppearanceOptionsWidget::AppearanceOptionsWidget(PreferencesDialog *dialog)
     ui->setupUi(this);
     updateFromConfig();
 
-    QStringList langs = Config()->getAvailableTranslations();
-    ui->languageComboBox->addItems(langs);
-
-    QString curr = Config()->getCurrLocale().nativeLanguageName();
-    if (!langs.contains(curr)) {
-        curr = "English";
+    auto langs = Config()->getAvailableTranslations();
+    for (auto &lang : langs) {
+        ui->languageComboBox->addItem(lang.name, lang.locale);
     }
-    ui->languageComboBox->setCurrentText(curr);
+
+    auto matchingLang =
+            std::find_if(langs.begin(), langs.end(), [](const Configuration::LangInfo &v) {
+                return v.locale == Config()->getCurrLocale();
+            });
+    if (matchingLang == langs.end()) {
+        matchingLang =
+                std::find_if(langs.begin(), langs.end(), [](const Configuration::LangInfo &v) {
+                    return v.locale.language() == QLocale::English;
+                });
+    }
+    if (matchingLang != langs.end()) {
+        ui->languageComboBox->setCurrentIndex(matchingLang - langs.begin());
+    } else {
+        ui->languageComboBox->setCurrentText("English");
+    }
 
     auto setIcons = [this]() {
         QColor textColor = palette().text().color();
@@ -235,14 +247,14 @@ void AppearanceOptionsWidget::on_renameButton_clicked()
 
 void AppearanceOptionsWidget::onLanguageComboBoxCurrentIndexChanged(int index)
 {
-    QString language = ui->languageComboBox->itemText(index).toLower();
-    if (Config()->setLocaleByName(language)) {
+    QVariant language = ui->languageComboBox->currentData();
+    if (language.canConvert<QLocale>()) {
+        Config()->setLocale(language.toLocale());
         QMessageBox::information(this, tr("Language settings"),
                                  tr("Language will be changed after next application start."));
-        return;
+    } else {
+        qWarning() << tr("Cannot set language, not found in available ones");
     }
-
-    qWarning() << tr("Cannot set language, not found in available ones");
 }
 
 void AppearanceOptionsWidget::updateModificationButtons(const QString &theme)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Should work with both the existing translations that use two character language codes like "en" and language+region like "en_us".

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

For now not enabling most extra translations which have barely any progress. Would probably be a bit confusing to see something choice of "Portuguese" and "Portuguese, Brazilian" with no obvious indication that choosing users preferred one it might lower translation amount from 90% to 10%.  I doubt many users would go back and try the other Portuguese in such case.

When both Portuguese are enabled Qt names them Portuguese and Portuguese European, seems a bit weird to me. Regular one refers to Brazilian one. I guess there is some logic behind it considering that Brazil has 20x more people. 

Also Urdu (Pakistan) and Urdu (India) currently get the same name in selection. I am leaving name adjustment for the time when both of them will have some translation progress.  For now keep the untranslated one disabled.

**Test plan (required)**

Using CI build :heavy_check_mark: 

* Open cutter make sure UI is not broken
* open settings check the language list
* switch language restart
* language should now be applied
* Close cutter,  erase settings
* make sure language selection is properly displayed in initial welcome screen
* change language in welcome screen, and make sure it's applied (restart if needed)

Using local build

* Uncomment both zh_cn, zh_tw, and pt_pt, pt_br  do a devbuild. See #3476 for easier way of testing translations in dev builds without having to install Cutter. Make sure all 4 languages are available correctly named, and applied when selected. :heavy_check_mark: 


* Choose a language, close cutter. Remove file for corresponding language. Make sure Cutter falls back to English when previously selected language is missing. :heavy_check_mark: 

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

Closes #2321
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
