### PR TITLE
feat: Add context menu to change calling convention (#3513)

### DIFF
--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -1024,7 +1024,7 @@ void DisassemblyContextMenu::on_actionEditFunction_triggered()
                 fcn->cc = rz_str_constpool_get(&core->analysis->constpool, newCC.constData());
             }
 
-            emit Core()-> functionsChanged();
+            emit Core()->functionsChanged();
         }
     }
 }
@@ -1117,7 +1117,7 @@ void DisassemblyContextMenu::on_actionSetCallingConvention_triggered(QAction *ac
     QByteArray newCCBytes = newCC.toUtf8();
     if (rz_analysis_cc_exist(core->analysis, newCCBytes.constData())) {
         fcn->cc = rz_str_constpool_get(&core->analysis->constpool, newCCBytes.constData());
-        emit Core()-> functionsChanged();
+        emit Core()->functionsChanged();
     }
 }
 

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -125,6 +125,8 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
     connect(structureOffsetMenu, &QMenu::triggered, this,
             &DisassemblyContextMenu::on_actionStructureOffsetMenu_triggered);
 
+    addSetCallingConventionMenu();
+
     addSetAsMenu();
 
     addSeparator();
@@ -582,6 +584,30 @@ void DisassemblyContextMenu::aboutToShowSlot()
     // Note: This might be useless if we consider setCurrentHighlightedWord is always called before
     setupRenaming();
 
+    if (isHighlightedWordCC()) {
+        setCallingConventionMenu->menuAction()->setVisible(true);
+        setCallingConventionMenu->clear();
+
+        RzCoreLocked core(Core());
+        RzList *list = rz_analysis_calling_conventions(core->analysis);
+        if (list) {
+            RzListIter *iter;
+            const char *cc;
+            CutterRzListForeach (list, iter, const char, cc) {
+                QString ccStr(cc);
+                QAction *action = setCallingConventionMenu->addAction(ccStr);
+                action->setData(ccStr);
+                if (ccStr == curHighlightedWord) {
+                    action->setCheckable(true);
+                    action->setChecked(true);
+                }
+            }
+            rz_list_free(list);
+        }
+    } else {
+        setCallingConventionMenu->menuAction()->setVisible(false);
+    }
+
     // Only show retype for local vars if in a function
     RzAnalysisFunction *in_fcn = Core()->functionIn(offset);
     if (in_fcn) {
@@ -998,7 +1024,7 @@ void DisassemblyContextMenu::on_actionEditFunction_triggered()
                 fcn->cc = rz_str_constpool_get(&core->analysis->constpool, newCC.constData());
             }
 
-            emit Core()->functionsChanged();
+            emit Core() -> functionsChanged();
         }
     }
 }
@@ -1068,4 +1094,49 @@ bool DisassemblyContextMenu::isHighlightedWordLocalVar()
         }
     }
     return false;
+}
+
+void DisassemblyContextMenu::addSetCallingConventionMenu()
+{
+    setCallingConventionMenu = addMenu(tr("Set calling convention"));
+    connect(setCallingConventionMenu, &QMenu::triggered, this,
+            &DisassemblyContextMenu::on_actionSetCallingConvention_triggered);
+}
+
+void DisassemblyContextMenu::on_actionSetCallingConvention_triggered(QAction *action)
+{
+    QString newCC = action->data().toString();
+    if (newCC.isEmpty()) {
+        return;
+    }
+    RzCoreLocked core(Core());
+    RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(core->analysis, offset, 0);
+    if (!fcn) {
+        return;
+    }
+    QByteArray newCCBytes = newCC.toUtf8();
+    if (rz_analysis_cc_exist(core->analysis, newCCBytes.constData())) {
+        fcn->cc = rz_str_constpool_get(&core->analysis->constpool, newCCBytes.constData());
+        emit Core() -> functionsChanged();
+    }
+}
+
+bool DisassemblyContextMenu::isHighlightedWordCC()
+{
+    RzCoreLocked core(Core());
+    RzList *list = rz_analysis_calling_conventions(core->analysis);
+    if (!list) {
+        return false;
+    }
+    bool found = false;
+    RzListIter *iter;
+    const char *cc;
+    CutterRzListForeach (list, iter, const char, cc) {
+        if (curHighlightedWord == QString(cc)) {
+            found = true;
+            break;
+        }
+    }
+    rz_list_free(list);
+    return found;
 }

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -1024,7 +1024,7 @@ void DisassemblyContextMenu::on_actionEditFunction_triggered()
                 fcn->cc = rz_str_constpool_get(&core->analysis->constpool, newCC.constData());
             }
 
