### PR TITLE
Add more info in navigation bar

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -67,7 +67,7 @@ const QHash<QString, QHash<ColorFlags, QColor>> Configuration::cutterOptionColor
       { { DarkFlag, QColor(0xdd, 0xa3, 0x68) }, { LightFlag, QColor(0xe5, 0x96, 0x45) } } },
     { "gui.navbar.import",
       { { DarkFlag, QColor(0xEE, 0x8B, 0xA2) }, { LightFlag, QColor(0xEE, 0x8B, 0xA2) } } },
-    { "gui.navbar.flirt",
+    { "gui.navbar.signature",
       { { DarkFlag, QColor(0xF5, 0xF5, 0xF5) }, { LightFlag, QColor(0x8D, 0x6E, 0x63) } } },
     { "gui.navbar.data",
       { { DarkFlag, QColor(0x23, 0x3d, 0x4d) }, { LightFlag, QColor(0x4E, 0xD1, 0xC1) } } },

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -65,7 +65,13 @@ const QHash<QString, QHash<ColorFlags, QColor>> Configuration::cutterOptionColor
       { { DarkFlag, QColor(0x6f, 0x86, 0xd8) }, { LightFlag, QColor(0x45, 0x68, 0xe5) } } },
     { "gui.navbar.sym",
       { { DarkFlag, QColor(0xdd, 0xa3, 0x68) }, { LightFlag, QColor(0xe5, 0x96, 0x45) } } },
-    { "gui.navbar.empty",
+    { "gui.navbar.import",
+      { { DarkFlag, QColor(0xEE, 0x8B, 0xA2) }, { LightFlag, QColor(0xEE, 0x8B, 0xA2) } } },
+    { "gui.navbar.flirt",
+      { { DarkFlag, QColor(0xF5, 0xF5, 0xF5) }, { LightFlag, QColor(0x8D, 0x6E, 0x63) } } },
+    { "gui.navbar.data",
+      { { DarkFlag, QColor(0x23, 0x3d, 0x4d) }, { LightFlag, QColor(0x4E, 0xD1, 0xC1) } } },
+    { "gui.navbar.unexplored",
       { { DarkFlag, QColor(0x64, 0x64, 0x64) }, { LightFlag, QColor(0xdc, 0xec, 0xf5) } } },
     { "gui.breakpoint_background",
       { { DarkFlag, QColor(0x8c, 0x4c, 0x4c) }, { LightFlag, QColor(0xe9, 0x8f, 0x8f) } } },
@@ -895,4 +901,14 @@ QString Configuration::getFunctionsWidgetLayout()
 void Configuration::setFunctionsWidgetLayout(const QString &layout)
 {
     s.setValue("functionsWidgetLayout", layout);
+}
+
+void Configuration::setNavBarLegendEnabled(bool enabled)
+{
+    s.setValue("navBarLegend", enabled);
+}
+
+bool Configuration::getNavBarLegendEnabled()
+{
+    return s.value("navBarLegend").toBool();
 }

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -264,6 +264,19 @@ public:
      * @param layout The layout of the Functions widget, either horizontal or vertical.
      */
     void setFunctionsWidgetLayout(const QString &layout);
+
+    /**
+     * @brief Enable or disable the display of the legend in the navigation bar
+     * @param enabled Set to true to show the legend, false to hide it
+     */
+    void setNavBarLegendEnabled(bool enabled);
+
+    /**
+     * @brief Check if the navigation bar legend is enabled
+     * @return True if the legend is enabled, false otherwise
+     */
+    bool getNavBarLegendEnabled();
+
 public slots:
     void refreshFont();
 signals:

--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -12,15 +12,27 @@
 #include <QJsonParseError>
 #include <QToolTip>
 #include <QMouseEvent>
+#include <QLayout>
 
 #include <array>
 #include <cmath>
+
+static const int NAVBAR_HEIGHT = 15;
+static const int LEGEND_HEIGHT = 25;
+static const int TOTAL_HEIGHT = NAVBAR_HEIGHT + LEGEND_HEIGHT;
+
+static const int LEGEND_BOX_SIZE = 16;
+static const int LEGEND_BOX_Y_OFFSET = 7; // Relative to navbar bottom
+static const int LEGEND_TEXT_X_OFFSET = 17;
+static const int LEGEND_TEXT_Y_OFFSET = -5;
+static const int LEGEND_ITEM_SPACING = 30;
 
 VisualNavbar::VisualNavbar(MainWindow *main, QWidget *parent)
     : QToolBar(main),
       graphicsView(new QGraphicsView),
       seekGraphicsItem(nullptr),
       PCGraphicsItem(nullptr),
+      legendItem(nullptr),
       main(main)
 {
     Q_UNUSED(parent);
@@ -59,8 +71,12 @@ VisualNavbar::VisualNavbar(MainWindow *main, QWidget *parent)
     graphicsScene->setBackgroundBrush(bg);
 
     this->graphicsView->setAlignment(Qt::AlignLeft);
-    this->graphicsView->setMinimumHeight(15);
-    this->graphicsView->setMaximumHeight(15);
+
+    bool legendEnabled = Config()->getNavBarLegendEnabled();
+    int initialHeight = legendEnabled ? TOTAL_HEIGHT : NAVBAR_HEIGHT;
+    this->graphicsView->setMinimumHeight(initialHeight);
+    this->graphicsView->setMaximumHeight(initialHeight);
+
     this->graphicsView->setFrameShape(QFrame::NoFrame);
     this->graphicsView->setRenderHints({});
     this->graphicsView->setScene(graphicsScene);
@@ -71,6 +87,9 @@ VisualNavbar::VisualNavbar(MainWindow *main, QWidget *parent)
     this->graphicsView->setEnabled(false);
     this->graphicsView->setMouseTracking(true);
     setMouseTracking(true);
+
+    setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(this, &QWidget::customContextMenuRequested, this, &VisualNavbar::showLegendContextMenu);
 }
 
 unsigned int nextPow2(unsigned int n)
@@ -146,22 +165,23 @@ void VisualNavbar::fetchStats()
             rz_core_analysis_get_stats(core, from, to, RZ_MAX(1, (to + 1 - from) / blocksCount)));
 }
 
