### PR TITLE
Allow setting RzRun profile before debugging

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,6 +159,7 @@ set(SOURCES
     shortcuts/ShortcutManager.cpp
     shortcuts/DefaultShortcuts.cpp
     dialogs/MarkDialog.cpp
+    dialogs/ProfileDirectivesDialog.cpp
 )
 set(HEADER_FILES
     core/Cutter.h
@@ -327,6 +328,7 @@ set(HEADER_FILES
     shortcuts/ShortcutManager.h
     shortcuts/DefaultShortcuts.h
     dialogs/MarkDialog.h
+    dialogs/ProfileDirectivesDialog.h
 )
 set(UI_FILES
     dialogs/AboutDialog.ui
@@ -403,6 +405,7 @@ set(UI_FILES
     tools/basefind/BaseFindResultsDialog.ui
     dialogs/preferences/ShortcutOptionsWidget.ui
     dialogs/MarkDialog.ui
+    dialogs/ProfileDirectivesDialog.ui
 )
 set(QRC_FILES
     resources.qrc

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -441,6 +441,24 @@ bool CutterCore::isDebugTaskInProgress()
     return false;
 }
 
+void CutterCore::setProfileDirectives(const QString &directives)
+{
+    QString file = getConfig("dbg.profile");
+    if (file.isEmpty()) {
+        char *temp_path = rz_file_temp("rz-run");
+        file = QString::fromUtf8(temp_path);
+        free(temp_path);
+        setConfig("dbg.profile", file);
+    }
+
+    QByteArray fileNameBytes = file.toUtf8();
+    QByteArray directiveBytes = directives.toUtf8();
+
+    const char *pathPtr = fileNameBytes.constData();
+    rz_file_dump(pathPtr, (const ut8 *)directiveBytes.data(), (int)directiveBytes.size(), 0);
+    rz_file_dump(pathPtr, (const ut8 *)"\n", 1, 1);
+}
+
 bool CutterCore::asyncTask(std::function<void *(RzCore *)> fcn, QSharedPointer<RizinTask> &task)
 {
     if (!task.isNull()) {

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -554,6 +554,14 @@ public:
     QList<RVA> getBreakpointsAddresses();
 
     /**
+     * @brief Sets the RzRun profile directives by writing them to a file
+     * If a profile path is already set in 'dbg.profile', this method overwrites that file
+     * If no path is set, it creates a temporary file and updates 'dbg.profile' to point to it
+     * @param directives The raw string containing key=value profile directives
+     */
+    void setProfileDirectives(const QString &directives);
+
+    /**
      * @brief Get all breakpoinst that are belong to a functions at this address
      */
     QList<RVA> getBreakpointsInFunction(RVA funcAddr);

--- a/src/dialogs/NativeDebugDialog.cpp
+++ b/src/dialogs/NativeDebugDialog.cpp
@@ -6,6 +6,7 @@
 #include <QMessageBox>
 #include <QShortcut>
 #include <QFileDialog>
+#include <QTextStream>
 
 NativeDebugDialog::NativeDebugDialog(QWidget *parent)
     : QDialog(parent), ui(new Ui::NativeDebugDialog)

--- a/src/dialogs/NativeDebugDialog.cpp
+++ b/src/dialogs/NativeDebugDialog.cpp
@@ -125,5 +125,5 @@ void NativeDebugDialog::directiveListBtnClicked()
 
 void NativeDebugDialog::showWarning(const QString &filePath)
 {
-    QMessageBox::warning(this, "Error", QString("Could not open file: %1").arg(filePath));
+    QMessageBox::warning(this, tr("Error"), tr("Could not open file: %1").arg(filePath));
 }

--- a/src/dialogs/NativeDebugDialog.cpp
+++ b/src/dialogs/NativeDebugDialog.cpp
@@ -1,9 +1,11 @@
 #include "NativeDebugDialog.h"
 #include "ui_NativeDebugDialog.h"
 #include "shortcuts/ShortcutManager.h"
+#include "ProfileDirectivesDialog.h"
 
 #include <QMessageBox>
 #include <QShortcut>
+#include <QFileDialog>
 
 NativeDebugDialog::NativeDebugDialog(QWidget *parent)
     : QDialog(parent), ui(new Ui::NativeDebugDialog)
@@ -13,6 +15,15 @@ NativeDebugDialog::NativeDebugDialog(QWidget *parent)
     auto shortcut = Shortcuts()->makeQShortcut("Debug.accept", ui->argEdit);
     shortcut->setContext(Qt::ShortcutContext::WidgetShortcut);
     connect(shortcut, &QShortcut::activated, this, &QDialog::accept);
+
+    connect(ui->profileCheckbox, &QCheckBox::toggled, this,
+            &NativeDebugDialog::profileCheckboxToggled);
+    connect(ui->profilePathBtn, &QPushButton::clicked, this,
+            &NativeDebugDialog::profilePathBtnClicked);
+    connect(ui->directiveListBtn, &QPushButton::clicked, this,
+            &NativeDebugDialog::directiveListBtnClicked);
+
+    profileCheckboxToggled(ui->profileCheckbox->isChecked());
 }
 
 NativeDebugDialog::~NativeDebugDialog() {}
@@ -26,4 +37,92 @@ void NativeDebugDialog::setArgs(const QString &args)
 {
     ui->argEdit->setPlainText(args);
     ui->argEdit->selectAll();
+}
+
+void NativeDebugDialog::setProfilePath(const QString &profilePath)
+{
+    ui->profilePathEdit->setText(profilePath);
+    setFileContents(profilePath);
+}
+
+void NativeDebugDialog::profileCheckboxToggled(bool checked)
+{
+    if (checked && showWarningWhenChecked) {
+        showWarning(profilePath);
+    }
+
+    ui->argEdit->setEnabled(!checked);
+    ui->argText->setEnabled(!checked);
+
+    ui->profileText->setEnabled(checked);
+    ui->profilePathEdit->setEnabled(checked);
+    ui->profilePathBtn->setEnabled(checked);
+    ui->directiveText->setEnabled(checked);
+    ui->directiveEdit->setEnabled(checked);
+}
+
+QString NativeDebugDialog::getProfilePath() const
+{
+    return ui->profilePathEdit->text();
+}
+
+QString NativeDebugDialog::getDirectives() const
+{
+    return ui->directiveEdit->toPlainText();
+}
+
+DebugConfigMethod NativeDebugDialog::getSelectedMethod() const
+{
+    return !ui->profileCheckbox->isChecked()
+            ? DebugConfigMethod::CommandLine
+            : (ui->directiveEdit->document()->isModified() ? DebugConfigMethod::RzRunDirectives
+                                                           : DebugConfigMethod::RzRunProfile);
+}
+
+void NativeDebugDialog::profilePathBtnClicked()
+{
+    QString filePath =
+            QFileDialog::getOpenFileName(this, tr("Open RzRun Profile"), QString(),
+                                         tr("RzRun Profiles (*.rz *.rrz);;All Files (*)"));
+    setFileContents(filePath);
+}
+
+void NativeDebugDialog::setFileContents(const QString &filePath)
+{
+    if (filePath.isEmpty()) {
+        return;
+    }
+
+    ui->profilePathEdit->setText(filePath);
+
+    QFile file(filePath);
+    if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QTextStream in(&file);
+        QString directives = in.readAll();
+
+        // These directives are loaded from the profile
+        // If unmodified: 'dbg.profile' will point directly to the original file path
+        // If modified: A temporary file containing the new directives will be created and used as
+        // the 'dbg.profile' value instead
+        ui->directiveEdit->setPlainText(directives);
+        ui->directiveEdit->document()->setModified(false);
+
+        file.close();
+    } else if (ui->profileCheckbox->isChecked()) {
+        showWarning(filePath);
+    } else {
+        showWarningWhenChecked = true;
+        profilePath = filePath;
+    }
+}
+
+void NativeDebugDialog::directiveListBtnClicked()
+{
+    ProfileDirectivesDialog pdd(this);
+    pdd.exec();
+}
+
+void NativeDebugDialog::showWarning(const QString &filePath)
+{
+    QMessageBox::warning(this, "Error", QString("Could not open file: %1").arg(filePath));
 }

--- a/src/dialogs/NativeDebugDialog.h
+++ b/src/dialogs/NativeDebugDialog.h
@@ -8,6 +8,8 @@ namespace Ui {
 class NativeDebugDialog;
 }
 
+enum class DebugConfigMethod { CommandLine, RzRunProfile, RzRunDirectives };
+
 /**
  * @brief Dialog for connecting to native debug
  */
@@ -22,8 +24,38 @@ public:
     QString getArgs() const;
     void setArgs(const QString &args);
 
+    /**
+     * @brief Sets the path to an RzRun profile and loads its contents
+     * @param profilePath Path to a .rz or .rrz file
+     */
+    void setProfilePath(const QString &profilePath);
+
+    QString getProfilePath() const;
+    QString getDirectives() const;
+
+    /**
+     * @brief Determines which configuration method should be used based on UI state
+     * @return The selected DebugConfigMethod
+     */
+    DebugConfigMethod getSelectedMethod() const;
+
+private slots:
+    void profileCheckboxToggled(bool checked);
+    void profilePathBtnClicked();
+    void directiveListBtnClicked();
+
 private:
     std::unique_ptr<Ui::NativeDebugDialog> ui;
+
+    /**
+     * @brief Reads a file from disk and populates the directive edit
+     * @param filePath Path of the file to read
+     */
+    void setFileContents(const QString &filePath);
+
+    void showWarning(const QString &filePath);
+    QString profilePath;
+    bool showWarningWhenChecked = false;
 };
 
 #endif // NATIVE_DEBUG_DIALOG

--- a/src/dialogs/NativeDebugDialog.ui
+++ b/src/dialogs/NativeDebugDialog.ui
@@ -3,14 +3,14 @@
  <class>NativeDebugDialog</class>
  <widget class="QDialog" name="NativeDebugDialog">
   <property name="windowModality">
-   <enum>Qt::NonModal</enum>
+   <enum>Qt::WindowModality::NonModal</enum>
   </property>
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>350</width>
-    <height>113</height>
+    <width>600</width>
+    <height>450</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -53,41 +53,94 @@
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>16777215</height>
+       <height>45</height>
       </size>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+    <widget class="QCheckBox" name="profileCheckbox">
+     <property name="text">
+      <string>Use Debugger Profile (RzRun)</string>
      </property>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="loadProfileLayout">
+     <item>
+      <widget class="QLabel" name="profileText">
+       <property name="text">
+        <string>Load Profile</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="profilePathEdit">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="profilePathBtn">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Select</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="directiveText">
+     <property name="text">
+      <string>Profile Directives</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="directiveEdit">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="inputMethodHints">
+      <set>Qt::InputMethodHint::ImhMultiLine</set>
+     </property>
+     <property name="placeholderText">
+      <string>key=value</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="bottomLayout">
+     <item>
+      <widget class="QPushButton" name="directiveListBtn">
+       <property name="text">
+        <string>Show Profile Directives</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
  <resources/>
  <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>NativeDebugDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>234</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
@@ -101,6 +154,22 @@
     <hint type="destinationlabel">
      <x>286</x>
      <y>254</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>NativeDebugDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>234</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
     </hint>
    </hints>
   </connection>

--- a/src/dialogs/NativeDebugDialog.ui
+++ b/src/dialogs/NativeDebugDialog.ui
@@ -121,7 +121,7 @@
      <item>
       <widget class="QPushButton" name="directiveListBtn">
        <property name="text">
-        <string>Show All Directives</string>
+        <string>Show Help</string>
        </property>
       </widget>
      </item>

--- a/src/dialogs/NativeDebugDialog.ui
+++ b/src/dialogs/NativeDebugDialog.ui
@@ -121,7 +121,7 @@
      <item>
       <widget class="QPushButton" name="directiveListBtn">
        <property name="text">
-        <string>Show Profile Directives</string>
+        <string>Show All Directives</string>
        </property>
       </widget>
      </item>

--- a/src/dialogs/NativeDebugDialog.ui
+++ b/src/dialogs/NativeDebugDialog.ui
@@ -61,7 +61,7 @@
    <item>
     <widget class="QCheckBox" name="profileCheckbox">
      <property name="text">
-      <string>Use Debugger Profile (RzRun)</string>
+      <string>Use RzRun Profile</string>
      </property>
     </widget>
    </item>

--- a/src/dialogs/ProfileDirectivesDialog.cpp
+++ b/src/dialogs/ProfileDirectivesDialog.cpp
@@ -8,10 +8,10 @@ ProfileDirectivesDialog::ProfileDirectivesDialog(QWidget *parent)
 {
     ui->setupUi(this);
 
-    setWindowTitle("Profile Directives");
+    setWindowTitle(tr("Profile Directives"));
 
     model = new QStandardItemModel(this);
-    model->setHorizontalHeaderLabels({ "Key", "Description" });
+    model->setHorizontalHeaderLabels({ tr("Key"), tr("Description") });
 
     addDirective("arg[0-511]", tr("Set value for argument N passed to the program"));
     addDirective("aslr", tr("Enable or disable ASLR"));

--- a/src/dialogs/ProfileDirectivesDialog.cpp
+++ b/src/dialogs/ProfileDirectivesDialog.cpp
@@ -1,0 +1,90 @@
+#include "ProfileDirectivesDialog.h"
+#include "ui_ProfileDirectivesDialog.h"
+
+#include <QPushButton>
+
+ProfileDirectivesDialog::ProfileDirectivesDialog(QWidget *parent)
+    : QDialog(parent), ui(new Ui::ProfileDirectivesDialog)
+{
+    ui->setupUi(this);
+
+    setWindowTitle("Profile Directives");
+
+    model = new QStandardItemModel(this);
+    model->setHorizontalHeaderLabels({ "Key", "Description" });
+
+    addDirective("arg[0-511]", tr("Set value for argument N passed to the program"));
+    addDirective("aslr", tr("Enable or disable ASLR"));
+    addDirective("bits", tr("Set 32 or 64 bit (if the architecture supports it)"));
+    addDirective("chdir", tr("Change directory before executing the program"));
+    addDirective("chroot", tr("Run the program in chroot. requires some previous setup"));
+    addDirective("connect", tr("Connect stdin/stdout/stderr to a socket"));
+    addDirective("core", tr("Set no limit the core file size"));
+    addDirective("daemon",
+                 tr("Set to false by default, otherwise it will run the program in background, "
+                    "detached from the terminal"));
+    addDirective("envfile", tr("Set a file with lines like `var=value` to be used as env"));
+    addDirective("fork",
+                 tr("Used with the listen option, allow to spawn a different process for each "
+                    "connection. Ignored when debugging."));
+    addDirective("input", tr("Set string to be passed to the program via stdin"));
+    addDirective("libpath",
+                 tr("Override path where the dynamic loader will look for shared libraries"));
+    addDirective("listen", tr("Bound stdin/stdout/stderr to a listening socket"));
+    addDirective("maxfd", tr("Set the maximum number of file descriptors"));
+    addDirective("maxproc", tr("Set the maximum number of processes"));
+    addDirective("maxstack", tr("Set the maximum size for the stack"));
+    addDirective("nice", tr("Set the niceness level of the process"));
+    addDirective("pid", tr("Set to true to print the PID of the process to stderr"));
+    addDirective("pidfile", tr("Print the PID of the process to the specified file"));
+    addDirective("preload", tr("Preload a library (not supported on Windows, only linux,osx,bsd)"));
+    addDirective("program", tr("Path to program to be executed"));
+    addDirective("pty", tr("Use a pty for connection over socket (with connect/listen)"));
+    addDirective("runlib", tr("Path to the library to be executed"));
+    addDirective("runlib.fcn", tr("Function name to call from runlib library"));
+    addDirective("rzpreload",
+                 tr("Preload with librz, kill -USR1 to get an rizin shell or -USRZ to spawn a "
+                    "webserver in a thread"));
+    addDirective("setegid", tr("Set effective process group id"));
+    addDirective("setenv", tr("Set value for given environment variable (setenv=FOO=BAR)"));
+    addDirective("seteuid", tr("Set effective process uid"));
+    addDirective("setgid", tr("Set process group id"));
+    addDirective("setuid", tr("Set process uid"));
+    addDirective("sleep", tr("Sleep for the given amount of seconds"));
+    addDirective("sterr", tr("Select file to replace stderr file descriptor"));
+    addDirective("stdin", tr("Select file to read data from stdin"));
+    addDirective(
+            "stdio",
+            tr("Select io stream to redirect data from/to. Redirect input/output to the process "
+               "created by the command prefixed by '!' (stdio=!cmd)"));
+    addDirective("stdout", tr("Select file to replace stdout file descriptor"));
+    addDirective("system", tr("Execute the given command"));
+    addDirective("timeout", tr("Set a timeout"));
+    addDirective("timeoutsig",
+                 tr("Signal to use when killing the child because the timeout happens"));
+    addDirective("unsetenv", tr("Unset one environment variable"));
+
+    proxyModel = new QSortFilterProxyModel(this);
+    proxyModel->setSourceModel(model);
+    proxyModel->setFilterKeyColumn(0);
+    proxyModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
+
+    ui->treeView->setModel(proxyModel);
+    ui->treeView->setSortingEnabled(true);
+    ui->treeView->resizeColumnToContents(1);
+    ui->treeView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+
+    connect(ui->filterEdit, &QLineEdit::textChanged, proxyModel,
+            &QSortFilterProxyModel::setFilterFixedString);
+    connect(ui->closeBtn, &QPushButton::clicked, this, &QDialog::close);
+}
+
+ProfileDirectivesDialog::~ProfileDirectivesDialog() {}
+
+void ProfileDirectivesDialog::addDirective(const QString &key, const QString &description)
+{
+    QList<QStandardItem *> items;
+    items << new QStandardItem(key);
+    items << new QStandardItem(description);
+    model->appendRow(items);
+}

--- a/src/dialogs/ProfileDirectivesDialog.h
+++ b/src/dialogs/ProfileDirectivesDialog.h
@@ -1,0 +1,37 @@
+#ifndef PROFILEDIRECTIVESDIALOG_H
+#define PROFILEDIRECTIVESDIALOG_H
+
+#include <QDialog>
+#include <QStandardItemModel>
+#include <QSortFilterProxyModel>
+#include <memory>
+
+namespace Ui {
+class ProfileDirectivesDialog;
+}
+
+/**
+ * @brief Dialog displaying a searchable list of available RzRun profile directives
+ */
+class ProfileDirectivesDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ProfileDirectivesDialog(QWidget *parent = nullptr);
+    ~ProfileDirectivesDialog();
+
+private:
+    std::unique_ptr<Ui::ProfileDirectivesDialog> ui;
+    QStandardItemModel *model;
+    QSortFilterProxyModel *proxyModel;
+
+    /**
+     * @brief Adds a directive entry to the list model
+     * @param key The directive name (e.g., "aslr")
+     * @param description Explanation of what the directive does
+     */
+    void addDirective(const QString &key, const QString &description);
+};
+
+#endif

--- a/src/dialogs/ProfileDirectivesDialog.ui
+++ b/src/dialogs/ProfileDirectivesDialog.ui
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ProfileDirectivesDialog</class>
+ <widget class="QDialog" name="ProfileDirectivesDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>950</width>
+    <height>650</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTreeView" name="treeView"/>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="filterEdit">
+     <property name="placeholderText">
+      <string>Filter</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="bottomLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeBtn">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -387,15 +387,28 @@ void DebugActions::startDebug()
 
     NativeDebugDialog dialog(main);
     dialog.setArgs(Core()->getConfig("dbg.args"));
-    QString args;
-    if (dialog.exec()) {
-        args = dialog.getArgs();
-    } else {
+    dialog.setProfilePath(Core()->getConfig("dbg.profile"));
+    if (!dialog.exec()) {
         return;
     }
 
-    // Update dbg.args with the new args
-    Core()->setConfig("dbg.args", args);
+    switch (dialog.getSelectedMethod()) {
+    case DebugConfigMethod::CommandLine: {
+        Core()->setConfig("dbg.args", dialog.getArgs());
+        Core()->setConfig("dbg.profile", ""); // profile overrides args, so remove it
+        break;
+    }
+    case DebugConfigMethod::RzRunProfile: {
+        Core()->setConfig("dbg.profile", dialog.getProfilePath());
+        break;
+    }
+    case DebugConfigMethod::RzRunDirectives: {
+        Core()->setProfileDirectives(dialog.getDirectives());
+        break;
+    }
+    default:
+        break;
+    }
 
     setAllActionsVisible(true);
     actionAttach->setVisible(false);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Allows setting RzRun profile or RzRun profile directives before debugging in the "Native Debugging Configuration" dialog

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

* Open any binary in cutter
* Click the debug icon or press F9
* Now you can select RzRun profile and optionally modify it OR manually write profile directives
* The dialog also contains a "Show Profile Directives" button which lists all of the valid directives

**Note:** Selecting RzRun profile sets the 'dbg.profile' value equal to the specified file path, If the contents of the file are modified using the "directiveEdit" then a temporary file is created containing the modified directives and 'dbg.profile' value is set to the new temporary file's path, same approach is followed if manually writing directives. That's how **rizin** currently handles directives using `dor` command
 
<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

<img width="400" height="400" alt="rzrun-profile-dialog" src="https://github.com/user-attachments/assets/f8ab166b-2d00-4e05-981e-b4411ed06ec8" />

<img width="1920" height="1080" alt="profile-directives-dialog" src="https://github.com/user-attachments/assets/c979f8d7-e2d9-458b-9289-dd7a62d2d365" />

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3199 
Also related: #2148 #2427 