### PR TITLE
Fix VisualNavbar address selection and dragging issues

### DIFF
--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -354,10 +354,13 @@ void VisualNavbar::mousePressEvent(QMouseEvent *event)
     QPoint scenePos = graphicsView->mapFromParent(toolbarPos);
 
     if (scenePos.y() > NAVBAR_HEIGHT) {
+        // Only allow dragging if it originated from the main navbar (not the legend)
+        isDraggable = false;
         QToolTip::hideText();
         return;
     }
 
+    isDraggable = true;
     handleMouseAction(event, scenePos);
 }
 
@@ -367,7 +370,7 @@ void VisualNavbar::mouseMoveEvent(QMouseEvent *event)
     event->accept();
     QPoint toolbarPos = qhelpers::mouseEventPos(event).toPoint();
     QPoint scenePos = graphicsView->mapFromParent(toolbarPos);
-    if (event->buttons() & Qt::LeftButton || scenePos.y() <= NAVBAR_HEIGHT) {
+    if ((event->buttons() & Qt::LeftButton && isDraggable) || scenePos.y() <= NAVBAR_HEIGHT) {
         handleMouseAction(event, scenePos);
     } else {
         QToolTip::hideText();

--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -350,20 +350,33 @@ void VisualNavbar::on_seekChanged(RVA addr)
 
 void VisualNavbar::mousePressEvent(QMouseEvent *event)
 {
-    if (blockTooltip) {
+    QPoint toolbarPos = qhelpers::mouseEventPos(event).toPoint();
+    QPoint scenePos = graphicsView->mapFromParent(toolbarPos);
+
+    if (scenePos.y() > NAVBAR_HEIGHT) {
+        QToolTip::hideText();
         return;
     }
 
-    // Get mouse position relative to toolbar (this)
+    handleMouseAction(event, scenePos);
+}
+
+void VisualNavbar::mouseMoveEvent(QMouseEvent *event)
+{
+
+    event->accept();
     QPoint toolbarPos = qhelpers::mouseEventPos(event).toPoint();
-
-    // Map mouse coordinates to the viewport to account for toolbar margins
     QPoint scenePos = graphicsView->mapFromParent(toolbarPos);
-    qreal y = scenePos.y();
-
-    // Ignore mouse event on legend
-    if (y > NAVBAR_HEIGHT) {
+    if (event->buttons() & Qt::LeftButton || scenePos.y() <= NAVBAR_HEIGHT) {
+        handleMouseAction(event, scenePos);
+    } else {
         QToolTip::hideText();
+    }
+}
+
+void VisualNavbar::handleMouseAction(QMouseEvent *event, const QPoint &scenePos)
+{
+    if (blockTooltip) {
         return;
     }
 
@@ -380,12 +393,6 @@ void VisualNavbar::mousePressEvent(QMouseEvent *event)
             Core()->seek(address);
         }
     }
-}
-
-void VisualNavbar::mouseMoveEvent(QMouseEvent *event)
-{
-    event->accept();
-    mousePressEvent(event);
 }
 
 RVA VisualNavbar::localXToAddress(double x)

--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -323,7 +323,8 @@ void VisualNavbar::drawCursor(RVA addr, QColor color, QGraphicsRectItem *&graphi
     if (std::isnan(cursor_x)) {
         return;
     }
-    graphicsItem = new QGraphicsRectItem(cursor_x, 0, 2, NAVBAR_HEIGHT);
+    // Subtract 1 so the 2px wide cursor is centered
+    graphicsItem = new QGraphicsRectItem(cursor_x - 1, 0, 2, NAVBAR_HEIGHT);
     graphicsItem->setPen(Qt::NoPen);
     graphicsItem->setBrush(QBrush(color));
     graphicsScene->addItem(graphicsItem);

--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -85,6 +85,7 @@ VisualNavbar::VisualNavbar(MainWindow *main, QWidget *parent)
     this->graphicsView->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     // So the graphicsView doesn't intercept mouse events.
     this->graphicsView->setEnabled(false);
+    this->graphicsView->installEventFilter(this);
     this->graphicsView->setMouseTracking(true);
     setMouseTracking(true);
 
@@ -348,33 +349,38 @@ void VisualNavbar::on_seekChanged(RVA addr)
     this->drawSeekCursor();
 }
 
-void VisualNavbar::mousePressEvent(QMouseEvent *event)
+bool VisualNavbar::eventFilter(QObject *watched, QEvent *event)
 {
-    QPoint toolbarPos = qhelpers::mouseEventPos(event).toPoint();
-    QPoint scenePos = graphicsView->mapFromParent(toolbarPos);
+    switch (event->type()) {
+    case QEvent::MouseButtonPress: {
+        auto *mouseEvent = static_cast<QMouseEvent *>(event);
+        const QPoint scenePos = mouseEvent->pos();
 
-    if (scenePos.y() > NAVBAR_HEIGHT) {
-        // Only allow dragging if it originated from the main navbar (not the legend)
+        if (scenePos.y() <= NAVBAR_HEIGHT) {
+            isDraggable = true;
+            handleMouseAction(mouseEvent, scenePos);
+            return true;
+        }
         isDraggable = false;
-        QToolTip::hideText();
-        return;
+        break;
+    }
+    case QEvent::MouseMove: {
+        auto *mouseEvent = static_cast<QMouseEvent *>(event);
+        const QPoint scenePos = mouseEvent->pos();
+
+        if ((mouseEvent->buttons() & Qt::LeftButton && isDraggable)
+            || scenePos.y() <= NAVBAR_HEIGHT) {
+            handleMouseAction(mouseEvent, scenePos);
+        } else {
+            QToolTip::hideText();
+        }
+        return true;
+    }
+    default:
+        break;
     }
 
-    isDraggable = true;
-    handleMouseAction(event, scenePos);
-}
-
-void VisualNavbar::mouseMoveEvent(QMouseEvent *event)
-{
-
-    event->accept();
-    QPoint toolbarPos = qhelpers::mouseEventPos(event).toPoint();
-    QPoint scenePos = graphicsView->mapFromParent(toolbarPos);
-    if ((event->buttons() & Qt::LeftButton && isDraggable) || scenePos.y() <= NAVBAR_HEIGHT) {
-        handleMouseAction(event, scenePos);
-    } else {
-        QToolTip::hideText();
-    }
+    return QToolBar::eventFilter(watched, event);
 }
 
 void VisualNavbar::handleMouseAction(QMouseEvent *event, const QPoint &scenePos)

--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -353,13 +353,20 @@ void VisualNavbar::mousePressEvent(QMouseEvent *event)
         return;
     }
 
+    // Get mouse position relative to toolbar (this)
+    QPoint toolbarPos = qhelpers::mouseEventPos(event).toPoint();
+
+    // Map mouse coordinates to the viewport to account for toolbar margins
+    QPoint scenePos = graphicsView->mapFromParent(toolbarPos);
+    qreal y = scenePos.y();
+
     // Ignore mouse event on legend
-    qreal y = qhelpers::mouseEventPos(event).y();
-    if (y > NAVBAR_HEIGHT + 10) {
+    if (y > NAVBAR_HEIGHT) {
         QToolTip::hideText();
         return;
     }
-    qreal x = qhelpers::mouseEventPos(event).x();
+
+    qreal x = scenePos.x();
     RVA address = localXToAddress(x);
     if (address != RVA_INVALID) {
         auto tooltipPos = qhelpers::mouseEventGlobalPos(event);

--- a/src/widgets/VisualNavbar.h
+++ b/src/widgets/VisualNavbar.h
@@ -64,6 +64,7 @@ private:
 
     void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
+    void handleMouseAction(QMouseEvent *event, const QPoint &scenePos);
 };
 
 #endif // VISUALNAVBAR_H

--- a/src/widgets/VisualNavbar.h
+++ b/src/widgets/VisualNavbar.h
@@ -63,8 +63,7 @@ private:
     QList<QString> sectionsForAddress(RVA address);
     QString toolTipForAddress(RVA address);
 
-    void mousePressEvent(QMouseEvent *event) override;
-    void mouseMoveEvent(QMouseEvent *event) override;
+    bool eventFilter(QObject *watched, QEvent *event) override;
     void handleMouseAction(QMouseEvent *event, const QPoint &scenePos);
 };
 

--- a/src/widgets/VisualNavbar.h
+++ b/src/widgets/VisualNavbar.h
@@ -56,6 +56,7 @@ private:
 
     QList<XToAddress> xToAddress;
     bool blockTooltip;
+    bool isDraggable = true;
 
     RVA localXToAddress(double x);
     double addressToLocalX(RVA address);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Fixes the incorrect tooltip and wrong address selection when clicking on the visual navbar

Also fixes the drag getting stuck when cursor moves into the legend area and below. This issue was caused by immediately returning in `mousePressEvent()` whenever the mouse y co-ordinate is greater than the actual navbar height (excluding the legend area) without checking whether the event is `mouseMove` or `mousePress`

**Address selection before**
<img src="https://github.com/user-attachments/assets/d03e674f-6bab-4b55-b8fb-1d293f1f5465" width="800">

**Address selection after**
<img src="https://github.com/user-attachments/assets/ba3ff968-63c2-49b5-8e24-99b35475ca57" width="800">

**Dragging before**
![drag-before_trimmed](https://github.com/user-attachments/assets/91dc83e9-fc14-4706-8191-3ab0dd31b0a1)


**Dragging After**
![drag-after_trimmed](https://github.com/user-attachments/assets/efe15eb8-5182-4c10-9410-4067c8ff53be)

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

* Open any binary in cutter
* Try hovering over the visual navbar and clicking

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3543 