-enum class DataType : int { Empty, Code, String, Symbol, Count };
+enum class DataType : int { Flirt, Code, Data, String, Import, Symbol, Unexplored, Count };
 
 void VisualNavbar::updateGraphicsScene()
 {
+    bool legendVisible = Config()->getNavBarLegendEnabled();
     graphicsScene->clear();
     xToAddress.clear();
     seekGraphicsItem = nullptr;
     PCGraphicsItem = nullptr;
-    graphicsScene->setBackgroundBrush(QBrush(Config()->getColor("gui.navbar.empty")));
+    legendItem = nullptr;
+    graphicsScene->setBackgroundBrush(QBrush(Config()->getColor("gui.navbar.unexplored")));
 
     if (!stats) {
         return;
     }
 
     int w = graphicsView->width();
-    int h = graphicsView->height();
 
     RVA totalSize = stats->to - stats->from + 1;
     RVA beginAddr = stats->from;
@@ -173,16 +193,24 @@ void VisualNavbar::updateGraphicsScene()
     };
 
     std::array<QBrush, static_cast<int>(DataType::Count)> dataTypeBrushes;
+    dataTypeBrushes[static_cast<int>(DataType::Flirt)] =
+            QBrush(Config()->getColor("gui.navbar.flirt"));
     dataTypeBrushes[static_cast<int>(DataType::Code)] =
             QBrush(Config()->getColor("gui.navbar.code"));
+    dataTypeBrushes[static_cast<int>(DataType::Data)] =
+            QBrush(Config()->getColor("gui.navbar.data"));
     dataTypeBrushes[static_cast<int>(DataType::String)] =
             QBrush(Config()->getColor("gui.navbar.str"));
+    dataTypeBrushes[static_cast<int>(DataType::Import)] =
+            QBrush(Config()->getColor("gui.navbar.import"));
     dataTypeBrushes[static_cast<int>(DataType::Symbol)] =
             QBrush(Config()->getColor("gui.navbar.sym"));
