### PR TITLE
Fix Deadlock in Remote Debug connection

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -2054,7 +2054,7 @@ void CutterCore::attachRemote(const QString &uri)
     // connect to a debugger with the given plugin
     if (!asyncTask(
                 [&](RzCore *core) {
-                    setConfig("cfg.debug", true);
+                    rz_config_set_b(core->config, "cfg.debug", true);
                     rz_core_file_reopen_remote_debug(core, uri.toStdString().c_str(), 0);
                     return nullptr;
                 },


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Fixes the infinite loading issue when connecting to a remote debugger

`setConfig()` tries to lock **core** which is already locked by `asyncTask()`
`asyncTask()` cannot complete and release lock until `setConfig()` finishes -> Deadlock

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

* Start gdbserver in terminal e.g: `gdbserver :1234 <path/to/binary>`
* Open **Cutter**
* Open the debug dropdown by clicking the small arrow next to debug icon
* Select "Connect to a remote debugger"
* Type in the IP and Port, (`127.0.0.1` and `1234` in this case), and start the connection 

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3277 
closes #3350 
closes #3373 