### PR TITLE
Fix file opening logic for Enter key and fileless mode

### DIFF
--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -135,10 +135,12 @@ void NewFileDialog::on_shellcodeButton_clicked()
 
 void NewFileDialog::on_recentsListWidget_itemClicked(QListWidgetItem *item)
 {
-    QStringList sitem = item->data(Qt::UserRole).toStringList();
+    updateSelectionFromItem(item);
+}
 
-    ui->ioPlugin->setCurrentIndex(ui->ioPlugin->findText(sitem.at(0)));
-    ui->newFileEdit->setText(sitem.at(1));
+void NewFileDialog::on_recentsListWidget_currentItemChanged(QListWidgetItem *current)
+{
+    updateSelectionFromItem(current);
 }
 
 void NewFileDialog::on_recentsListWidget_itemDoubleClicked(QListWidgetItem *item)
@@ -327,31 +329,34 @@ void NewFileDialog::updateLoadProjectButton()
 
 void NewFileDialog::loadFile(const QString &filename)
 {
-    const QString &nativeFn = QDir::toNativeSeparators(filename);
-    if (ui->ioPlugin->currentIndex() == 0 && !Core()->tryFile(nativeFn, false)
-        && !ui->checkBox_FilelessOpen->isChecked()) {
-        QMessageBox msgBox(this);
-        msgBox.setText(tr("Select a new program or a previous one before continuing."));
-        msgBox.exec();
-        return;
+    bool isFileless = ui->checkBox_FilelessOpen->isChecked();
+    QString ioFile;
+    if (!isFileless) {
+        const QString &nativeFn = QDir::toNativeSeparators(filename);
+        if (ui->ioPlugin->currentIndex() == 0 && !Core()->tryFile(nativeFn, false)) {
+            QMessageBox msgBox(this);
+            msgBox.setText(tr("Select a new program or a previous one before continuing."));
+            msgBox.exec();
+            return;
+        }
+
+        const QString ioMode = ui->ioPlugin->currentText();
+        ioFile = ioMode + nativeFn;
+
+        // Add file to recent file list
+        RecentFileEntry file = { ioMode, nativeFn };
+        QList<RecentFileEntry> files = Config()->getRecentFiles();
+        files.removeAll(file);
+        files.prepend(file);
+        while (files.size() > MaxRecentFiles)
+            files.removeLast();
+        Config()->setRecentFiles(files);
     }
-
-    const QString ioMode = ui->ioPlugin->currentText();
-    const QString ioFile = ioMode + nativeFn;
-
-    // Add file to recent file list
-    RecentFileEntry file = { ioMode, nativeFn };
-    QList<RecentFileEntry> files = Config()->getRecentFiles();
-    files.removeAll(file);
-    files.prepend(file);
-    while (files.size() > MaxRecentFiles)
-        files.removeLast();
-    Config()->setRecentFiles(files);
 
     // Close dialog and open MainWindow/InitialOptionsDialog
     InitialOptions options;
     options.filename = ioFile;
-    main->openNewFile(options, ui->checkBox_FilelessOpen->isChecked());
+    main->openNewFile(options, isFileless);
 
     close();
 }
@@ -407,4 +412,14 @@ bool NewFileDialog::eventFilter(QObject * /*obj*/, QEvent *event)
     }
 
     return false;
+}
+
+void NewFileDialog::updateSelectionFromItem(QListWidgetItem *item)
+{
+    if (!item) {
+        return;
+    }
+    QStringList sitem = item->data(Qt::UserRole).toStringList();
+    ui->ioPlugin->setCurrentIndex(ui->ioPlugin->findText(sitem.at(0)));
+    ui->newFileEdit->setText(sitem.at(1));
 }

--- a/src/dialogs/NewFileDialog.h
+++ b/src/dialogs/NewFileDialog.h
@@ -31,6 +31,7 @@ private slots:
 
     void on_recentsListWidget_itemClicked(QListWidgetItem *item);
     void on_recentsListWidget_itemDoubleClicked(QListWidgetItem *item);
+    void on_recentsListWidget_currentItemChanged(QListWidgetItem *current);
 
     void on_projectFileEdit_textChanged();
     void on_projectsListWidget_itemClicked(QListWidgetItem *item);
@@ -68,6 +69,11 @@ private:
     void loadFile(const QString &filename);
     void loadProject(const QString &project);
     void loadShellcode(const QString &shellcode, const int size);
+    /**
+     * @brief Updates IO plugin and file path based on the selected recent item
+     * @param item The list item containing the IO mode and file path in its UserRole data
+     */
+    void updateSelectionFromItem(QListWidgetItem *item);
 
     bool eventFilter(QObject *obj, QEvent *event);
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This PR does fixes two things:
1) The "Don't open any file" option. This previously used to show an error saying: 
2) Pressing enter to open file from recent files list

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

* Open cutter
* Check the "Don't open any file" box and Click Ok. [1]
* Try navigating recent files through keyboard and pressing enter to open. [2]

tested on linux x86_64 (kali) and windows 10 (64-bit)
<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Additional Media**

**Before:**
<img src="https://github.com/user-attachments/assets/b4002bb4-ae15-4986-8016-80e7e99c5eb8" width="400">
opens the file initially selected using mouse click, despite changing selection through keyboard

**After:**
<img src="https://github.com/user-attachments/assets/461c0bf3-19fe-4f6f-8d93-22c9e58729ed" width="400">
opens the correct file

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3492 