+    dataTypeBrushes[static_cast<int>(DataType::Unexplored)] =
+            QBrush(Config()->getColor("gui.navbar.unexplored"));
 
-    DataType lastDataType = DataType::Empty;
+    DataType lastDataType = DataType::Unexplored;
     QGraphicsRectItem *dataItem = nullptr;
-    QRectF dataItemRect(0.0, 0.0, 0.0, h);
+    QRectF dataItemRect(0.0, 0.0, 0.0, (double)NAVBAR_HEIGHT);
     for (size_t i = 0; i < rz_vector_len(&stats->blocks); i++) {
         RzCoreAnalysisStatsItem *block =
                 reinterpret_cast<RzCoreAnalysisStatsItem *>(rz_vector_index_ptr(&stats->blocks, i));
@@ -198,7 +226,11 @@ void VisualNavbar::updateGraphicsScene()
         xToAddress.append(x2a);
 
         DataType dataType;
-        if (block->functions) {
+        if (block->flirt) {
+            dataType = DataType::Flirt;
+        } else if (block->imports) {
+            dataType = DataType::Import;
+        } else if (block->functions) {
             dataType = DataType::Code;
         } else if (block->strings) {
             dataType = DataType::String;
@@ -206,8 +238,10 @@ void VisualNavbar::updateGraphicsScene()
             dataType = DataType::Symbol;
         } else if (block->in_functions) {
             dataType = DataType::Code;
+        } else if (block->perm & RZ_PERM_RW && !(block->perm & RZ_PERM_X)) {
+            dataType = DataType::Data;
         } else {
-            lastDataType = DataType::Empty;
+            lastDataType = DataType::Unexplored;
             continue;
         }
 
@@ -224,7 +258,7 @@ void VisualNavbar::updateGraphicsScene()
         dataItemRect.setX(xFromAddr(from));
         dataItemRect.setRight(xFromAddr(to));
 
-        dataItem = new QGraphicsRectItem();
+        dataItem = new QGraphicsRectItem(dataItemRect);
         dataItem->setPen(Qt::NoPen);
         dataItem->setBrush(dataTypeBrushes[static_cast<int>(dataType)]);
         graphicsScene->addItem(dataItem);
@@ -232,10 +266,50 @@ void VisualNavbar::updateGraphicsScene()
         lastDataType = dataType;
     }
 
-    // Update scene width
-    graphicsScene->setSceneRect(0, 0, w, h);
-
     drawSeekCursor();
+
+    legendItem = new QGraphicsItemGroup();
+
+    QColor themeBg = Config()->windowColorIsDark() ? palette().color(QPalette::Window)
+                                                   : Config()->getColor("gui.background");
+
+    QGraphicsRectItem *lBg = new QGraphicsRectItem(0, NAVBAR_HEIGHT, w, LEGEND_HEIGHT);
+    lBg->setBrush(themeBg);
+    lBg->setPen(Qt::NoPen);
+    legendItem->addToGroup(lBg);
+
+    struct LegendPart
+    {
+        QString name;
+        QBrush brush;
+    };
+    QList<LegendPart> parts = {
+        { tr("Flirt"), dataTypeBrushes[static_cast<int>(DataType::Flirt)] },
+        { tr("Code"), dataTypeBrushes[static_cast<int>(DataType::Code)] },
+        { tr("Data"), dataTypeBrushes[static_cast<int>(DataType::Data)] },
+        { tr("Strings"), dataTypeBrushes[static_cast<int>(DataType::String)] },
+        { tr("Imports"), dataTypeBrushes[static_cast<int>(DataType::Import)] },
+        { tr("Symbols"), dataTypeBrushes[static_cast<int>(DataType::Symbol)] },
+        { tr("Unexplored"), dataTypeBrushes[static_cast<int>(DataType::Unexplored)] }
+    };
+
+    qreal curX = 10;
+    qreal legY = NAVBAR_HEIGHT + LEGEND_BOX_Y_OFFSET;
+    for (const auto &p : parts) {
+        QGraphicsRectItem *r = new QGraphicsRectItem(curX, legY, LEGEND_BOX_SIZE, LEGEND_BOX_SIZE);
+        r->setBrush(p.brush);
+        r->setPen(QPen(Qt::black, 0.5));
+        legendItem->addToGroup(r);
+
+        QGraphicsTextItem *t = new QGraphicsTextItem(p.name);
+        t->setPos(curX + LEGEND_TEXT_X_OFFSET, legY + LEGEND_TEXT_Y_OFFSET);
+        legendItem->addToGroup(t);
+        curX += t->boundingRect().width() + LEGEND_ITEM_SPACING;
+    }
+
+    graphicsScene->addItem(legendItem);
+    legendItem->setVisible(legendVisible);
+    graphicsScene->setSceneRect(0, 0, w, legendVisible ? TOTAL_HEIGHT : NAVBAR_HEIGHT);
 }
 
 void VisualNavbar::drawCursor(RVA addr, QColor color, QGraphicsRectItem *&graphicsItem)
