### PR TITLE
Disable Copy address and instruction when multiple lines selected

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -811,14 +811,18 @@ void DisassemblyContextMenu::on_actionCopy_triggered()
 
 void DisassemblyContextMenu::on_actionCopyAddr_triggered()
 {
-    QClipboard *clipboard = QApplication::clipboard();
-    clipboard->setText(RzAddressString(offset));
+    if (singleLineSelect) {
+        QClipboard *clipboard = QApplication::clipboard();
+        clipboard->setText(RzAddressString(offset));
+    }
 }
 
 void DisassemblyContextMenu::on_actionCopyInstrBytes_triggered()
 {
-    QClipboard *clipboard = QApplication::clipboard();
-    clipboard->setText(Core()->getInstructionBytes(offset));
+    if (singleLineSelect) {
+        QClipboard *clipboard = QApplication::clipboard();
+        clipboard->setText(Core()->getInstructionBytes(offset));
+    }
 }
 
 void DisassemblyContextMenu::on_actionAddBreakpoint_triggered()

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -24,6 +24,7 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
     : QMenu(parent),
       offset(0),
       canCopy(false),
+      singleLineSelect(false),
       mainWindow(mainWindow),
       ioModesController(this),
       actionEditInstruction(this),
@@ -377,6 +378,11 @@ void DisassemblyContextMenu::setCanCopy(bool enabled)
     this->canCopy = enabled;
 }
 
+void DisassemblyContextMenu::setSingleLineSelect(bool enabled)
+{
+    this->singleLineSelect = enabled;
+}
+
 void DisassemblyContextMenu::setCurHighlightedWord(const QString &text)
 {
     this->curHighlightedWord = text;
@@ -582,6 +588,10 @@ void DisassemblyContextMenu::aboutToShowSlot()
 
     actionCopy.setVisible(canCopy);
     copySeparator->setVisible(canCopy);
+
+    // Only enable if single line is selected
+    actionCopyAddr.setEnabled(singleLineSelect);
+    actionCopyInstrBytes.setEnabled(singleLineSelect);
 
     // Handle renaming of variable, function, flag, ...
     // Note: This might be useless if we consider setCurrentHighlightedWord is always called before

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -22,6 +22,7 @@ signals:
 public slots:
     void setOffset(RVA offset);
     void setCanCopy(bool enabled);
+    void setSingleLineSelect(bool enabled);
 
     /**
      * @brief Sets the value of curHighlightedWord
@@ -98,6 +99,7 @@ private:
 
     RVA offset;
     bool canCopy;
+    bool singleLineSelect;
     QString curHighlightedWord; // The current highlighted word
     MainWindow *mainWindow;
     IOModesController ioModesController;

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -550,21 +550,21 @@ void DisassemblyWidget::cursorPositionChanged()
     highlightCurrentLine();
     highlightPCLine();
 
-    QTextCursor cursor = mDisasTextEdit->textCursor();
-    if (cursor.hasSelection()) {
+    c = mDisasTextEdit->textCursor();
+    if (c.hasSelection()) {
         mCtxMenu->setCanCopy(true);
 
-        int startLine = cursor.blockNumber();
-        QTextCursor endCursor = cursor;
+        int start = c.blockNumber();
+        c.setPosition(c.selectionEnd());
+        int end = c.blockNumber();
 
-        endCursor.setPosition(cursor.selectionEnd());
-        int endLine = endCursor.blockNumber();
-
-        if (endLine == startLine) {
+        if (end == start) {
             mCtxMenu->setSingleLineSelect(true);
         } else {
             mCtxMenu->setSingleLineSelect(false);
         }
+    } else {
+        mCtxMenu->setSingleLineSelect(true);
     }
 
     if (mDisasTextEdit->textCursor().hasSelection()) {

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -554,9 +554,8 @@ void DisassemblyWidget::cursorPositionChanged()
     if (c.hasSelection()) {
         mCtxMenu->setCanCopy(true);
 
-        int start = c.blockNumber();
-        c.setPosition(c.selectionEnd());
-        int end = c.blockNumber();
+        int start = mDisasTextEdit->document()->findBlock(c.selectionStart()).blockNumber();
+        int end = mDisasTextEdit->document()->findBlock(c.selectionEnd()).blockNumber();
 
         if (end == start) {
             mCtxMenu->setSingleLineSelect(true);

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -549,7 +549,24 @@ void DisassemblyWidget::cursorPositionChanged()
     seekFromCursor = false;
     highlightCurrentLine();
     highlightPCLine();
-    mCtxMenu->setCanCopy(mDisasTextEdit->textCursor().hasSelection());
+
+    QTextCursor cursor = mDisasTextEdit->textCursor();
+    if (cursor.hasSelection()) {
+        mCtxMenu->setCanCopy(true);
+
+        int startLine = cursor.blockNumber();
+        QTextCursor endCursor = cursor;
+
+        endCursor.setPosition(cursor.selectionEnd());
+        int endLine = endCursor.blockNumber();
+
+        if (endLine == startLine) {
+            mCtxMenu->setSingleLineSelect(true);
+        } else {
+            mCtxMenu->setSingleLineSelect(false);
+        }
+    }
+
     if (mDisasTextEdit->textCursor().hasSelection()) {
         // A word is selected so use it
         mCtxMenu->setCurHighlightedWord(mDisasTextEdit->textCursor().selectedText());


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Selecting multiple lines and the using `Copy address` or `Copy instruction bytes` only copies the address or instruction bytes of the last instruction in the selection, which can be misleading. Now the options are greyed out (disabled)

**Note:** this was the solution I thought was best, if there is a better way to know that multiple lines were selected please lmk and I will update the PR.

Also the shortcuts also won't work if multiple lines/instructions are selected

![cutter-disabled-btns](https://github.com/user-attachments/assets/577246bc-e429-4f3b-ab5d-a6a4cd009892)

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

open any binary, go to disassembly view, select multiple lines then Right Click, `Copy address` and `Copy instruction bytes` will be disabled.
if a single line or nothing is selected i.e: the cursor is sitting at one line, both options will be available.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3094 