### PR TITLE
Hide Edit instruction option when no assembler exists

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -2984,6 +2984,29 @@ QStringList CutterCore::getAnalysisPluginNames()
     return ret;
 }
 
+bool CutterCore::hasAssembler()
+{
+    CORE_LOCK();
+    QString archStr = Core()->getConfig("asm.arch");
+    int currBits = Core()->getConfigi("asm.bits");
+    if (!core->rasm || archStr.isEmpty() || currBits == 0) {
+        return false;
+    }
+
+    bool found = false;
+    CutterHtSP<RzAsmPlugin>(core->rasm->plugins).ForEach([&](const char *k, const RzAsmPlugin *ap) {
+        if (!ap->arch || !ap->assemble || !(ap->bits & currBits)) {
+            return true;
+        }
+        if (QString(ap->arch) == archStr) {
+            found = true;
+            return false;
+        }
+        return true;
+    });
+    return found;
+}
+
 QList<RzBinPluginDescription> CutterCore::getBinPluginDescriptions(bool bin, bool xtr)
 {
     CORE_LOCK();

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -607,6 +607,12 @@ public:
     QStringList getAsmPluginNames();
     QStringList getAnalysisPluginNames();
 
+    /**
+     * @brief Checks if an assembler is available for the current architecture.
+     * @return true if there is an assembler plugin for the current architecture, false otherwise.
+     */
+    bool hasAssembler();
+
     /* Widgets */
     QList<RzBinPluginDescription> getBinPluginDescriptions(bool bin = true, bool xtr = true);
     QList<RzIOPluginDescription> getRIOPluginDescriptions();

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -622,6 +622,8 @@ void DisassemblyContextMenu::aboutToShowSlot()
     if (isLocalVar) {
         actionXRefsForVariables.setText(tr("X-Refs for %1").arg(curHighlightedWord));
     }
+
+    actionEditInstruction.setEnabled(Core()->hasAssembler());
 }
 
 void DisassemblyContextMenu::aboutToHideSlot()


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

Hides the edit instruction option when no assembler plugin is available for the current architecture. 
This is done by matching the current arch to the arch supported by the plugin and later checking if a callback to the assemble function exists

Still unsure how a tooltip could be shown (when no assembler is available) that doesn't look wrong

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

Open a binary whose architecture is not supported by any of the assembler plugins : "Edit -> Instruction" option will no longer be available

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #2568 