@@ -249,8 +323,7 @@ void VisualNavbar::drawCursor(RVA addr, QColor color, QGraphicsRectItem *&graphi
     if (std::isnan(cursor_x)) {
         return;
     }
-    int h = this->graphicsView->height();
-    graphicsItem = new QGraphicsRectItem(cursor_x, 0, 2, h);
+    graphicsItem = new QGraphicsRectItem(cursor_x, 0, 2, NAVBAR_HEIGHT);
     graphicsItem->setPen(Qt::NoPen);
     graphicsItem->setBrush(QBrush(color));
     graphicsScene->addItem(graphicsItem);
@@ -277,6 +350,13 @@ void VisualNavbar::on_seekChanged(RVA addr)
 void VisualNavbar::mousePressEvent(QMouseEvent *event)
 {
     if (blockTooltip) {
+        return;
+    }
+
+    // Ignore mouse event on legend
+    qreal y = qhelpers::mouseEventPos(event).y();
+    if (y > NAVBAR_HEIGHT + 10) {
+        QToolTip::hideText();
         return;
     }
     qreal x = qhelpers::mouseEventPos(event).x();
@@ -360,4 +440,29 @@ QString VisualNavbar::toolTipForAddress(RVA address)
         }
     }
     return ret;
+}
+
+void VisualNavbar::showLegendContextMenu(const QPoint &pos)
+{
+    QMenu menu(this);
+    QAction *toggleLegend = menu.addAction(tr("Show Legend"));
+    toggleLegend->setCheckable(true);
+    toggleLegend->setChecked(Config()->getNavBarLegendEnabled());
+
+    if (menu.exec(mapToGlobal(pos))) {
+        bool checked = toggleLegend->isChecked();
+        Config()->setNavBarLegendEnabled(checked);
+        int h = checked ? TOTAL_HEIGHT : NAVBAR_HEIGHT;
+        this->graphicsView->setMinimumHeight(h);
+        this->graphicsView->setMaximumHeight(h);
+
+        // Force the layout to realize the height change
+        // Without this navbar jumps slightly down and then back up, when hiding legend
+        this->graphicsView->updateGeometry();
+        if (this->layout()) {
+            this->layout()->activate();
+        }
+
+        updateGraphicsScene();
+    }
 }

--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -165,7 +165,7 @@ void VisualNavbar::fetchStats()
             rz_core_analysis_get_stats(core, from, to, RZ_MAX(1, (to + 1 - from) / blocksCount)));
 }
 
-enum class DataType : int { Flirt, Code, Data, String, Import, Symbol, Unexplored, Count };
+enum class DataType : int { Signature, Code, Data, String, Import, Symbol, Unexplored, Count };
 
 void VisualNavbar::updateGraphicsScene()
 {
@@ -193,8 +193,8 @@ void VisualNavbar::updateGraphicsScene()
     };
 
     std::array<QBrush, static_cast<int>(DataType::Count)> dataTypeBrushes;
-    dataTypeBrushes[static_cast<int>(DataType::Flirt)] =
-            QBrush(Config()->getColor("gui.navbar.flirt"));
+    dataTypeBrushes[static_cast<int>(DataType::Signature)] =
+            QBrush(Config()->getColor("gui.navbar.signature"));
     dataTypeBrushes[static_cast<int>(DataType::Code)] =
             QBrush(Config()->getColor("gui.navbar.code"));
     dataTypeBrushes[static_cast<int>(DataType::Data)] =
