### PR TITLE
Fix: graph.offset option

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -278,8 +278,12 @@ void DisassemblerGraphView::loadCurrentGraph()
         RzCoreDisasmOptions options = {};
         options.vec = vec.get();
         options.cbytes = 1;
+
+        bool asmOffset = Core()->getConfigb("asm.offset");
+        Core()->setConfig("asm.offset", Core()->getConfigb("graph.offset"));
         rz_core_print_disasm(core, bbi->addr, buf.get(), (int)bbi->size, (int)bbi->size, NULL,
                              &options);
+        Core()->setConfig("asm.offset", asmOffset);
 
         auto vecVisitor = CutterPVector<RzAnalysisDisasmText>(vec.get());
         auto iter = vecVisitor.begin();


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

* Cutter graph option: "Show offset for each instruction (graph.offset)" was not working.
* Offsets for each instruction in the graphs were shown even if the "graph.offset" option was unchecked due to "asm.offset" being true.
* In other words, showing offsets in graphs was controlled by "asm.offset" instead of "graph.offset"

A workaround done in this PR is to set the "asm.option" config equal to "graph.offset" temporarily when rendering instructions for a graph, and revert it back after
Rizin also seems to follow a similar approach:
inside `get_body() -- line: 2134` in `rizin/librz/core/agraph.c` (for reference)
```
rz_config_hold_i(hc, "asm.lines", "asm.bytes",
		"asm.cmt.col", "asm.marks", "asm.offset",
		"asm.comments", "asm.cmt.right", "asm.bb.line", NULL);
	.
	.
	const bool o_graph_offset = rz_config_get_i(core->config, "graph.offset");
	.
	.
	if (opts & BODY_OFFSETS || opts & BODY_SUMMARY || o_graph_offset) {
		rz_config_set_i(core->config, "asm.offset", true);
	} else {
		rz_config_set_i(core->config, "asm.offset", false);
	}
```  

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

Uncheck "asm.offset" inside Preferences->Disassembly
Check "graph.offset" option inside Preferences->Graph
Offsets for each instruction will now be shown in graphs but not in disassembly

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3144 