### PR TITLE
Fix crash on multiple Widget destructors (#3516)

### DIFF
--- a/src/tools/basefind/BaseFindResultsDialog.cpp
+++ b/src/tools/basefind/BaseFindResultsDialog.cpp
@@ -7,14 +7,14 @@
 #include <core/Cutter.h>
 #include <CutterApplication.h>
 
-BaseFindResultsModel::BaseFindResultsModel(QList<BasefindResultDescription> *list, QObject *parent)
+BaseFindResultsModel::BaseFindResultsModel(QList<BasefindResultDescription> list, QObject *parent)
     : QAbstractListModel(parent), list(list)
 {
 }
 
 int BaseFindResultsModel::rowCount(const QModelIndex &) const
 {
-    return list->count();
+    return list.count();
 }
 
 int BaseFindResultsModel::columnCount(const QModelIndex &) const
@@ -24,10 +24,10 @@ int BaseFindResultsModel::columnCount(const QModelIndex &) const
 
 QVariant BaseFindResultsModel::data(const QModelIndex &index, int role) const
 {
-    if (index.row() >= list->count())
+    if (index.row() >= list.count())
         return QVariant();
 
-    const BasefindResultDescription &entry = list->at(index.row());
+    const BasefindResultDescription &entry = list.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
@@ -68,12 +68,12 @@ QVariant BaseFindResultsModel::headerData(int section, Qt::Orientation, int role
 
 BaseFindResultsDialog::BaseFindResultsDialog(QList<BasefindResultDescription> results,
                                              QWidget *parent)
-    : QDialog(parent), list(results), ui(new Ui::BaseFindResultsDialog)
+    : QDialog(parent), ui(new Ui::BaseFindResultsDialog)
 {
     ui->setupUi(this);
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
 
-    model = new BaseFindResultsModel(&list, this);
+    model = new BaseFindResultsModel(results, this);
     ui->tableView->setModel(model);
     ui->tableView->sortByColumn(BaseFindResultsModel::ScoreColumn, Qt::AscendingOrder);
     ui->tableView->verticalHeader()->hide();
@@ -104,7 +104,7 @@ void BaseFindResultsDialog::showItemContextMenu(const QPoint &pt)
 {
     auto index = ui->tableView->currentIndex();
     if (index.isValid()) {
-        const BasefindResultDescription &entry = list.at(index.row());
+        const BasefindResultDescription &entry = model->list.at(index.row());
         candidate = entry.candidate;
         auto addr = QString::asprintf("%#010llx", candidate);
         actionCopyCandidate->setText(tr("Copy %1").arg(addr));

--- a/src/tools/basefind/BaseFindResultsDialog.h
+++ b/src/tools/basefind/BaseFindResultsDialog.h
@@ -23,7 +23,7 @@ class BaseFindResultsModel : public QAbstractListModel
 public:
     enum Column { ScoreColumn = 0, CandidateColumn, ColumnCount };
 
-    BaseFindResultsModel(QList<BasefindResultDescription> *list, QObject *parent = nullptr);
+    BaseFindResultsModel(QList<BasefindResultDescription> list, QObject *parent = nullptr);
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
@@ -32,7 +32,7 @@ public:
     int columnCount(const QModelIndex &parent = QModelIndex()) const;
 
 private:
-    QList<BasefindResultDescription> *list;
+    QList<BasefindResultDescription> list;
 };
 
 class BaseFindResultsDialog : public QDialog
@@ -55,7 +55,6 @@ private:
     void onActionSetLoadAddr();
     void onActionSetMapAddr();
 
-    QList<BasefindResultDescription> list;
     std::unique_ptr<Ui::BaseFindResultsDialog> ui;
     BaseFindResultsModel *model;
     QMenu *blockMenu;

--- a/src/widgets/BreakpointWidget.h
+++ b/src/widgets/BreakpointWidget.h
@@ -85,7 +85,6 @@ private:
 
     BreakpointModel *breakpointModel;
     BreakpointProxyModel *breakpointProxyModel;
-    QList<BreakpointDescription> breakpoints;
     QAction *actionDelBreakpoint = nullptr;
     QAction *actionToggleBreakpoint = nullptr;
     QAction *actionEditBreakpoint = nullptr;

--- a/src/widgets/CommentsWidget.cpp
+++ b/src/widgets/CommentsWidget.cpp
@@ -7,14 +7,7 @@
 #include <QShortcut>
 #include <QActionGroup>
 
-CommentsModel::CommentsModel(QList<CommentDescription> *comments,
-                             QList<CommentGroup> *nestedComments, QObject *parent)
-    : AddressableItemModel<>(parent),
-      comments(comments),
-      nestedComments(nestedComments),
-      nested(false)
-{
-}
+CommentsModel::CommentsModel(QObject *parent) : AddressableItemModel<>(parent), nested(false) {}
 
 bool CommentsModel::isNested() const
 {
@@ -32,13 +25,13 @@ RVA CommentsModel::address(const QModelIndex &index) const
 {
     if (isNested()) {
         if (index.internalId() != 0) {
-            auto &group = nestedComments->at(index.parent().row());
+            auto &group = nestedComments.at(index.parent().row());
             return group.comments.at(index.row()).offset;
         } else {
-            return nestedComments->at(index.row()).offset;
+            return nestedComments.at(index.row()).offset;
         }
     } else {
-        return comments->at(index.row()).offset;
+        return comments.at(index.row()).offset;
     }
 }
 
@@ -64,10 +57,10 @@ QModelIndex CommentsModel::parent(const QModelIndex &index) const
 int CommentsModel::rowCount(const QModelIndex &parent) const
 {
     if (!parent.isValid())
-        return (isNested() ? nestedComments->size() : comments->count());
+        return (isNested() ? nestedComments.size() : comments.count());
 
     if (isNested() && parent.internalId() == 0) {
-        return nestedComments->at(parent.row()).comments.size();
+        return nestedComments.at(parent.row()).comments.size();
     }
 
     return 0;
@@ -99,13 +92,13 @@ QVariant CommentsModel::data(const QModelIndex &index, int role) const
     QString groupName;
     CommentDescription comment;
     if (isNested()) {
-        auto &group = nestedComments->at(commentIndex);
+        auto &group = nestedComments.at(commentIndex);
         groupName = group.name;
         if (isSubnode) {
             comment = group.comments.at(index.row());
         }
     } else {
-        comment = comments->at(commentIndex);
+        comment = comments.at(commentIndex);
     }
 
     switch (role) {
@@ -238,7 +231,7 @@ CommentsWidget::CommentsWidget(MainWindow *main)
     setWindowTitle(tr("Comments"));
     setObjectName("CommentsWidget");
 
-    commentsModel = new CommentsModel(&comments, &nestedComments, this);
+    commentsModel = new CommentsModel(this);
     commentsProxyModel = new CommentsProxyModel(commentsModel, this);
     setModels(commentsProxyModel);
     ui->treeView->sortByColumn(CommentsModel::CommentColumn, Qt::AscendingOrder);
@@ -290,18 +283,18 @@ void CommentsWidget::refreshTree()
 {
     commentsModel->beginResetModel();
 
-    comments = Core()->getAllComments("CCu");
-    nestedComments.clear();
+    commentsModel->comments = Core()->getAllComments("CCu");
+    commentsModel->nestedComments.clear();
     QMap<QString, size_t> nestedCommentMapping;
-    for (const CommentDescription &comment : comments) {
+    for (const CommentDescription &comment : commentsModel->comments) {
         RVA offset = RVA_INVALID;
         QString fcnName = Core()->nearestFlag(comment.offset, &offset);
         auto nestedCommentIt = nestedCommentMapping.find(fcnName);
         if (nestedCommentIt == nestedCommentMapping.end()) {
-            nestedCommentMapping.insert(fcnName, nestedComments.size());
-            nestedComments.push_back({ fcnName, offset, { comment } });
+            nestedCommentMapping.insert(fcnName, commentsModel->nestedComments.size());
+            commentsModel->nestedComments.push_back({ fcnName, offset, { comment } });
         } else {
-            auto &commentGroup = nestedComments[nestedCommentIt.value()];
+            auto &commentGroup = commentsModel->nestedComments[nestedCommentIt.value()];
             commentGroup.comments.append(comment);
         }
     }

--- a/src/widgets/CommentsWidget.h
+++ b/src/widgets/CommentsWidget.h
@@ -29,8 +29,8 @@ class CommentsModel : public AddressableItemModel<>
     friend CommentsWidget;
 
 private:
-    QList<CommentDescription> *comments;
-    QList<CommentGroup> *nestedComments;
+    QList<CommentDescription> comments;
+    QList<CommentGroup> nestedComments;
     bool nested;
 
 public:
@@ -38,8 +38,7 @@ public:
     enum NestedColumn { OffsetNestedColumn = 0, CommentNestedColumn, NestedColumnCount };
     enum Role { CommentDescriptionRole = Qt::UserRole, FunctionRole };
 
-    CommentsModel(QList<CommentDescription> *comments, QList<CommentGroup> *nestedComments,
-                  QObject *parent = nullptr);
+    CommentsModel(QObject *parent = nullptr);
 
     QModelIndex index(int row, int column,
                       const QModelIndex &parent = QModelIndex()) const override;
@@ -91,9 +90,6 @@ private:
     CommentsProxyModel *commentsProxyModel;
     QAction actionHorizontal;
     QAction actionVertical;
-
-    QList<CommentDescription> comments;
-    QList<CommentGroup> nestedComments;
 
     QMenu *titleContextMenu;
 };

--- a/src/widgets/ExportsWidget.cpp
+++ b/src/widgets/ExportsWidget.cpp
@@ -6,14 +6,11 @@
 
 #include <QShortcut>
 
-ExportsModel::ExportsModel(QList<ExportDescription> *exports, QObject *parent)
-    : AddressableItemModel<QAbstractListModel>(parent), exports(exports)
-{
-}
+ExportsModel::ExportsModel(QObject *parent) : AddressableItemModel<QAbstractListModel>(parent) {}
 
 int ExportsModel::rowCount(const QModelIndex &) const
 {
-    return exports->count();
+    return exports.count();
 }
 
 int ExportsModel::columnCount(const QModelIndex &) const
@@ -23,10 +20,10 @@ int ExportsModel::columnCount(const QModelIndex &) const
 
 QVariant ExportsModel::data(const QModelIndex &index, int role) const
 {
-    if (index.row() >= exports->count())
+    if (index.row() >= exports.count())
         return QVariant();
 
-    const ExportDescription &exp = exports->at(index.row());
+    const ExportDescription &exp = exports.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
@@ -76,13 +73,13 @@ QVariant ExportsModel::headerData(int section, Qt::Orientation, int role) const
 
 RVA ExportsModel::address(const QModelIndex &index) const
 {
-    const ExportDescription &exp = exports->at(index.row());
+    const ExportDescription &exp = exports.at(index.row());
     return exp.vaddr;
 }
 
 QString ExportsModel::name(const QModelIndex &index) const
 {
-    const ExportDescription &exp = exports->at(index.row());
+    const ExportDescription &exp = exports.at(index.row());
     return exp.name;
 }
 
@@ -138,7 +135,7 @@ ExportsWidget::ExportsWidget(MainWindow *main) : ListDockWidget(main)
     setWindowTitle(tr("Exports"));
     setObjectName("ExportsWidget");
 
-    exportsModel = new ExportsModel(&exports, this);
+    exportsModel = new ExportsModel(this);
     exportsProxyModel = new ExportsProxyModel(exportsModel, this);
     setModels(exportsProxyModel);
 
@@ -171,7 +168,7 @@ ExportsWidget::~ExportsWidget() {}
 void ExportsWidget::refreshExports()
 {
     exportsModel->beginResetModel();
-    exports = Core()->getAllExports();
+    exportsModel->exports = Core()->getAllExports();
     exportsModel->endResetModel();
 
     qhelpers::adjustColumns(ui->treeView, 3, 0);

--- a/src/widgets/ExportsWidget.h
+++ b/src/widgets/ExportsWidget.h
@@ -25,7 +25,7 @@ class ExportsModel : public AddressableItemModel<QAbstractListModel>
     friend ExportsWidget;
 
 private:
-    QList<ExportDescription> *exports;
+    QList<ExportDescription> exports;
 
 public:
     enum Column {
@@ -38,7 +38,7 @@ public:
     };
     enum Role { ExportDescriptionRole = Qt::UserRole };
 
-    ExportsModel(QList<ExportDescription> *exports, QObject *parent = nullptr);
+    ExportsModel(QObject *parent = nullptr);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -77,7 +77,6 @@ private slots:
 private:
     ExportsModel *exportsModel;
     ExportsProxyModel *exportsProxyModel;
-    QList<ExportDescription> exports;
 };
 
 #endif // EXPORTSWIDGET_H

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -11,14 +11,11 @@
 #include <QStandardItemModel>
 #include <QInputDialog>
 
-FlagsModel::FlagsModel(QList<FlagDescription> *flags, QObject *parent)
-    : AddressableItemModel<QAbstractListModel>(parent), flags(flags)
-{
-}
+FlagsModel::FlagsModel(QObject *parent) : AddressableItemModel<QAbstractListModel>(parent) {}
 
 int FlagsModel::rowCount(const QModelIndex &) const
 {
-    return flags->count();
+    return flags.count();
 }
 
 int FlagsModel::columnCount(const QModelIndex &) const
@@ -28,10 +25,10 @@ int FlagsModel::columnCount(const QModelIndex &) const
 
 QVariant FlagsModel::data(const QModelIndex &index, int role) const
 {
-    if (index.row() >= flags->count())
+    if (index.row() >= flags.count())
         return QVariant();
 
-    const FlagDescription &flag = flags->at(index.row());
+    const FlagDescription &flag = flags.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
@@ -81,20 +78,20 @@ QVariant FlagsModel::headerData(int section, Qt::Orientation, int role) const
 
 RVA FlagsModel::address(const QModelIndex &index) const
 {
-    const FlagDescription &flag = flags->at(index.row());
+    const FlagDescription &flag = flags.at(index.row());
     return flag.offset;
 }
 
 QString FlagsModel::name(const QModelIndex &index) const
 {
-    const FlagDescription &flag = flags->at(index.row());
+    const FlagDescription &flag = flags.at(index.row());
     return flag.name;
 }
 
 const FlagDescription *FlagsModel::description(QModelIndex index) const
 {
-    if (index.row() < flags->size()) {
-        return &flags->at(index.row());
+    if (index.row() < flags.size()) {
+        return &flags.at(index.row());
     }
     return nullptr;
 }
@@ -151,7 +148,7 @@ FlagsWidget::FlagsWidget(MainWindow *main)
     // Add Status Bar footer
     tree->addStatusBar(ui->verticalLayout);
 
-    flags_model = new FlagsModel(&flags, this);
+    flags_model = new FlagsModel(this);
     flags_proxy_model = new FlagsSortFilterProxyModel(flags_model, this);
     connect(ui->filterLineEdit, &QLineEdit::textChanged, flags_proxy_model,
             &QSortFilterProxyModel::setFilterWildcard);
@@ -267,14 +264,14 @@ void FlagsWidget::refreshFlags()
         flagspace = flagspace_data.value<FlagspaceDescription>().name;
 
     flags_model->beginResetModel();
-    flags = Core()->getAllFlags(flagspace);
+    flags_model->flags = Core()->getAllFlags(flagspace);
     flags_model->endResetModel();
 
     tree->showItemsNumber(flags_proxy_model->rowCount());
 
     // TODO: this is not a very good place for the following:
     QStringList flagNames;
-    for (const FlagDescription &i : flags)
+    for (const FlagDescription &i : flags_model->flags)
         flagNames.append(i.name);
     main->refreshOmniBar(flagNames);
 }

--- a/src/widgets/FlagsWidget.h
+++ b/src/widgets/FlagsWidget.h
@@ -23,13 +23,13 @@ class FlagsModel : public AddressableItemModel<QAbstractListModel>
     friend FlagsWidget;
 
 private:
-    QList<FlagDescription> *flags;
+    QList<FlagDescription> flags;
 
 public:
     enum Columns { OFFSET = 0, SIZE, NAME, REALNAME, COMMENT, COUNT };
     static const int FlagDescriptionRole = Qt::UserRole;
 
-    FlagsModel(QList<FlagDescription> *flags, QObject *parent = nullptr);
+    FlagsModel(QObject *parent = nullptr);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -84,7 +84,6 @@ private:
     bool disableFlagRefresh = false;
     FlagsModel *flags_model;
     FlagsSortFilterProxyModel *flags_proxy_model;
-    QList<FlagDescription> flags;
     CutterTreeWidget *tree;
 
     void refreshFlags();

--- a/src/widgets/FlirtWidget.cpp
+++ b/src/widgets/FlirtWidget.cpp
@@ -3,14 +3,11 @@
 #include "core/MainWindow.h"
 #include "common/Helpers.h"
 
-FlirtModel::FlirtModel(QList<FlirtDescription> *sigdb, QObject *parent)
-    : QAbstractListModel(parent), sigdb(sigdb)
-{
-}
+FlirtModel::FlirtModel(QObject *parent) : QAbstractListModel(parent) {}
 
 int FlirtModel::rowCount(const QModelIndex &) const
 {
-    return sigdb->count();
+    return sigdb.count();
 }
 
 int FlirtModel::columnCount(const QModelIndex &) const
@@ -20,10 +17,10 @@ int FlirtModel::columnCount(const QModelIndex &) const
 
 QVariant FlirtModel::data(const QModelIndex &index, int role) const
 {
-    if (index.row() >= sigdb->count())
+    if (index.row() >= sigdb.count())
         return QVariant();
 
-    const FlirtDescription &entry = sigdb->at(index.row());
+    const FlirtDescription &entry = sigdb.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
@@ -128,7 +125,7 @@ FlirtWidget::FlirtWidget(MainWindow *main)
 {
     ui->setupUi(this);
 
-    model = new FlirtModel(&sigdb, this);
+    model = new FlirtModel(this);
     proxyModel = new FlirtProxyModel(model, this);
     ui->flirtTreeView->setModel(proxyModel);
     ui->flirtTreeView->sortByColumn(FlirtModel::BinTypeColumn, Qt::AscendingOrder);
@@ -151,7 +148,7 @@ FlirtWidget::~FlirtWidget() {}
 void FlirtWidget::refreshFlirt()
 {
     model->beginResetModel();
-    sigdb = Core()->getSignaturesDB();
+    model->sigdb = Core()->getSignaturesDB();
     model->endResetModel();
 
     ui->flirtTreeView->resizeColumnToContents(0);
@@ -170,7 +167,7 @@ void FlirtWidget::setScrollMode()
 void FlirtWidget::onSelectedItemChanged(const QModelIndex &index)
 {
     if (index.isValid()) {
-        const FlirtDescription &entry = sigdb.at(index.row());
+        const FlirtDescription &entry = model->sigdb.at(index.row());
         blockMenu->setTarget(entry);
     } else {
         blockMenu->clearTarget();
@@ -181,7 +178,7 @@ void FlirtWidget::showItemContextMenu(const QPoint &pt)
 {
     auto index = ui->flirtTreeView->currentIndex();
     if (index.isValid()) {
-        const FlirtDescription &entry = sigdb.at(index.row());
+        const FlirtDescription &entry = model->sigdb.at(index.row());
         blockMenu->setTarget(entry);
         blockMenu->exec(this->mapToGlobal(pt));
     }

--- a/src/widgets/FlirtWidget.h
+++ b/src/widgets/FlirtWidget.h
@@ -37,7 +37,7 @@ public:
     };
     enum Role { FlirtDescriptionRole = Qt::UserRole };
 
-    FlirtModel(QList<FlirtDescription> *sigdb, QObject *parent = 0);
+    FlirtModel(QObject *parent = 0);
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
@@ -46,7 +46,7 @@ public:
     int columnCount(const QModelIndex &parent = QModelIndex()) const;
 
 private:
-    QList<FlirtDescription> *sigdb;
+    QList<FlirtDescription> sigdb;
 };
 
 class FlirtProxyModel : public QSortFilterProxyModel
@@ -79,7 +79,6 @@ private:
 
     FlirtModel *model;
     FlirtProxyModel *proxyModel;
-    QList<FlirtDescription> sigdb;
     FlirtContextMenu *blockMenu;
 
     void setScrollMode();

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -30,13 +30,8 @@ static const int kMaxTooltipHighlightsLines = 5;
 
 }
 
-FunctionModel::FunctionModel(QList<FunctionDescription> *functions, QSet<RVA> *importAddresses,
-                             ut64 *mainAdress, bool nested, QFont default_font,
-                             QFont highlight_font, QObject *parent)
+FunctionModel::FunctionModel(bool nested, QFont default_font, QFont highlight_font, QObject *parent)
     : AddressableItemModel<>(parent),
-      functions(functions),
-      importAddresses(importAddresses),
-      mainAdress(mainAdress),
       highlightFont(highlight_font),
       defaultFont(default_font),
       nested(nested),
@@ -76,7 +71,7 @@ QModelIndex FunctionModel::parent(const QModelIndex &index) const
 int FunctionModel::rowCount(const QModelIndex &parent) const
 {
     if (!parent.isValid())
-        return functions->count();
+        return functions.count();
 
     if (nested) {
         if (parent.internalId() == 0)
@@ -96,12 +91,12 @@ int FunctionModel::columnCount(const QModelIndex & /*parent*/) const
 
 bool FunctionModel::functionIsImport(ut64 addr) const
 {
-    return importAddresses->contains(addr);
+    return importAddresses.contains(addr);
 }
 
 bool FunctionModel::functionIsMain(ut64 addr) const
 {
-    return *mainAdress == addr;
+    return mainAdress == addr;
 }
 
 QVariant FunctionModel::data(const QModelIndex &index, int role) const
@@ -121,9 +116,9 @@ QVariant FunctionModel::data(const QModelIndex &index, int role) const
         subnode = false;
     }
 
-    const FunctionDescription &function = functions->at(function_index);
+    const FunctionDescription &function = functions.at(function_index);
 
-    if (function_index >= functions->count())
+    if (function_index >= functions.count())
         return QVariant();
 
     switch (role) {
@@ -293,7 +288,7 @@ QVariant FunctionModel::data(const QModelIndex &index, int role) const
         return QVariant::fromValue(function);
 
     case IsImportRole:
-        return importAddresses->contains(function.offset);
+        return importAddresses.contains(function.offset);
 
     default:
         return {};
@@ -378,8 +373,8 @@ bool FunctionModel::updateCurrentIndex()
 
     RVA seek = Core()->getOffset();
 
-    for (int i = 0; i < functions->count(); i++) {
-        const FunctionDescription &function = functions->at(i);
+    for (int i = 0; i < functions.count(); i++) {
+        const FunctionDescription &function = functions.at(i);
 
         if (function.contains(seek) && function.offset >= offset) {
             offset = function.offset;
@@ -396,8 +391,8 @@ bool FunctionModel::updateCurrentIndex()
 
 void FunctionModel::functionRenamed(const RVA offset, const QString &new_name)
 {
-    for (int i = 0; i < functions->count(); i++) {
-        FunctionDescription &function = (*functions)[i];
+    for (int i = 0; i < functions.count(); i++) {
+        FunctionDescription &function = functions[i];
         if (function.offset == offset) {
             function.name = new_name;
             emit dataChanged(index(i, 0), index(i, columnCount() - 1));
@@ -504,8 +499,7 @@ FunctionsWidget::FunctionsWidget(MainWindow *main)
     QFont default_font = QFont(font_info.family(), font_info.pointSize());
     QFont highlight_font = QFont(font_info.family(), font_info.pointSize(), QFont::Bold);
 
-    functionModel = new FunctionModel(&functions, &importAddresses, &mainAdress, false,
-                                      default_font, highlight_font, this);
+    functionModel = new FunctionModel(false, default_font, highlight_font, this);
     functionProxyModel = new FunctionSortFilterProxyModel(functionModel, this);
     setModels(functionProxyModel);
     ui->treeView->sortByColumn(FunctionModel::NameColumn, Qt::AscendingOrder);
@@ -568,14 +562,14 @@ void FunctionsWidget::refreshTree()
             [this](const QList<FunctionDescription> &functions) {
                 functionModel->beginResetModel();
 
-                this->functions = functions;
+                functionModel->functions = functions;
 
-                importAddresses.clear();
+                functionModel->importAddresses.clear();
                 for (const ImportDescription &import : Core()->getAllImports()) {
-                    importAddresses.insert(import.plt);
+                    functionModel->importAddresses.insert(import.plt);
                 }
 
-                mainAdress = RVA_INVALID;
+                functionModel->mainAdress = RVA_INVALID;
                 RzCoreLocked core(Core());
                 RzBinFile *bf = rz_bin_cur(core->bin);
                 if (bf) {
@@ -583,8 +577,9 @@ void FunctionsWidget::refreshTree()
                             rz_bin_object_get_special_symbol(bf->o, RZ_BIN_SPECIAL_SYMBOL_MAIN);
                     if (binmain) {
                         int va = core->io->va || core->bin->is_debugger;
-                        mainAdress = va ? rz_bin_object_addr_with_base(bf->o, binmain->vaddr)
-                                        : binmain->paddr;
+                        functionModel->mainAdress = va
+                                ? rz_bin_object_addr_with_base(bf->o, binmain->vaddr)
+                                : binmain->paddr;
                     }
                 }
 

--- a/src/widgets/FunctionsWidget.h
+++ b/src/widgets/FunctionsWidget.h
@@ -18,9 +18,9 @@ class FunctionModel : public AddressableItemModel<>
     friend FunctionsWidget;
 
 private:
-    QList<FunctionDescription> *functions;
-    QSet<RVA> *importAddresses;
-    ut64 *mainAdress;
+    QList<FunctionDescription> functions;
+    QSet<RVA> importAddresses;
+    ut64 mainAdress;
 
     QFont highlightFont;
     QFont defaultFont;
@@ -58,9 +58,7 @@ public:
         ColumnCount
     };
 
-    FunctionModel(QList<FunctionDescription> *functions, QSet<RVA> *importAddresses,
-                  ut64 *mainAdress, bool nested, QFont defaultFont, QFont highlightFont,
-                  QObject *parent = nullptr);
+    FunctionModel(bool nested, QFont defaultFont, QFont highlightFont, QObject *parent = nullptr);
 
     QModelIndex index(int row, int column,
                       const QModelIndex &parent = QModelIndex()) const override;
@@ -120,9 +118,6 @@ private slots:
 
 private:
     QSharedPointer<FunctionsTask> task;
-    QList<FunctionDescription> functions;
-    QSet<RVA> importAddresses;
-    ut64 mainAdress;
     FunctionModel *functionModel;
     FunctionSortFilterProxyModel *functionProxyModel;
 

--- a/src/widgets/GlobalsWidget.cpp
+++ b/src/widgets/GlobalsWidget.cpp
@@ -8,14 +8,11 @@
 #include <QMenu>
 #include <QShortcut>
 
-GlobalsModel::GlobalsModel(QList<GlobalDescription> *globals, QObject *parent)
-    : AddressableItemModel<QAbstractListModel>(parent), globals(globals)
-{
-}
+GlobalsModel::GlobalsModel(QObject *parent) : AddressableItemModel<QAbstractListModel>(parent) {}
 
 int GlobalsModel::rowCount(const QModelIndex &) const
 {
-    return globals->count();
+    return globals.count();
 }
 
 int GlobalsModel::columnCount(const QModelIndex &) const
@@ -25,11 +22,11 @@ int GlobalsModel::columnCount(const QModelIndex &) const
 
 QVariant GlobalsModel::data(const QModelIndex &index, int role) const
 {
-    if (index.row() >= globals->count()) {
+    if (index.row() >= globals.count()) {
         return QVariant();
     }
 
-    const GlobalDescription &global = globals->at(index.row());
+    const GlobalDescription &global = globals.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
@@ -75,13 +72,13 @@ QVariant GlobalsModel::headerData(int section, Qt::Orientation, int role) const
 
 RVA GlobalsModel::address(const QModelIndex &index) const
 {
-    const GlobalDescription &global = globals->at(index.row());
+    const GlobalDescription &global = globals.at(index.row());
     return global.addr;
 }
 
 QString GlobalsModel::name(const QModelIndex &index) const
 {
-    const GlobalDescription &global = globals->at(index.row());
+    const GlobalDescription &global = globals.at(index.row());
     return global.name;
 }
 
@@ -165,7 +162,7 @@ GlobalsWidget::GlobalsWidget(MainWindow *main)
     ui->treeView->setMainWindow(mainWindow);
 
     // Setup up the model and the proxy model
-    globalsModel = new GlobalsModel(&globals, this);
+    globalsModel = new GlobalsModel(this);
     globalsProxyModel = new GlobalsProxyModel(globalsModel, this);
     ui->treeView->setModel(globalsProxyModel);
     ui->treeView->sortByColumn(GlobalsModel::AddressColumn, Qt::AscendingOrder);
@@ -211,7 +208,7 @@ GlobalsWidget::~GlobalsWidget() {}
 void GlobalsWidget::refreshGlobals()
 {
     globalsModel->beginResetModel();
-    globals = Core()->getAllGlobals();
+    globalsModel->globals = Core()->getAllGlobals();
     globalsModel->endResetModel();
 
     qhelpers::adjustColumns(ui->treeView, GlobalsModel::ColumnCount, 0);

--- a/src/widgets/GlobalsWidget.h
+++ b/src/widgets/GlobalsWidget.h
@@ -27,13 +27,13 @@ class GlobalsModel : public AddressableItemModel<QAbstractListModel>
     friend GlobalsWidget;
 
 private:
-    QList<GlobalDescription> *globals;
+    QList<GlobalDescription> globals;
 
 public:
     enum Column { AddressColumn = 0, TypeColumn, NameColumn, CommentColumn, ColumnCount };
     enum Role { GlobalDescriptionRole = Qt::UserRole };
 
-    GlobalsModel(QList<GlobalDescription> *exports, QObject *parent = nullptr);
+    GlobalsModel(QObject *parent = nullptr);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -75,7 +75,6 @@ private slots:
 private:
     std::unique_ptr<Ui::GlobalsWidget> ui;
 
-    QList<GlobalDescription> globals;
     GlobalsModel *globalsModel;
     GlobalsProxyModel *globalsProxyModel;
     CutterTreeWidget *tree;

--- a/src/widgets/HeadersWidget.cpp
+++ b/src/widgets/HeadersWidget.cpp
@@ -3,14 +3,11 @@
 #include "core/MainWindow.h"
 #include "common/Helpers.h"
 
-HeadersModel::HeadersModel(QList<HeaderDescription> *headers, QObject *parent)
-    : AddressableItemModel<QAbstractListModel>(parent), headers(headers)
-{
-}
+HeadersModel::HeadersModel(QObject *parent) : AddressableItemModel<QAbstractListModel>(parent) {}
 
 int HeadersModel::rowCount(const QModelIndex &) const
 {
-    return headers->count();
+    return headers.count();
 }
 
 int HeadersModel::columnCount(const QModelIndex &) const
@@ -20,10 +17,10 @@ int HeadersModel::columnCount(const QModelIndex &) const
 
 QVariant HeadersModel::data(const QModelIndex &index, int role) const
 {
-    if (index.row() >= headers->count())
+    if (index.row() >= headers.count())
         return QVariant();
 
-    const HeaderDescription &header = headers->at(index.row());
+    const HeaderDescription &header = headers.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
@@ -69,13 +66,13 @@ QVariant HeadersModel::headerData(int section, Qt::Orientation, int role) const
 
 RVA HeadersModel::address(const QModelIndex &index) const
 {
-    const HeaderDescription &header = headers->at(index.row());
+    const HeaderDescription &header = headers.at(index.row());
     return header.vaddr;
 }
 
 QString HeadersModel::name(const QModelIndex &index) const
 {
-    const HeaderDescription &header = headers->at(index.row());
+    const HeaderDescription &header = headers.at(index.row());
     return header.name;
 }
 
@@ -120,7 +117,7 @@ HeadersWidget::HeadersWidget(MainWindow *main) : ListDockWidget(main)
     setWindowTitle(tr("Headers"));
     setObjectName("HeadersWidget");
 
-    headersModel = new HeadersModel(&headers, this);
+    headersModel = new HeadersModel(this);
     headersProxyModel = new HeadersProxyModel(headersModel, this);
     setModels(headersProxyModel);
     ui->treeView->sortByColumn(HeadersModel::OffsetColumn, Qt::AscendingOrder);
@@ -139,7 +136,7 @@ HeadersWidget::~HeadersWidget() {}
 void HeadersWidget::refreshHeaders()
 {
     headersModel->beginResetModel();
-    headers = Core()->getAllHeaders();
+    headersModel->headers = Core()->getAllHeaders();
     headersModel->endResetModel();
 
     ui->treeView->resizeColumnToContents(0);

--- a/src/widgets/HeadersWidget.h
+++ b/src/widgets/HeadersWidget.h
@@ -27,13 +27,13 @@ class HeadersModel : public AddressableItemModel<QAbstractListModel>
     friend HeadersWidget;
 
 private:
-    QList<HeaderDescription> *headers;
+    QList<HeaderDescription> headers;
 
 public:
     enum Column { OffsetColumn = 0, NameColumn, ValueColumn, CommentColumn, ColumnCount };
     enum Role { HeaderDescriptionRole = Qt::UserRole };
 
-    HeadersModel(QList<HeaderDescription> *headers, QObject *parent = nullptr);
+    HeadersModel(QObject *parent = nullptr);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -72,7 +72,6 @@ private slots:
 private:
     HeadersModel *headersModel;
     HeadersProxyModel *headersProxyModel;
-    QList<HeaderDescription> headers;
 };
 
 #endif // HEADERSWIDGET_H

--- a/src/widgets/MemoryMapWidget.cpp
+++ b/src/widgets/MemoryMapWidget.cpp
@@ -4,14 +4,13 @@
 #include "common/Helpers.h"
 #include <QShortcut>
 
-MemoryMapModel::MemoryMapModel(QList<MemoryMapDescription> *memoryMaps, QObject *parent)
-    : AddressableItemModel<QAbstractListModel>(parent), memoryMaps(memoryMaps)
+MemoryMapModel::MemoryMapModel(QObject *parent) : AddressableItemModel<QAbstractListModel>(parent)
 {
 }
 
 int MemoryMapModel::rowCount(const QModelIndex &) const
 {
-    return memoryMaps->count();
+    return memoryMaps.count();
 }
 
 int MemoryMapModel::columnCount(const QModelIndex &) const
@@ -21,10 +20,10 @@ int MemoryMapModel::columnCount(const QModelIndex &) const
 
 QVariant MemoryMapModel::data(const QModelIndex &index, int role) const
 {
-    if (index.row() >= memoryMaps->count())
+    if (index.row() >= memoryMaps.count())
         return QVariant();
 
-    const MemoryMapDescription &memoryMap = memoryMaps->at(index.row());
+    const MemoryMapDescription &memoryMap = memoryMaps.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
@@ -74,7 +73,7 @@ QVariant MemoryMapModel::headerData(int section, Qt::Orientation, int role) cons
 
 RVA MemoryMapModel::address(const QModelIndex &index) const
 {
-    const MemoryMapDescription &memoryMap = memoryMaps->at(index.row());
+    const MemoryMapDescription &memoryMap = memoryMaps.at(index.row());
     return memoryMap.addrStart;
 }
 
@@ -123,7 +122,7 @@ MemoryMapWidget::MemoryMapWidget(MainWindow *main)
     setWindowTitle(tr("Memory Map"));
     setObjectName("MemoryMapWidget");
 
-    memoryModel = new MemoryMapModel(&memoryMaps, this);
+    memoryModel = new MemoryMapModel(this);
     memoryProxyModel = new MemoryProxyModel(memoryModel, this);
     setModels(memoryProxyModel);
     ui->treeView->sortByColumn(MemoryMapModel::AddrStartColumn, Qt::AscendingOrder);
@@ -150,7 +149,7 @@ void MemoryMapWidget::refreshMemoryMap()
         return;
     }
     memoryModel->beginResetModel();
-    memoryMaps = Core()->getMemoryMap();
+    memoryModel->memoryMaps = Core()->getMemoryMap();
     memoryModel->endResetModel();
 
     ui->treeView->resizeColumnToContents(0);

--- a/src/widgets/MemoryMapWidget.h
+++ b/src/widgets/MemoryMapWidget.h
@@ -27,7 +27,7 @@ class MemoryMapModel : public AddressableItemModel<QAbstractListModel>
     friend MemoryMapWidget;
 
 private:
-    QList<MemoryMapDescription> *memoryMaps;
+    QList<MemoryMapDescription> memoryMaps;
 
 public:
     enum Column {
@@ -40,7 +40,7 @@ public:
     };
     enum Role { MemoryDescriptionRole = Qt::UserRole };
 
-    MemoryMapModel(QList<MemoryMapDescription> *memoryMaps, QObject *parent = nullptr);
+    MemoryMapModel(QObject *parent = nullptr);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -79,7 +79,6 @@ private slots:
 private:
     MemoryMapModel *memoryModel;
     MemoryProxyModel *memoryProxyModel;
-    QList<MemoryMapDescription> memoryMaps;
 
     RefreshDeferrer *refreshDeferrer;
 };

--- a/src/widgets/RegisterRefsWidget.cpp
+++ b/src/widgets/RegisterRefsWidget.cpp
@@ -9,14 +9,11 @@
 #include <QClipboard>
 #include <QShortcut>
 
-RegisterRefModel::RegisterRefModel(QList<RegisterRefDescription> *registerRefs, QObject *parent)
-    : QAbstractListModel(parent), registerRefs(registerRefs)
-{
-}
+RegisterRefModel::RegisterRefModel(QObject *parent) : QAbstractListModel(parent) {}
 
 int RegisterRefModel::rowCount(const QModelIndex &) const
 {
-    return registerRefs->count();
+    return registerRefs.count();
 }
 
 int RegisterRefModel::columnCount(const QModelIndex &) const
@@ -26,10 +23,10 @@ int RegisterRefModel::columnCount(const QModelIndex &) const
 
 QVariant RegisterRefModel::data(const QModelIndex &index, int role) const
 {
-    if (index.row() >= registerRefs->count())
+    if (index.row() >= registerRefs.count())
         return QVariant();
 
-    const RegisterRefDescription &registerRef = registerRefs->at(index.row());
+    const RegisterRefDescription &registerRef = registerRefs.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
@@ -129,7 +126,7 @@ RegisterRefsWidget::RegisterRefsWidget(MainWindow *main)
     // Add Status Bar footer
     tree->addStatusBar(ui->verticalLayout);
 
-    registerRefModel = new RegisterRefModel(&registerRefs, this);
+    registerRefModel = new RegisterRefModel(this);
     registerRefProxyModel = new RegisterRefProxyModel(registerRefModel, this);
     ui->registerRefTreeView->setModel(registerRefProxyModel);
     ui->registerRefTreeView->setAutoScroll(false);
@@ -185,7 +182,7 @@ void RegisterRefsWidget::refreshRegisterRef()
 
     registerRefModel->beginResetModel();
 
-    registerRefs.clear();
+    registerRefModel->registerRefs.clear();
     for (const RegisterRef &reg : Core()->getRegisterRefs()) {
         RegisterRefDescription desc;
 
@@ -193,7 +190,7 @@ void RegisterRefsWidget::refreshRegisterRef()
         desc.reg = reg.name;
         desc.refDesc = Core()->formatRefDesc(QSharedPointer<AddrRefs>::create(reg.ref));
 
-        registerRefs.push_back(desc);
+        registerRefModel->registerRefs.push_back(desc);
     }
 
     registerRefModel->endResetModel();

--- a/src/widgets/RegisterRefsWidget.h
+++ b/src/widgets/RegisterRefsWidget.h
@@ -36,13 +36,13 @@ class RegisterRefModel : public QAbstractListModel
     friend RegisterRefsWidget;
 
 private:
-    QList<RegisterRefDescription> *registerRefs;
+    QList<RegisterRefDescription> registerRefs;
 
 public:
     enum Column { RegColumn = 0, ValueColumn, RefColumn, CommentColumn, ColumnCount };
     enum Role { RegisterRefDescriptionRole = Qt::UserRole };
 
-    RegisterRefModel(QList<RegisterRefDescription> *registerRefs, QObject *parent = 0);
+    RegisterRefModel(QObject *parent = 0);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
     int columnCount(const QModelIndex &parent = QModelIndex()) const;
@@ -83,7 +83,6 @@ private:
 
     RegisterRefModel *registerRefModel;
     RegisterRefProxyModel *registerRefProxyModel;
-    QList<RegisterRefDescription> registerRefs;
     CutterTreeWidget *tree;
     void setScrollMode();
 

--- a/src/widgets/ResourcesWidget.cpp
+++ b/src/widgets/ResourcesWidget.cpp
@@ -4,14 +4,13 @@
 #include "core/MainWindow.h"
 #include <QVBoxLayout>
 
-ResourcesModel::ResourcesModel(QList<ResourcesDescription> *resources, QObject *parent)
-    : AddressableItemModel<QAbstractListModel>(parent), resources(resources)
+ResourcesModel::ResourcesModel(QObject *parent) : AddressableItemModel<QAbstractListModel>(parent)
 {
 }
 
 int ResourcesModel::rowCount(const QModelIndex &) const
 {
-    return resources->count();
+    return resources.count();
 }
 
 int ResourcesModel::columnCount(const QModelIndex &) const
@@ -21,7 +20,7 @@ int ResourcesModel::columnCount(const QModelIndex &) const
 
 QVariant ResourcesModel::data(const QModelIndex &index, int role) const
 {
-    const ResourcesDescription &res = resources->at(index.row());
+    const ResourcesDescription &res = resources.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
@@ -96,7 +95,7 @@ QVariant ResourcesModel::headerData(int section, Qt::Orientation, int role) cons
 
 RVA ResourcesModel::address(const QModelIndex &index) const
 {
-    const ResourcesDescription &res = resources->at(index.row());
+    const ResourcesDescription &res = resources.at(index.row());
     return res.vaddr;
 }
 
@@ -105,7 +104,7 @@ ResourcesWidget::ResourcesWidget(MainWindow *main)
 {
     setObjectName("ResourcesWidget");
 
-    model = new ResourcesModel(&resources, this);
+    model = new ResourcesModel(this);
     filterModel = new AddressableFilterProxyModel(model, this);
     filterModel->setSortRole(Qt::EditRole);
     setModels(filterModel);
@@ -125,6 +124,6 @@ ResourcesWidget::ResourcesWidget(MainWindow *main)
 void ResourcesWidget::refreshResources()
 {
     model->beginResetModel();
-    resources = Core()->getAllResources();
+    model->resources = Core()->getAllResources();
     model->endResetModel();
 }

--- a/src/widgets/ResourcesWidget.h
+++ b/src/widgets/ResourcesWidget.h
@@ -17,11 +17,11 @@ class ResourcesModel : public AddressableItemModel<QAbstractListModel>
     friend ResourcesWidget;
 
 private:
-    QList<ResourcesDescription> *resources;
+    QList<ResourcesDescription> resources;
 
 public:
     enum Columns { INDEX = 0, NAME, VADDR, TYPE, SIZE, LANG, COMMENT, COUNT };
-    explicit ResourcesModel(QList<ResourcesDescription> *resources, QObject *parent = nullptr);
+    explicit ResourcesModel(QObject *parent = nullptr);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -40,7 +40,6 @@ class ResourcesWidget : public ListDockWidget
 private:
     ResourcesModel *model;
     AddressableFilterProxyModel *filterModel;
-    QList<ResourcesDescription> resources;
 
 public:
     explicit ResourcesWidget(MainWindow *main);

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -89,14 +89,11 @@ static const SearchKindInfo &searchKindInfo(SearchKind kind)
     return searchKinds[1];
 }
 
-SearchModel::SearchModel(QList<SearchDescription> *search, QObject *parent)
-    : AddressableItemModel<QAbstractListModel>(parent), search(search)
-{
-}
+SearchModel::SearchModel(QObject *parent) : AddressableItemModel<QAbstractListModel>(parent) {}
 
 int SearchModel::rowCount(const QModelIndex &) const
 {
-    return search->count();
+    return search.count();
 }
 
 int SearchModel::columnCount(const QModelIndex &) const
@@ -106,10 +103,10 @@ int SearchModel::columnCount(const QModelIndex &) const
 
 QVariant SearchModel::data(const QModelIndex &index, int role) const
 {
-    if (index.row() >= search->count())
+    if (index.row() >= search.count())
         return QVariant();
 
-    const SearchDescription &exp = search->at(index.row());
+    const SearchDescription &exp = search.at(index.row());
 
     switch (role) {
     case Qt::FontRole: {
@@ -200,7 +197,7 @@ QVariant SearchModel::headerData(int section, Qt::Orientation, int role) const
 
 RVA SearchModel::address(const QModelIndex &index) const
 {
-    const SearchDescription &exp = search->at(index.row());
+    const SearchDescription &exp = search.at(index.row());
     return exp.offset;
 }
 
@@ -249,7 +246,7 @@ SearchWidget::SearchWidget(MainWindow *main) : CutterDockWidget(main), ui(new Ui
 
     updateSearchBoundaries();
 
-    search_model = new SearchModel(&search, this);
+    search_model = new SearchModel(this);
     search_proxy_model = new SearchSortFilterProxyModel(search_model, this);
     ui->searchTreeView->setModel(search_proxy_model);
     ui->searchTreeView->setMainWindow(main);
@@ -334,7 +331,7 @@ void SearchWidget::refreshSearch()
     QString searchIn = ui->searchInCombo->currentData().toString();
 
     search_model->beginResetModel();
-    search = Core()->getAllSearch(searchFor, searchSpace, searchIn);
+    search_model->search = Core()->getAllSearch(searchFor, searchSpace, searchIn);
     search_model->endResetModel();
 
     qhelpers::adjustColumns(ui->searchTreeView, 3, 0);
@@ -344,7 +341,7 @@ void SearchWidget::refreshSearch()
 // Called by &QShortcut::activated and &QAbstractButton::clicked signals
 void SearchWidget::checkSearchResultEmpty()
 {
-    if (!search.isEmpty())
+    if (!search_model->search.isEmpty())
         return;
 
     QString searchFor = ui->filterLineEdit->text();

--- a/src/widgets/SearchWidget.h
+++ b/src/widgets/SearchWidget.h
@@ -21,13 +21,13 @@ class SearchModel : public AddressableItemModel<QAbstractListModel>
     friend SearchWidget;
 
 private:
-    QList<SearchDescription> *search;
+    QList<SearchDescription> search;
 
 public:
     enum Columns { OFFSET = 0, SIZE, CODE, DATA, COMMENT, COUNT };
     static const int SearchDescriptionRole = Qt::UserRole;
 
-    SearchModel(QList<SearchDescription> *search, QObject *parent = nullptr);
+    SearchModel(QObject *parent = nullptr);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -75,7 +75,6 @@ private:
 
     SearchModel *search_model;
     SearchSortFilterProxyModel *search_proxy_model;
-    QList<SearchDescription> search;
 
     void refreshSearch();
     void checkSearchResultEmpty();

--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -13,14 +13,11 @@
 #include <QShortcut>
 #include <QToolTip>
 
-SectionsModel::SectionsModel(QList<SectionDescription> *sections, QObject *parent)
-    : AddressableItemModel<QAbstractListModel>(parent), sections(sections)
-{
-}
+SectionsModel::SectionsModel(QObject *parent) : AddressableItemModel<QAbstractListModel>(parent) {}
 
 int SectionsModel::rowCount(const QModelIndex &) const
 {
-    return sections->count();
+    return sections.count();
 }
 
 int SectionsModel::columnCount(const QModelIndex &) const
@@ -45,11 +42,11 @@ QVariant SectionsModel::data(const QModelIndex &index, int role) const
         QColor("#95A5A6") // COBCRETE
     };
 
-    if (index.row() >= sections->count()) {
+    if (index.row() >= sections.count()) {
         return QVariant();
     }
 
-    const SectionDescription &section = sections->at(index.row());
+    const SectionDescription &section = sections.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
@@ -115,13 +112,13 @@ QVariant SectionsModel::headerData(int section, Qt::Orientation, int role) const
 
 RVA SectionsModel::address(const QModelIndex &index) const
 {
-    const SectionDescription &section = sections->at(index.row());
+    const SectionDescription &section = sections.at(index.row());
     return section.vaddr;
 }
 
 QString SectionsModel::name(const QModelIndex &index) const
 {
-    const SectionDescription &section = sections->at(index.row());
+    const SectionDescription &section = sections.at(index.row());
     return section.name;
 }
 
@@ -180,7 +177,7 @@ SectionsWidget::~SectionsWidget() = default;
 
 void SectionsWidget::initSectionsTable()
 {
-    sectionsModel = new SectionsModel(&sections, this);
+    sectionsModel = new SectionsModel(this);
     proxyModel = new SectionsProxyModel(sectionsModel, this);
     setModels(proxyModel);
 
@@ -255,7 +252,7 @@ void SectionsWidget::refreshSections()
         return;
     }
     sectionsModel->beginResetModel();
-    sections = Core()->getAllSections();
+    sectionsModel->sections = Core()->getAllSections();
     sectionsModel->endResetModel();
     qhelpers::adjustColumns(ui->treeView, SectionsModel::ColumnCount, 0);
     refreshDocks();

--- a/src/widgets/SectionsWidget.h
+++ b/src/widgets/SectionsWidget.h
@@ -33,7 +33,7 @@ class SectionsModel : public AddressableItemModel<QAbstractListModel>
     friend SectionsWidget;
 
 private:
-    QList<SectionDescription> *sections;
+    QList<SectionDescription> sections;
 
 public:
     enum Column {
@@ -49,7 +49,7 @@ public:
     };
     enum Role { SectionDescriptionRole = Qt::UserRole };
 
-    SectionsModel(QList<SectionDescription> *sections, QObject *parent = nullptr);
+    SectionsModel(QObject *parent = nullptr);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -89,7 +89,6 @@ protected:
     void resizeEvent(QResizeEvent *event) override;
 
 private:
-    QList<SectionDescription> sections;
     SectionsModel *sectionsModel;
     SectionsProxyModel *proxyModel;
 

--- a/src/widgets/SegmentsWidget.cpp
+++ b/src/widgets/SegmentsWidget.cpp
@@ -6,14 +6,11 @@
 #include <QVBoxLayout>
 #include <QShortcut>
 
-SegmentsModel::SegmentsModel(QList<SegmentDescription> *segments, QObject *parent)
-    : AddressableItemModel<QAbstractListModel>(parent), segments(segments)
-{
-}
+SegmentsModel::SegmentsModel(QObject *parent) : AddressableItemModel<QAbstractListModel>(parent) {}
 
 int SegmentsModel::rowCount(const QModelIndex &) const
 {
-    return segments->count();
+    return segments.count();
 }
 
 int SegmentsModel::columnCount(const QModelIndex &) const
@@ -38,10 +35,10 @@ QVariant SegmentsModel::data(const QModelIndex &index, int role) const
         QColor("#95A5A6") // COBCRETE
     };
 
-    if (index.row() >= segments->count())
+    if (index.row() >= segments.count())
         return QVariant();
 
-    const SegmentDescription &segment = segments->at(index.row());
+    const SegmentDescription &segment = segments.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
@@ -99,13 +96,13 @@ QVariant SegmentsModel::headerData(int segment, Qt::Orientation, int role) const
 
 RVA SegmentsModel::address(const QModelIndex &index) const
 {
-    const SegmentDescription &segment = segments->at(index.row());
+    const SegmentDescription &segment = segments.at(index.row());
     return segment.vaddr;
 }
 
 QString SegmentsModel::name(const QModelIndex &index) const
 {
-    const SegmentDescription &segment = segments->at(index.row());
+    const SegmentDescription &segment = segments.at(index.row());
     return segment.name;
 }
 
@@ -142,7 +139,7 @@ SegmentsWidget::SegmentsWidget(MainWindow *main) : ListDockWidget(main)
     setObjectName("SegmentsWidget");
     setWindowTitle(tr("Segments"));
 
-    segmentsModel = new SegmentsModel(&segments, this);
+    segmentsModel = new SegmentsModel(this);
     auto proxyModel = new SegmentsProxyModel(segmentsModel, this);
     setModels(proxyModel);
 
@@ -162,7 +159,7 @@ SegmentsWidget::~SegmentsWidget() {}
 void SegmentsWidget::refreshSegments()
 {
     segmentsModel->beginResetModel();
-    segments = Core()->getAllSegments();
+    segmentsModel->segments = Core()->getAllSegments();
     segmentsModel->endResetModel();
 
     qhelpers::adjustColumns(ui->treeView, SegmentsModel::ColumnCount, 0);

--- a/src/widgets/SegmentsWidget.h
+++ b/src/widgets/SegmentsWidget.h
@@ -19,7 +19,7 @@ class SegmentsModel : public AddressableItemModel<QAbstractListModel>
     friend SegmentsWidget;
 
 private:
-    QList<SegmentDescription> *segments;
+    QList<SegmentDescription> segments;
 
 public:
     enum Column {
@@ -33,7 +33,7 @@ public:
     };
     enum Role { SegmentDescriptionRole = Qt::UserRole };
 
-    SegmentsModel(QList<SegmentDescription> *segments, QObject *parent = nullptr);
+    SegmentsModel(QObject *parent = nullptr);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -69,7 +69,6 @@ private slots:
     void refreshSegments();
 
 private:
-    QList<SegmentDescription> segments;
     SegmentsModel *segmentsModel;
 };
 

--- a/src/widgets/StringsWidget.cpp
+++ b/src/widgets/StringsWidget.cpp
@@ -9,14 +9,11 @@
 #include <QModelIndex>
 #include <QShortcut>
 
-StringsModel::StringsModel(QList<StringDescription> *strings, QObject *parent)
-    : AddressableItemModel<QAbstractListModel>(parent), strings(strings)
-{
-}
+StringsModel::StringsModel(QObject *parent) : AddressableItemModel<QAbstractListModel>(parent) {}
 
 int StringsModel::rowCount(const QModelIndex &) const
 {
-    return strings->count();
+    return strings.count();
 }
 
 int StringsModel::columnCount(const QModelIndex &) const
@@ -26,10 +23,10 @@ int StringsModel::columnCount(const QModelIndex &) const
 
 QVariant StringsModel::data(const QModelIndex &index, int role) const
 {
-    if (index.row() >= strings->count())
+    if (index.row() >= strings.count())
         return QVariant();
 
-    const StringDescription &str = strings->at(index.row());
+    const StringDescription &str = strings.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
@@ -87,13 +84,13 @@ QVariant StringsModel::headerData(int section, Qt::Orientation, int role) const
 
 RVA StringsModel::address(const QModelIndex &index) const
 {
-    const StringDescription &str = strings->at(index.row());
+    const StringDescription &str = strings.at(index.row());
     return str.vaddr;
 }
 
 const StringDescription *StringsModel::description(const QModelIndex &index) const
 {
-    return &strings->at(index.row());
+    return &strings.at(index.row());
 }
 
 StringsProxyModel::StringsProxyModel(StringsModel *sourceModel, QObject *parent)
@@ -175,7 +172,7 @@ StringsWidget::StringsWidget(MainWindow *main)
 
     ui->stringsTreeView->setContextMenuPolicy(Qt::CustomContextMenu);
 
-    model = new StringsModel(&strings, this);
+    model = new StringsModel(this);
     proxyModel = new StringsProxyModel(model, this);
     ui->stringsTreeView->setMainWindow(main);
     ui->stringsTreeView->setModel(proxyModel);
@@ -253,7 +250,7 @@ void StringsWidget::refreshSectionCombo()
 void StringsWidget::stringSearchFinished(const QList<StringDescription> &strings)
 {
     model->beginResetModel();
-    this->strings = strings;
+    model->strings = strings;
     model->endResetModel();
 
     tree->showItemsNumber(proxyModel->rowCount());

--- a/src/widgets/StringsWidget.h
+++ b/src/widgets/StringsWidget.h
@@ -27,7 +27,7 @@ class StringsModel : public AddressableItemModel<QAbstractListModel>
     friend StringsWidget;
 
 private:
-    QList<StringDescription> *strings;
+    QList<StringDescription> strings;
 
 public:
     enum Column {
@@ -42,7 +42,7 @@ public:
     };
     static const int StringDescriptionRole = Qt::UserRole;
 
-    StringsModel(QList<StringDescription> *strings, QObject *parent = nullptr);
+    StringsModel(QObject *parent = nullptr);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -92,7 +92,6 @@ private:
 
     StringsModel *model;
     StringsProxyModel *proxyModel;
-    QList<StringDescription> strings;
     CutterTreeWidget *tree;
 };
 

--- a/src/widgets/SymbolsWidget.cpp
+++ b/src/widgets/SymbolsWidget.cpp
@@ -5,14 +5,11 @@
 
 #include <QShortcut>
 
-SymbolsModel::SymbolsModel(QList<SymbolDescription> *symbols, QObject *parent)
-    : AddressableItemModel<QAbstractListModel>(parent), symbols(symbols)
-{
-}
+SymbolsModel::SymbolsModel(QObject *parent) : AddressableItemModel<QAbstractListModel>(parent) {}
 
 int SymbolsModel::rowCount(const QModelIndex &) const
 {
-    return symbols->count();
+    return symbols.count();
 }
 
 int SymbolsModel::columnCount(const QModelIndex &) const
@@ -22,11 +19,11 @@ int SymbolsModel::columnCount(const QModelIndex &) const
 
 QVariant SymbolsModel::data(const QModelIndex &index, int role) const
 {
-    if (index.row() >= symbols->count()) {
+    if (index.row() >= symbols.count()) {
         return QVariant();
     }
 
-    const SymbolDescription &symbol = symbols->at(index.row());
+    const SymbolDescription &symbol = symbols.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
@@ -72,13 +69,13 @@ QVariant SymbolsModel::headerData(int section, Qt::Orientation, int role) const
 
 RVA SymbolsModel::address(const QModelIndex &index) const
 {
-    const SymbolDescription &symbol = symbols->at(index.row());
+    const SymbolDescription &symbol = symbols.at(index.row());
     return symbol.vaddr;
 }
 
 QString SymbolsModel::name(const QModelIndex &index) const
 {
-    const SymbolDescription &symbol = symbols->at(index.row());
+    const SymbolDescription &symbol = symbols.at(index.row());
     return symbol.name;
 }
 
@@ -123,7 +120,7 @@ SymbolsWidget::SymbolsWidget(MainWindow *main) : ListDockWidget(main)
     setWindowTitle(tr("Symbols"));
     setObjectName("SymbolsWidget");
 
-    symbolsModel = new SymbolsModel(&symbols, this);
+    symbolsModel = new SymbolsModel(this);
     symbolsProxyModel = new SymbolsProxyModel(symbolsModel, this);
     setModels(symbolsProxyModel);
     ui->treeView->sortByColumn(SymbolsModel::AddressColumn, Qt::AscendingOrder);
@@ -139,7 +136,7 @@ SymbolsWidget::~SymbolsWidget() {}
 void SymbolsWidget::refreshSymbols()
 {
     symbolsModel->beginResetModel();
-    symbols = Core()->getAllSymbols();
+    symbolsModel->symbols = Core()->getAllSymbols();
     symbolsModel->endResetModel();
 
     qhelpers::adjustColumns(ui->treeView, SymbolsModel::ColumnCount, 0);

--- a/src/widgets/SymbolsWidget.h
+++ b/src/widgets/SymbolsWidget.h
@@ -20,13 +20,13 @@ class SymbolsModel : public AddressableItemModel<QAbstractListModel>
     friend SymbolsWidget;
 
 private:
-    QList<SymbolDescription> *symbols;
+    QList<SymbolDescription> symbols;
 
 public:
     enum Column { AddressColumn = 0, TypeColumn, NameColumn, CommentColumn, ColumnCount };
     enum Role { SymbolDescriptionRole = Qt::UserRole };
 
-    SymbolsModel(QList<SymbolDescription> *exports, QObject *parent = nullptr);
+    SymbolsModel(QObject *parent = nullptr);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -63,7 +63,6 @@ private slots:
     void refreshSymbols();
 
 private:
-    QList<SymbolDescription> symbols;
     SymbolsModel *symbolsModel;
     SymbolsProxyModel *symbolsProxyModel;
 };

--- a/src/widgets/TypesWidget.cpp
+++ b/src/widgets/TypesWidget.cpp
@@ -10,10 +10,7 @@
 #include <QShortcut>
 #include <QIcon>
 
-TypesModel::TypesModel(QList<TypeDescription> *types, QObject *parent)
-    : QAbstractListModel(parent), types(types)
-{
-}
+TypesModel::TypesModel(QObject *parent) : QAbstractListModel(parent) {}
 
 QVariant TypesModel::toolTipValue(const QModelIndex &index) const
 {
@@ -28,7 +25,7 @@ QVariant TypesModel::toolTipValue(const QModelIndex &index) const
 
 int TypesModel::rowCount(const QModelIndex &) const
 {
-    return types->count();
+    return types.count();
 }
 
 int TypesModel::columnCount(const QModelIndex &) const
@@ -38,10 +35,10 @@ int TypesModel::columnCount(const QModelIndex &) const
 
 QVariant TypesModel::data(const QModelIndex &index, int role) const
 {
-    if (index.row() >= types->count())
+    if (index.row() >= types.count())
         return QVariant();
 
-    const TypeDescription &exp = types->at(index.row());
+    const TypeDescription &exp = types.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
@@ -90,10 +87,10 @@ QVariant TypesModel::headerData(int section, Qt::Orientation, int role) const
 bool TypesModel::removeRows(int row, int count, const QModelIndex &parent)
 {
     RzCoreLocked core(Core());
-    rz_type_db_del(core->analysis->typedb, types->at(row).type.toUtf8().constData());
+    rz_type_db_del(core->analysis->typedb, types.at(row).type.toUtf8().constData());
     beginRemoveRows(parent, row, row + count - 1);
     while (count--) {
-        types->removeAt(row);
+        types.removeAt(row);
     }
     endRemoveRows();
     return true;
@@ -160,7 +157,7 @@ TypesWidget::TypesWidget(MainWindow *main)
     ui->typesTreeView->setSelectionMode(QAbstractItemView::SingleSelection);
 
     // Setup up the model and the proxy model
-    types_model = new TypesModel(&types, this);
+    types_model = new TypesModel(this);
     types_proxy_model = new TypesSortFilterProxyModel(types_model, this);
     ui->typesTreeView->setModel(types_proxy_model);
     ui->typesTreeView->sortByColumn(TypesModel::TYPE, Qt::AscendingOrder);
@@ -210,11 +207,11 @@ TypesWidget::~TypesWidget() {}
 void TypesWidget::refreshTypes()
 {
     types_model->beginResetModel();
-    types = Core()->getAllTypes();
+    types_model->types = Core()->getAllTypes();
     types_model->endResetModel();
 
     QStringList categories;
-    for (TypeDescription exp : types) {
+    for (const TypeDescription &exp : types_model->types) {
         categories << exp.category;
     }
     categories.removeDuplicates();

--- a/src/widgets/TypesWidget.h
+++ b/src/widgets/TypesWidget.h
@@ -28,7 +28,7 @@ class TypesModel : public QAbstractListModel
     friend TypesWidget;
 
 private:
-    QList<TypeDescription> *types;
+    QList<TypeDescription> types;
 
     /**
      * @brief Returns a description of the type for the given index
@@ -39,7 +39,7 @@ public:
     enum Columns { TYPE = 0, SIZE, CATEGORY, FORMAT, COUNT };
     static const int TypeDescriptionRole = Qt::UserRole;
 
-    TypesModel(QList<TypeDescription> *types, QObject *parent = nullptr);
+    TypesModel(QObject *parent = nullptr);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -121,7 +121,6 @@ private:
 
     TypesModel *types_model;
     TypesSortFilterProxyModel *types_proxy_model;
-    QList<TypeDescription> types;
     CutterTreeWidget *tree;
     QAction *actionViewType;
     QAction *actionEditType;

--- a/src/widgets/VTablesWidget.cpp
+++ b/src/widgets/VTablesWidget.cpp
@@ -8,10 +8,7 @@
 #include "VTablesWidget.h"
 #include "ui_VTablesWidget.h"
 
-VTableModel::VTableModel(QList<VTableDescription> *vtables, QObject *parent)
-    : QAbstractItemModel(parent), vtables(vtables)
-{
-}
+VTableModel::VTableModel(QObject *parent) : QAbstractItemModel(parent) {}
 
 QModelIndex VTableModel::index(int row, int column, const QModelIndex &parent) const
 {
@@ -28,8 +25,8 @@ QModelIndex VTableModel::parent(const QModelIndex &index) const
 int VTableModel::rowCount(const QModelIndex &parent) const
 {
     return parent.isValid()
-            ? (parent.parent().isValid() ? 0 : vtables->at(parent.row()).methods.count())
-            : vtables->count();
+            ? (parent.parent().isValid() ? 0 : vtables.at(parent.row()).methods.count())
+            : vtables.count();
 }
 
 int VTableModel::columnCount(const QModelIndex &) const
@@ -41,7 +38,7 @@ QVariant VTableModel::data(const QModelIndex &index, int role) const
 {
     QModelIndex parent = index.parent();
     if (parent.isValid()) {
-        const BinClassMethodDescription &res = vtables->at(parent.row()).methods.at(index.row());
+        const BinClassMethodDescription &res = vtables.at(parent.row()).methods.at(index.row());
         switch (role) {
         case Qt::DisplayRole:
             switch (index.column()) {
@@ -63,11 +60,11 @@ QVariant VTableModel::data(const QModelIndex &index, int role) const
             case NAME:
                 return tr("VTable") + " " + QString::number(index.row() + 1);
             case ADDRESS:
-                return RzAddressString(vtables->at(index.row()).addr);
+                return RzAddressString(vtables.at(index.row()).addr);
             }
             break;
         case VTableDescriptionRole: {
-            const VTableDescription &res = vtables->at(index.row());
+            const VTableDescription &res = vtables.at(index.row());
             return QVariant::fromValue(res);
         }
         default:
@@ -135,7 +132,7 @@ VTablesWidget::VTablesWidget(MainWindow *main)
     // Add Status Bar footer
     tree->addStatusBar(ui->verticalLayout);
 
-    model = new VTableModel(&vtables, this);
+    model = new VTableModel(this);
     proxy = new VTableSortFilterProxyModel(model, this);
 
     ui->vTableTreeView->setModel(proxy);
@@ -176,7 +173,7 @@ void VTablesWidget::refreshVTables()
     }
 
     model->beginResetModel();
-    vtables = Core()->getAllVTables();
+    model->vtables = Core()->getAllVTables();
     model->endResetModel();
 
     qhelpers::adjustColumns(ui->vTableTreeView, 3, 0);

--- a/src/widgets/VTablesWidget.h
+++ b/src/widgets/VTablesWidget.h
@@ -24,13 +24,13 @@ class VTableModel : public QAbstractItemModel
     friend VTablesWidget;
 
 private:
-    QList<VTableDescription> *vtables;
+    QList<VTableDescription> vtables;
 
 public:
     enum Columns { NAME = 0, ADDRESS, COUNT };
     static const int VTableDescriptionRole = Qt::UserRole;
 
-    VTableModel(QList<VTableDescription> *vtables, QObject *parent = nullptr);
+    VTableModel(QObject *parent = nullptr);
 
     QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const;
     QModelIndex parent(const QModelIndex &index) const;
@@ -68,7 +68,6 @@ private:
 
     VTableModel *model;
     QSortFilterProxyModel *proxy;
-    QList<VTableDescription> vtables;
     CutterTreeWidget *tree;
     RefreshDeferrer *refreshDeferrer;
 };


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [X] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Noticed that `importAddresses` was being used after being freed (see my logs on #3516) and I was able to fix it by moving that property to `FunctionModel` instead of `FunctionsWidget`, but I also found a lot of other widgets were causing similar crashes. I think this should cover most if not all of them.

What this does specifically is attach the lifetime of the widget data to each Model instead the widget itself, so they can still be used after the widget has been deallocated. This is similar to what is already implemented on some widgets ([Breakpoint](https://github.com/rizinorg/cutter/blob/dev/src/widgets/BreakpointWidget.h), [Relocs](https://github.com/rizinorg/cutter/blob/dev/src/widgets/RelocsWidget.h), [Stack](https://github.com/rizinorg/cutter/blob/dev/src/widgets/StackWidget.h) and [Threads](https://github.com/rizinorg/cutter/blob/dev/src/widgets/ThreadsWidget.h)).

Also found a similar pattern on `BaseFindResultsDialog`, although I didn't get a crash from it specifically.

Apparently, only required for Qt 6.9.1+.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

While Cutter is running, there should be no difference at all. Only at shutdown that there shouldn't be any more crashes coming from the Widgets. It is also reported in #3516 that the crash can happen while saving, but I didn't get that error specifically. I'll see if I can reproduce it.

I haven't tested Qt5 yet (edit: 5.15.5 works). It would be nice to verify that it works there too.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

Closes #3516 