@@ -226,8 +226,8 @@ void VisualNavbar::updateGraphicsScene()
         xToAddress.append(x2a);
 
         DataType dataType;
-        if (block->flirt) {
-            dataType = DataType::Flirt;
+        if (block->signatures) {
+            dataType = DataType::Signature;
         } else if (block->imports) {
             dataType = DataType::Import;
         } else if (block->functions) {
@@ -284,7 +284,7 @@ void VisualNavbar::updateGraphicsScene()
         QBrush brush;
     };
     QList<LegendPart> parts = {
-        { tr("Flirt"), dataTypeBrushes[static_cast<int>(DataType::Flirt)] },
+        { tr("Signatures"), dataTypeBrushes[static_cast<int>(DataType::Signature)] },
         { tr("Code"), dataTypeBrushes[static_cast<int>(DataType::Code)] },
         { tr("Data"), dataTypeBrushes[static_cast<int>(DataType::Data)] },
         { tr("Strings"), dataTypeBrushes[static_cast<int>(DataType::String)] },

--- a/src/widgets/VisualNavbar.h
+++ b/src/widgets/VisualNavbar.h
@@ -12,6 +12,7 @@
 
 class MainWindow;
 class QGraphicsView;
+class QGraphicsItemGroup;
 
 class VisualNavbar : public QToolBar
 {
@@ -39,12 +40,14 @@ private slots:
     void drawPCCursor();
     void drawCursor(RVA addr, QColor color, QGraphicsRectItem *&graphicsItem);
     void on_seekChanged(RVA addr);
+    void showLegendContextMenu(const QPoint &pos);
 
 private:
     QGraphicsView *graphicsView;
     QGraphicsScene *graphicsScene;
     QGraphicsRectItem *seekGraphicsItem;
     QGraphicsRectItem *PCGraphicsItem;
+    QGraphicsItemGroup *legendItem;
     MainWindow *main;
 
     UniquePtrC<RzCoreAnalysisStats, &rz_core_analysis_stats_free> stats;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Adds new data types and a translation map (legend), indicating what each color means, in the navigation bar
New data types include:
* Flirt
* Imports
* Data
* Unexplored - anything that doesn't fall under all the other categories (previously labelled empty)
Legend can be shown or hidden by right click -> Show legend

Colors are obviously subjective, these are the ones I thought worked well with the themes and the red seek indicator (can be changed ofcourse)
Also could add other data types maybe? might be too much though

CI jobs will most likely fail as this PR depends on the following [rizin PR #5821](https://github.com/rizinorg/rizin/pull/5821)

Light theme:
<img width="1920" height="30" alt="navbar-light" src="https://github.com/user-attachments/assets/e74340c4-fb94-4712-85ab-ac8b8c8344db" />
<img width="1920" height="53" alt="navbar-legend-light" src="https://github.com/user-attachments/assets/1def0eab-58f7-4af7-aeae-a771221f46e0" />

Dark theme:
<img width="1920" height="35" alt="navbar-dark" src="https://github.com/user-attachments/assets/5bc52324-a722-47d4-a05a-27b21f09292e" />
<img width="1920" height="58" alt="navbar-legend-dark" src="https://github.com/user-attachments/assets/a89b11d8-ed32-4f8c-8119-9bc3cc0fa600" />

Comparison on a simple test binary from [rizin-testbins/elf/switch-hello-world.elf](https://github.com/rizinorg/rizin-testbins/blob/master/elf/switch-hello-world.elf):

Before:
<img width="1920" height="319" alt="compare-bad" src="https://github.com/user-attachments/assets/9134abda-5560-4552-b2af-5bb30baaa1c2" />

After:
<img width="1920" height="345" alt="compare-good" src="https://github.com/user-attachments/assets/c8957e25-ba89-4bee-b87e-63352e804feb" />


**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

* Open any binary in Cutter
* Perform analysis
* See the navigation bar  + Right click to show/hide legend 
Note that clicking on the navigation bar seeks incorrectly, that's a separate issue, See #3543 

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3192 