### PR TITLE
Fix(EditInstructionDialog): Silence console errors from text preview

### DIFF
--- a/src/dialogs/EditInstructionDialog.cpp
+++ b/src/dialogs/EditInstructionDialog.cpp
@@ -62,7 +62,12 @@ void EditInstructionDialog::updatePreview(const QString &input)
         QByteArray data = CutterCore::hexStringToBytes(input);
         result = Core()->disassemble(data).replace('\n', "; ");
     } else if (editMode == EDIT_TEXT) {
-        QByteArray data = Core()->assemble(input);
+        QByteArray data;
+        try {
+            data = Core()->assemble(input);
+        } catch (const std::exception &e) {
+            data = QByteArray();
+        }
         result = CutterCore::bytesToHexString(data).trimmed();
     }
 


### PR DESCRIPTION


<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

This change resolves Issue #2551, where errors from Rizin were printed to the console when typing invalid instructions in the "Edit Instruction" dialog.

Problem:
When a user entered non-assemblable code, Core()->assemble() would fail. This failure not only caused Rizin to print error messages to the console but could also lead to unhandled exceptions, potentially crashing Cutter.

Fix:
This modification wraps the `Core()->assemble(input)` call within a try-catch block. By catching the `std::exception` that `Core()->assemble()` might throw:

* We successfully prevent the associated error messages, which resulted from these exceptions, from being printed to the console.
* We handle the failure case by setting data to an empty QByteArray.

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**
The following is an example of an unexpected console error:
![gif20250528161517](https://github.com/user-attachments/assets/a9354e1f-322e-449f-8b7d-c0f66498d7fc)

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->
After modification, the console no longer reports an error during the modification of instructions:
![gif20250528161302](https://github.com/user-attachments/assets/7dcc45c9-1bbf-4e79-8505-b0e31e9fce19)


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**
closes #2551 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
