### PR TITLE
Fixing Set-to-data shortkey

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -866,7 +866,7 @@ void CutterCore::setToData(RVA addr, int size, int repeat)
 
 int CutterCore::sizeofDataMeta(RVA addr)
 {
-    ut64 size;
+    ut64 size = 0;
     CORE_LOCK();
     rz_meta_get_at(core->analysis, addr, RZ_META_TYPE_DATA, &size);
     return (int)size;

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -284,6 +284,7 @@ void DisassemblyContextMenu::addSetToDataMenu()
 
     auto switchAction = new QAction(this);
     initShortcutAction(switchAction, "Disassembly.setToData", SLOT(on_actionSetToData_triggered()));
+    setToDataMenu->addAction(switchAction);
 }
 
 void DisassemblyContextMenu::addEditMenu()


### PR DESCRIPTION
The underlying functionality makes it possible to switch a certain memory in Cutter to data (via the shortcut `d`). This functionality is comparable to other similar products. The functionality already existed in cutter. Unfortunately it was broken due to two problems:
* The underlying action was not added to a widget - this is now fixed, by adding it to the `setToDataMenu` - like other related actions
* If the underlying meta was not prevously data, it simply just ignored the action, as the size of the data returned uninitilialized memory. This is now fixed. Returning -1 from `CutterCore::sizeofDataMeta` indicates that the Meta at the address is currently no data.

This change fixes the problem

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)

**Detailed description**

Please note: the problem was observed, by using Arch Linux with Sway and qt6-base version 6.10.0. If the described problem is not observed on other systems: please provide this as feedback so the change can be limited! 

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

**Test plan (required)**

Load a binary and simply press "d"-key (multiple times) at a memory-location that was not data before.

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
