### PR TITLE
Bump windows CI runner to windows 2022.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,7 +511,7 @@ jobs:
         set ARCH=x64
         set CUTTER_DEPS=%CD%\cutter-deps
         set PATH=%CD%\cutter-deps\qt\bin;%PATH%
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
         cd
         mkdir build
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,7 +406,7 @@ jobs:
           - system-deps: false
           - output-id: ""
           - name: windows-x86_64
-            os: windows-2019
+            os: windows-2022
             package: true
             python-version: 3.12.x
             output-id: artifact_windows
@@ -596,7 +596,7 @@ jobs:
             artifact-job: build
             artifact-output: artifact_macos
           - name: windows
-            os: windows-2019
+            os: windows-2022
             artifact-job: build
             artifact-output: artifact_windows
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,7 +511,7 @@ jobs:
         set ARCH=x64
         set CUTTER_DEPS=%CD%\cutter-deps
         set PATH=%CD%\cutter-deps\qt\bin;%PATH%
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
         cd
         mkdir build
         cd build


### PR DESCRIPTION
Github will soon remove the windows-2019 images.

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

> The Windows Server 2019 runner image will be fully unsupported by June 30, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Windows Server 2019. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times: 
     
**Test plan (required)**

* [x] CI builds successfully
* [x] download the windows build and make sure python is properly bundled, sample python plugin works.


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