-            emit Core() -> functionsChanged();
+            emit Core()-> functionsChanged();
         }
     }
 }
@@ -1117,7 +1117,7 @@ void DisassemblyContextMenu::on_actionSetCallingConvention_triggered(QAction *ac
     QByteArray newCCBytes = newCC.toUtf8();
     if (rz_analysis_cc_exist(core->analysis, newCCBytes.constData())) {
         fcn->cc = rz_str_constpool_get(&core->analysis->constpool, newCCBytes.constData());
-        emit Core() -> functionsChanged();
+        emit Core()-> functionsChanged();
     }
 }
 

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -74,6 +74,7 @@ private slots:
      * \param action The action which trigered the event
      */
     void on_actionStructureOffsetMenu_triggered(QAction *action);
+    void on_actionSetCallingConvention_triggered(QAction *action);
 
 private:
     RVA offset;
@@ -140,6 +141,7 @@ private:
     QAction actionSetAsStringAdvanced;
 
     QMenu *setToDataMenu;
+    QMenu *setCallingConventionMenu;
     QMenu *setAsMenu;
     QMenu *setAsString;
     QAction actionSetToDataEx;
@@ -173,6 +175,7 @@ private:
     void addSetBitsMenu();
     void addSetAsMenu();
     void addSetToDataMenu();
+    void addSetCallingConventionMenu();
     void addEditMenu();
     void addAddAtMenu();
     void addBreakpointMenu();
@@ -210,6 +213,7 @@ private:
      * parameter, return false otherwise.
      */
     bool isHighlightedWordLocalVar();
+    bool isHighlightedWordCC();
     struct ThingUsedHere
     {
         QString name;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

This pull request implements the ability to change a function's calling convention directly from the Disassembly view's context menu. Previously, users had to open the "Edit Function" dialog to modify this property.

**Key Changes:**
- Added a dynamic "Set calling convention" menu to [DisassemblyContextMenu](cci:1://file:///Users/aviralgarg/Everything/cutter/src/menus/DisassemblyContextMenu.cpp:23:0-162:1).
- Implemented [isHighlightedWordCC()](cci:1://file:///Users/aviralgarg/Everything/cutter/src/menus/DisassemblyContextMenu.cpp:1123:0-1141:1) to detect if the user right-clicked on a calling convention string (e.g., `cdecl`, `stdcall`).
- Populated the menu with available calling conventions for the current architecture using Rizin's analysis engine.
- Integrated the update logic to immediately refresh the disassembly view after a change.

**AI Disclosure:**
Some amount of help in understanding the codebase through Antigravity

**Test plan (required)**

1.  Open any binary in Cutter.
2.  Navigate to a function in the Disassembly view.
3.  Right-click on the calling convention name (e.g., `cdecl` or `fastcall`) in the function header.
4.  Verify that a new menu "Set calling convention" appears.
5.  Select a different calling convention from the list.
6.  **Expected Outcome:** The disassembly view should refresh immediately, and right-clicking again should show the new convention as checked.
7.  Verify the change by opening the **Edit Function** dialog (`Shift + F`); the selected convention should match.

**Closing issues**

closes #3513