### PR TITLE
Show correct context menu when using Menu key

### DIFF
--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -899,9 +899,17 @@ void DisassemblerGraphView::blockContextMenuRequested(GraphView::GraphBlock &blo
 
 void DisassemblerGraphView::contextMenuEvent(QContextMenuEvent *event)
 {
+    if (event->reason() == QContextMenuEvent::Keyboard) {
+        auto *db = blockForAddress(seekable->getOffset());
+        if (db) {
+            auto gb = blocks[db->entry];
+            blockContextMenuRequested(gb, event, QPoint());
+            return;
+        }
+    }
+
     GraphView::contextMenuEvent(event);
     if (!event->isAccepted()) {
-        // TODO: handle opening block menu using keyboard
         contextMenu->exec(event->globalPos());
         event->accept();
     }

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -690,6 +690,17 @@ void DisassemblyWidget::keyPressEvent(QKeyEvent *event)
     MemoryDockWidget::keyPressEvent(event);
 }
 
+void DisassemblyWidget::contextMenuEvent(QContextMenuEvent *event)
+{
+    if (event->reason() == QContextMenuEvent::Keyboard) {
+        showDisasContextMenu(event->pos());
+        event->accept();
+        return;
+    }
+
+    MemoryDockWidget::contextMenuEvent(event);
+}
+
 QString DisassemblyWidget::getWindowTitle() const
 {
     return tr("Disassembly");

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -93,6 +93,7 @@ private:
     RVA readCurrentDisassemblyOffset();
     bool eventFilter(QObject *obj, QEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
+    void contextMenuEvent(QContextMenuEvent *event) override;
     QString getWindowTitle() const override;
 
     int topOffsetHistoryPos = 0;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Opening context menu using the "Menu" key from the keyboard opens a generic context menu as if the user clicked outside of any instructions, both in disassembly and graph widgets. This PR fixes that specific case
  

**Test plan (required)**

Since not a lot of systems come with the "Menu" key, one can remap a key to behave as "Menu" key to test this PR

Wasn't able to find a working solution to get the "Menu/Application" key working on **macOS** both with and without remapping
See [context-menu-right-click-keyboard-shortcut-in-mac-os-x](https://superuser.com/questions/662175/context-menu-right-click-keyboard-shortcut-in-mac-os-x)

**Steps:**
* Open cutter with or without binary
* Go to Disassembly widget
* Press the "Menu" key (or the remapped key)
* Test the actions within the context menu to make sure they work for the currently selected instruction
* Repeat for Graph widget, also test when no graphs are available

Note that context menu opened through keyboard appears in the middle of the widget that currently has focus, (that's handled by Qt)

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #2107 