### PR TITLE
Fix preview and seek on XREF comment

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,6 +164,7 @@ set(SOURCES
     dialogs/ProfileDirectivesDialog.cpp
     dialogs/RegisterProfileDialog.cpp
     dialogs/EditRegProfileDialog.cpp
+    common/DisassemblyHelper.cpp
 )
 set(HEADER_FILES
     core/Cutter.h
@@ -337,6 +338,7 @@ set(HEADER_FILES
     dialogs/ProfileDirectivesDialog.h
     dialogs/RegisterProfileDialog.h
     dialogs/EditRegProfileDialog.h
+    common/DisassemblyHelper.h
 )
 set(UI_FILES
     dialogs/AboutDialog.ui

--- a/src/common/DisassemblyHelper.cpp
+++ b/src/common/DisassemblyHelper.cpp
@@ -18,9 +18,10 @@ DisassemblyTextBlockUserData *DisassemblyHelper::getUserData(const QTextBlock &b
 
 RVA DisassemblyHelper::getXRefFromWord(RVA offset, const QString &selectedWord)
 {
+    RVA selectedOffset = Core()->num(selectedWord);
     auto xrefsTo = Core()->getXRefs(offset, true, false);
     for (const auto &xref : xrefsTo) {
-        if (xref.from_str == selectedWord) {
+        if (xref.from == selectedOffset) {
             return xref.from;
         }
     }

--- a/src/common/DisassemblyHelper.cpp
+++ b/src/common/DisassemblyHelper.cpp
@@ -1,0 +1,43 @@
+#include "DisassemblyHelper.h"
+#include "Cutter.h"
+
+DisassemblyTextBlockUserData::DisassemblyTextBlockUserData(const DisassemblyLine &line)
+    : line { line }
+{
+}
+
+DisassemblyTextBlockUserData *DisassemblyHelper::getUserData(const QTextBlock &block)
+{
+    QTextBlockUserData *userData = block.userData();
+    if (!userData) {
+        return nullptr;
+    }
+
+    return static_cast<DisassemblyTextBlockUserData *>(userData);
+}
+
+RVA DisassemblyHelper::getXRefFromWord(RVA offset, const QString &selectedWord)
+{
+    auto xrefsTo = Core()->getXRefs(offset, true, false);
+    for (const auto &xref : xrefsTo) {
+        if (xref.from_str == selectedWord) {
+            return xref.from;
+        }
+    }
+    return RVA_INVALID;
+}
+
+bool DisassemblyHelper::isXRefFromComment(RVA offset, const QString &line)
+{
+    return Core()->getXRefCommentAt(offset).simplified().contains(line.simplified());
+}
+
+RVA DisassemblyHelper::readDisassemblyOffset(QTextCursor tc)
+{
+    auto userData = DisassemblyHelper::getUserData(tc.block());
+    if (!userData) {
+        return RVA_INVALID;
+    }
+
+    return userData->line.offset;
+}

--- a/src/common/DisassemblyHelper.h
+++ b/src/common/DisassemblyHelper.h
@@ -1,0 +1,51 @@
+#ifndef DISASSEMBLYHELPER_H
+#define DISASSEMBLYHELPER_H
+
+#include <QTextBlockUserData>
+#include "core/CutterDescriptions.h"
+
+/**
+ * @brief Metadata container attached to each QTextBlock in the disassembly view
+ *
+ * Each visible line in disassembly related widgets is treated as a single text block
+ */
+class DisassemblyTextBlockUserData : public QTextBlockUserData
+{
+public:
+    DisassemblyLine line;
+
+    explicit DisassemblyTextBlockUserData(const DisassemblyLine &line);
+};
+
+/**
+ * @brief Helpers for translating UI elements (words, lines) into disassembly data
+ */
+namespace DisassemblyHelper {
+
+DisassemblyTextBlockUserData *getUserData(const QTextBlock &block);
+
+/**
+ * @brief Finds the source (from) address of an XRef based on the text word under the cursor
+ * @param offset The base offset of the line which contains an XREF to it
+ * @param selectedWord The specific text string being hovered (must be an address)
+ * @return The source RVA of the XRef, or RVA_INVALID if not found
+ */
+RVA getXRefFromWord(RVA offset, const QString &selectedWord);
+
+/**
+ * @brief Checks if a disassembly line is an auto-generated XRef metadata line
+ * @param offset The offset of the current disassembly line/block
+ * @param line The full text content of the disassembly line/block
+ * @return True if the line is an analysis-generated XRef comment
+ */
+bool isXRefFromComment(RVA offset, const QString &line);
+
+/*!
+ * @brief Reads the offset for the cursor position
+ * @return The disassembly offset of the hovered asm text
+ */
+RVA readDisassemblyOffset(QTextCursor tc);
+
+}
+
+#endif // DISASSEMBLYHELPER_H

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -49,28 +49,49 @@ bool DisassemblyPreview::showDisasPreview(QWidget *parent, const QPoint &pointOf
          * on *and* the former is a valid offset, we are allowed to get a preview of offsetTo
          */
         if (offsetTo != offsetFrom && offsetTo != RVA_INVALID) {
-            QStringList disasmPreview = Core()->getDisassemblyPreview(offsetTo, 10);
-
-            // Last check to make sure the returned preview isn't an empty text (QStringList)
-            if (!disasmPreview.isEmpty()) {
-                const QFont &fnt = Config()->getFont();
-
-                QFontMetrics fm { fnt };
-
-                QString tooltip =
-                        QString { "<html><div style=\"font-family: %1; font-size: %2pt; "
-                                  "white-space: nowrap;\"><div style=\"margin-bottom: "
-                                  "10px;\"><strong>Disassembly Preview</strong>:<br>%3<div>" }
-                                .arg(fnt.family())
-                                .arg(qMax(8, fnt.pointSize() - 1))
-                                .arg(disasmPreview.join("<br>"));
-
-                QToolTip::showText(pointOfEvent, tooltip, parent, QRect {}, 3500);
-                return true;
-            }
+            return showDisasPreviewAt(parent, pointOfEvent, offsetTo);
         }
     }
     return false;
+}
+
+bool DisassemblyPreview::showDisasPreviewAt(QWidget *parent, const QPoint &pointOfEvent,
+                                            const RVA offset)
+{
+    QStringList disasmPreview = Core()->getDisassemblyPreview(offset, 10);
+    if (!disasmPreview.isEmpty()) {
+        const QFont &fnt = Config()->getFont();
+        QString tooltip = QString { "<html><div style=\"font-family: %1; font-size: %2pt; "
+                                    "white-space: nowrap;\"><div style=\"margin-bottom: "
+                                    "10px;\"><strong>Disassembly Preview</strong>:<br>%3<div>" }
+                                  .arg(fnt.family())
+                                  .arg(qMax(8, fnt.pointSize() - 1))
+                                  .arg(disasmPreview.join("<br>"));
+
+        QToolTip::showText(pointOfEvent, tooltip, parent, QRect {}, 3500);
+        return true;
+    }
+
+    return false;
+}
+
+RVA DisassemblyPreview::getXRefFromWord(RVA offset, const QString &selectedWord)
+{
+    auto xrefsTo = Core()->getXRefs(offset, true, false);
+    for (const auto &xref : xrefsTo) {
+        if (xref.from_str == selectedWord) {
+            return xref.from;
+        }
+    }
+    return RVA_INVALID;
+}
+
+bool DisassemblyPreview::isXRefFromComment(RVA offset, const QString &line)
+{
+    // return true if the line starts with ';' - contains the word "XREF" and is not a user comment
+    // e.g: ; CODE XREF from sym.USER32.dll_OpenClipboard @ 0x77cbc7e3
+    return (line.startsWith(";") && line.contains("XREF")
+            && !Core()->getCommentAt(offset).contains(line.mid(1).simplified()));
 }
 
 RVA DisassemblyPreview::readDisassemblyOffset(QTextCursor tc)

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -7,21 +7,6 @@
 #include <QToolTip>
 #include <QProcessEnvironment>
 
-DisassemblyTextBlockUserData::DisassemblyTextBlockUserData(const DisassemblyLine &line)
-    : line { line }
-{
-}
-
-DisassemblyTextBlockUserData *getUserData(const QTextBlock &block)
-{
-    QTextBlockUserData *userData = block.userData();
-    if (!userData) {
-        return nullptr;
-    }
-
-    return static_cast<DisassemblyTextBlockUserData *>(userData);
-}
-
 QString DisassemblyPreview::getToolTipStyleSheet()
 {
     return QString { "QToolTip { border-width: 1px; max-width: %1px;"
@@ -73,36 +58,6 @@ bool DisassemblyPreview::showDisasPreviewAt(QWidget *parent, const QPoint &point
     }
 
     return false;
-}
-
-RVA DisassemblyPreview::getXRefFromWord(RVA offset, const QString &selectedWord)
-{
-    auto xrefsTo = Core()->getXRefs(offset, true, false);
-    for (const auto &xref : xrefsTo) {
-        if (xref.from_str == selectedWord) {
-            return xref.from;
-        }
-    }
-    return RVA_INVALID;
-}
-
-bool DisassemblyPreview::isXRefFromComment(RVA offset, const QString &line)
-{
-    // return true if the line starts with ';' - contains the word "XREF" and is not a user comment
-    // OR a FLAG
-    // e.g: ; CODE XREF from sym.USER32.dll_OpenClipboard @ 0x77cbc7e3
-    return (line.startsWith(";") && !line.startsWith(";--") && line.contains("XREF")
-            && !Core()->getCommentAt(offset).contains(line.mid(1).simplified()));
-}
-
-RVA DisassemblyPreview::readDisassemblyOffset(QTextCursor tc)
-{
-    auto userData = getUserData(tc.block());
-    if (!userData) {
-        return RVA_INVALID;
-    }
-
-    return userData->line.offset;
 }
 
 typedef struct mmio_lookup_context

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -89,8 +89,9 @@ RVA DisassemblyPreview::getXRefFromWord(RVA offset, const QString &selectedWord)
 bool DisassemblyPreview::isXRefFromComment(RVA offset, const QString &line)
 {
     // return true if the line starts with ';' - contains the word "XREF" and is not a user comment
+    // OR a FLAG
     // e.g: ; CODE XREF from sym.USER32.dll_OpenClipboard @ 0x77cbc7e3
-    return (line.startsWith(";") && line.contains("XREF")
+    return (line.startsWith(";") && !line.startsWith(";--") && line.contains("XREF")
             && !Core()->getCommentAt(offset).contains(line.mid(1).simplified()));
 }
 

--- a/src/common/DisassemblyPreview.h
+++ b/src/common/DisassemblyPreview.h
@@ -34,7 +34,29 @@ QString getToolTipStyleSheet();
  * It works for GraphWidget and DisassemblyWidget
  * @return True if the tooltip is shown
  */
-bool showDisasPreview(QWidget *parent, const QPoint &pointOfEvent, const RVA offsetFrom);
+bool showDisasPreview(QWidget *parent, const QPoint &pointOfEvent, const RVA offsetFromk);
+
+/**
+ * @brief Show a QToolTip that previews the disassembly at a specific address
+ * @return True if the tooltip is shown
+ */
+bool showDisasPreviewAt(QWidget *parent, const QPoint &pointOfEvent, const RVA offset);
+
+/**
+ * @brief Finds the source (from) address of an XRef based on the text word under the cursor
+ * @param offset The base offset of the line which contains an XREF to it
+ * @param selectedWord The specific text string being hovered (must be an address)
+ * @return The source RVA of the XRef, or RVA_INVALID if not found
+ */
+RVA getXRefFromWord(RVA offset, const QString &selectedWord);
+
+/**
+ * @brief Checks if a disassembly line is an auto-generated XRef metadata line
+ * @param offset The offset of the current disassembly line/block
+ * @param line The full text content of the disassembly line/block
+ * @return True if the line is an analysis-generated XRef comment
+ */
+bool isXRefFromComment(RVA offset, const QString &line);
 
 /*!
  * @brief Reads the offset for the cursor position

--- a/src/common/DisassemblyPreview.h
+++ b/src/common/DisassemblyPreview.h
@@ -2,20 +2,9 @@
 #define DISASSEMBLYPREVIEW_H
 
 #include <QTextBlockUserData>
-
 #include "core/CutterDescriptions.h"
 
 class QWidget;
-
-class DisassemblyTextBlockUserData : public QTextBlockUserData
-{
-public:
-    DisassemblyLine line;
-
-    explicit DisassemblyTextBlockUserData(const DisassemblyLine &line);
-};
-
-DisassemblyTextBlockUserData *getUserData(const QTextBlock &block);
 
 /**
  * @brief Namespace to define relevant functions
@@ -41,28 +30,6 @@ bool showDisasPreview(QWidget *parent, const QPoint &pointOfEvent, const RVA off
  * @return True if the tooltip is shown
  */
 bool showDisasPreviewAt(QWidget *parent, const QPoint &pointOfEvent, const RVA offset);
-
-/**
- * @brief Finds the source (from) address of an XRef based on the text word under the cursor
- * @param offset The base offset of the line which contains an XREF to it
- * @param selectedWord The specific text string being hovered (must be an address)
- * @return The source RVA of the XRef, or RVA_INVALID if not found
- */
-RVA getXRefFromWord(RVA offset, const QString &selectedWord);
-
-/**
- * @brief Checks if a disassembly line is an auto-generated XRef metadata line
- * @param offset The offset of the current disassembly line/block
- * @param line The full text content of the disassembly line/block
- * @return True if the line is an analysis-generated XRef comment
- */
-bool isXRefFromComment(RVA offset, const QString &line);
-
-/*!
- * @brief Reads the offset for the cursor position
- * @return The disassembly offset of the hovered asm text
- */
-RVA readDisassemblyOffset(QTextCursor tc);
 
 /**
  * @brief Show a QToolTip that shows the value of the highlighted register, variable, or memory

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -4424,6 +4424,18 @@ QList<XrefDescription> CutterCore::getXRefs(RVA addr, bool to, bool whole_functi
     return xrefList;
 }
 
+QString CutterCore::getXRefCommentAt(RVA offset)
+{
+    CORE_LOCK();
+    QString commentStr;
+    char *comment = rz_core_get_xref_comment(core, offset);
+    if (comment) {
+        commentStr = QString::fromUtf8(comment);
+    }
+    free(comment);
+    return commentStr;
+}
+
 void CutterCore::addGlobalVariable(RVA offset, QString name, QString typ)
 {
     name = sanitizeStringForCommand(name);

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -765,6 +765,12 @@ public:
      */
     XrefDescription getFirstXRefForVariable(const QString &variableName, RVA offset);
 
+    /**
+     * @brief Retrieves the auto-generated comment describing XRefs at a specific offset
+     * @return The XRef comment string, seperated by \n if it spans multiple lines
+     */
+    QString getXRefCommentAt(RVA offset);
+
     void handleREvent(int type, void *data);
 
     /* Signals related */

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -12,6 +12,7 @@
 #include "common/BasicInstructionHighlighter.h"
 #include "common/Helpers.h"
 #include "shortcuts/ShortcutManager.h"
+#include "common/DisassemblyHelper.h"
 
 #include <QColorDialog>
 #include <QPainter>
@@ -568,12 +569,12 @@ bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
                 auto token = getToken(inst, pos.x());
                 bool hasPreview = Config()->getGraphPreview();
                 if (hasPreview
-                    && DisassemblyPreview::isXRefFromComment(offsetFrom,
-                                                             inst->plainText.trimmed())) {
+                    && DisassemblyHelper::isXRefFromComment(offsetFrom,
+                                                            inst->plainText.trimmed())) {
                     if (!token) {
                         return true;
                     }
-                    RVA xrefFrom = DisassemblyPreview::getXRefFromWord(offsetFrom, token->content);
+                    RVA xrefFrom = DisassemblyHelper::getXRefFromWord(offsetFrom, token->content);
                     if (xrefFrom != RVA_INVALID) {
                         DisassemblyPreview::showDisasPreviewAt(this, pointOfEvent, xrefFrom);
                     }
@@ -970,8 +971,8 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
 
     RVA offset = getAddrForMouseEvent(block, &pos);
 
-    if (DisassemblyPreview::isXRefFromComment(offset, instr->plainText.trimmed())) {
-        RVA xrefFrom = DisassemblyPreview::getXRefFromWord(offset, selectedText);
+    if (DisassemblyHelper::isXRefFromComment(offset, instr->plainText.trimmed())) {
+        RVA xrefFrom = DisassemblyHelper::getXRefFromWord(offset, selectedText);
         if (xrefFrom != RVA_INVALID) {
             seekable->seek(xrefFrom);
         }

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -568,9 +568,8 @@ bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
             if (getViewScale() >= 0.8) {
                 auto token = getToken(inst, pos.x());
                 bool hasPreview = Config()->getGraphPreview();
-                if (hasPreview
-                    && DisassemblyHelper::isXRefFromComment(offsetFrom,
-                                                            inst->plainText.trimmed())) {
+                if (hasPreview && Core()->getConfigb("asm.xrefs")
+                    && DisassemblyHelper::isXRefFromComment(offsetFrom, inst->plainText)) {
                     if (!token) {
                         return true;
                     }
@@ -971,7 +970,8 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
 
     RVA offset = getAddrForMouseEvent(block, &pos);
 
-    if (DisassemblyHelper::isXRefFromComment(offset, instr->plainText.trimmed())) {
+    if (Core()->getConfigb("asm.xrefs")
+        && DisassemblyHelper::isXRefFromComment(offset, instr->plainText)) {
         RVA xrefFrom = DisassemblyHelper::getXRefFromWord(offset, selectedText);
         if (xrefFrom != RVA_INVALID) {
             seekable->seek(xrefFrom);

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -565,12 +565,21 @@ bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
 
             // Don't preview anything for a small scale
             if (getViewScale() >= 0.8) {
-                if (Config()->getGraphPreview()
+                auto token = getToken(inst, pos.x());
+                bool hasPreview = Config()->getGraphPreview();
+                if (hasPreview
+                    && DisassemblyPreview::isXRefFromComment(offsetFrom, inst->plainText)) {
+                    RVA xrefFrom = DisassemblyPreview::getXRefFromWord(offsetFrom, token->content);
+                    if (xrefFrom != RVA_INVALID) {
+                        DisassemblyPreview::showDisasPreviewAt(this, pointOfEvent, xrefFrom);
+                    }
+                    return true;
+                }
+                if (hasPreview
                     && DisassemblyPreview::showDisasPreview(this, pointOfEvent, offsetFrom)) {
                     return true;
                 }
                 if (Config()->getShowVarTooltips() && inst) {
-                    auto token = getToken(inst, pos.x());
                     if (token
                         && DisassemblyPreview::showDebugValueTooltip(this, pointOfEvent,
                                                                      token->content, offsetFrom)) {
@@ -955,13 +964,23 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
         return;
     }
 
+    RVA offset = getAddrForMouseEvent(block, &pos);
+
+    if (DisassemblyPreview::isXRefFromComment(offset, instr->plainText)) {
+        RVA xrefFrom = DisassemblyPreview::getXRefFromWord(offset, selectedText);
+        if (xrefFrom != RVA_INVALID) {
+            seekable->seek(xrefFrom);
+        }
+        return;
+    }
+
     XrefDescription firstXref = Core()->getFirstXRefForVariable(selectedText, instr->addr);
     if (!firstXref.from_str.isEmpty() || !firstXref.to_str.isEmpty()) {
         seekable->seek(firstXref.from);
         return;
     }
 
-    seekable->seekToReference(getAddrForMouseEvent(block, &pos));
+    seekable->seekToReference(offset);
 }
 
 void DisassemblerGraphView::blockHelpEvent(GraphView::GraphBlock &block, QHelpEvent *event,

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -568,7 +568,8 @@ bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
                 auto token = getToken(inst, pos.x());
                 bool hasPreview = Config()->getGraphPreview();
                 if (hasPreview
-                    && DisassemblyPreview::isXRefFromComment(offsetFrom, inst->plainText)) {
+                    && DisassemblyPreview::isXRefFromComment(offsetFrom,
+                                                             inst->plainText.trimmed())) {
                     if (!token) {
                         return true;
                     }
@@ -969,7 +970,7 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
 
     RVA offset = getAddrForMouseEvent(block, &pos);
 
-    if (DisassemblyPreview::isXRefFromComment(offset, instr->plainText)) {
+    if (DisassemblyPreview::isXRefFromComment(offset, instr->plainText.trimmed())) {
         RVA xrefFrom = DisassemblyPreview::getXRefFromWord(offset, selectedText);
         if (xrefFrom != RVA_INVALID) {
             seekable->seek(xrefFrom);

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -569,6 +569,9 @@ bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
                 bool hasPreview = Config()->getGraphPreview();
                 if (hasPreview
                     && DisassemblyPreview::isXRefFromComment(offsetFrom, inst->plainText)) {
+                    if (!token) {
+                        return true;
+                    }
                     RVA xrefFrom = DisassemblyPreview::getXRefFromWord(offsetFrom, token->content);
                     if (xrefFrom != RVA_INVALID) {
                         DisassemblyPreview::showDisasPreviewAt(this, pointOfEvent, xrefFrom);

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -9,6 +9,7 @@
 #include "core/MainWindow.h"
 #include "widgets/AddressRangeScrollBar.h"
 #include "shortcuts/ShortcutManager.h"
+#include "DisassemblyHelper.h"
 
 #include <QApplication>
 #include <QScrollBar>
@@ -385,7 +386,7 @@ void DisassemblyWidget::highlightCurrentLine()
     highlightSelection.cursor = cursor;
     highlightSelection.cursor.movePosition(QTextCursor::Start);
     while (true) {
-        RVA lineOffset = DisassemblyPreview::readDisassemblyOffset(highlightSelection.cursor);
+        RVA lineOffset = DisassemblyHelper::readDisassemblyOffset(highlightSelection.cursor);
         if (lineOffset == seekable->getOffset()) {
             highlightSelection.format.setBackground(highlightColor);
             highlightSelection.format.setProperty(QTextFormat::FullWidthSelection, true);
@@ -420,7 +421,7 @@ void DisassemblyWidget::highlightPCLine()
     highlightSelection.cursor.movePosition(QTextCursor::Start);
     if (PCAddr != RVA_INVALID) {
         while (true) {
-            RVA lineOffset = DisassemblyPreview::readDisassemblyOffset(highlightSelection.cursor);
+            RVA lineOffset = DisassemblyHelper::readDisassemblyOffset(highlightSelection.cursor);
             if (lineOffset == PCAddr) {
                 highlightSelection.format.setBackground(highlightPCColor);
                 highlightSelection.format.setProperty(QTextFormat::FullWidthSelection, true);
@@ -453,7 +454,7 @@ void DisassemblyWidget::showDisasContextMenu(const QPoint &pt)
 RVA DisassemblyWidget::readCurrentDisassemblyOffset()
 {
     QTextCursor tc = mDisasTextEdit->textCursor();
-    return DisassemblyPreview::readDisassemblyOffset(tc);
+    return DisassemblyHelper::readDisassemblyOffset(tc);
 }
 
 void DisassemblyWidget::updateCursorPosition()
@@ -480,7 +481,7 @@ void DisassemblyWidget::updateCursorPosition()
         cursor.movePosition(QTextCursor::Start);
 
         while (true) {
-            RVA lineOffset = DisassemblyPreview::readDisassemblyOffset(cursor);
+            RVA lineOffset = DisassemblyHelper::readDisassemblyOffset(cursor);
             if (lineOffset == offset) {
                 if (cursorLineOffset > 0) {
                     cursor.movePosition(QTextCursor::Down, QTextCursor::MoveAnchor,
@@ -541,7 +542,7 @@ void DisassemblyWidget::cursorPositionChanged()
     cursorCharOffset = c.positionInBlock();
     while (c.blockNumber() > 0) {
         c.movePosition(QTextCursor::PreviousBlock);
-        if (DisassemblyPreview::readDisassemblyOffset(c) != offset) {
+        if (DisassemblyHelper::readDisassemblyOffset(c) != offset) {
             break;
         }
         cursorLineOffset++;
@@ -627,7 +628,7 @@ void DisassemblyWidget::moveCursorRelative(bool up, bool page)
 
 void DisassemblyWidget::jumpToOffsetUnderCursor(const QTextCursor &cursor)
 {
-    RVA offset = DisassemblyPreview::readDisassemblyOffset(cursor);
+    RVA offset = DisassemblyHelper::readDisassemblyOffset(cursor);
     seekable->seekToReference(offset);
 }
 
@@ -648,10 +649,10 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
                 return true;
             }
 
-            RVA offset = DisassemblyPreview::readDisassemblyOffset(cursor);
+            RVA offset = DisassemblyHelper::readDisassemblyOffset(cursor);
 
-            if (DisassemblyPreview::isXRefFromComment(offset, cursor.block().text().trimmed())) {
-                RVA xrefFrom = DisassemblyPreview::getXRefFromWord(offset, selectedText);
+            if (DisassemblyHelper::isXRefFromComment(offset, cursor.block().text().trimmed())) {
+                RVA xrefFrom = DisassemblyHelper::getXRefFromWord(offset, selectedText);
                 if (xrefFrom != RVA_INVALID) {
                     seekable->seek(xrefFrom);
                 }
@@ -676,18 +677,18 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
         auto cursorForWord = mDisasTextEdit->cursorForPosition(helpEvent->pos());
         cursorForWord.select(QTextCursor::WordUnderCursor);
 
-        RVA offsetFrom = DisassemblyPreview::readDisassemblyOffset(cursorForWord);
+        RVA offsetFrom = DisassemblyHelper::readDisassemblyOffset(cursorForWord);
 
         const QPoint pointOfEvent = helpEvent->globalPos();
         const QString word = cursorForWord.selectedText();
         const QString line = cursorForWord.block().text().trimmed();
 
         bool hasPreview = Config()->getPreviewValue();
-        if (hasPreview && DisassemblyPreview::isXRefFromComment(offsetFrom, line)) {
+        if (hasPreview && DisassemblyHelper::isXRefFromComment(offsetFrom, line)) {
             // Only show the tooltip if the text under cursor is an address when hovering over auto
             // generated XRef comment, this will show the preview of the caller where this offset is
             // called
-            RVA xrefFrom = DisassemblyPreview::getXRefFromWord(offsetFrom, word);
+            RVA xrefFrom = DisassemblyHelper::getXRefFromWord(offsetFrom, word);
             if (xrefFrom != RVA_INVALID) {
                 DisassemblyPreview::showDisasPreviewAt(this, pointOfEvent, xrefFrom);
             }

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -685,7 +685,8 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
         bool hasPreview = Config()->getPreviewValue();
         if (hasPreview && DisassemblyPreview::isXRefFromComment(offsetFrom, line)) {
             // Only show the tooltip if the text under cursor is an address when hovering over auto
-            // generated XRef comment
+            // generated XRef comment, this will show the preview of the caller where this offset is
+            // called
             RVA xrefFrom = DisassemblyPreview::getXRefFromWord(offsetFrom, word);
             if (xrefFrom != RVA_INVALID) {
                 DisassemblyPreview::showDisasPreviewAt(this, pointOfEvent, xrefFrom);

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -649,6 +649,18 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
             }
 
             RVA offset = DisassemblyPreview::readDisassemblyOffset(cursor);
+
+            if (DisassemblyPreview::isXRefFromComment(offset, cursor.block().text().trimmed())) {
+                RVA xrefFrom = DisassemblyPreview::getXRefFromWord(offset, selectedText);
+                if (xrefFrom != RVA_INVALID) {
+                    seekable->seek(xrefFrom);
+                }
+                // consume the event even if the text under cursor is not an address, this prevents
+                // jumping to incorrect offset (offset pointed to by the next instruction line)
+                // when double clicking on auto generated XREF comment
+                return true;
+            }
+
             XrefDescription firstXref = Core()->getFirstXRefForVariable(selectedText, offset);
             if (!firstXref.from_str.isEmpty() || !firstXref.to_str.isEmpty()) {
                 seekable->seek(firstXref.from);
@@ -666,13 +678,25 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 
         RVA offsetFrom = DisassemblyPreview::readDisassemblyOffset(cursorForWord);
 
-        if (Config()->getPreviewValue()
-            && DisassemblyPreview::showDisasPreview(this, helpEvent->globalPos(), offsetFrom)) {
+        const QPoint pointOfEvent = helpEvent->globalPos();
+        const QString word = cursorForWord.selectedText();
+        const QString line = cursorForWord.block().text().trimmed();
+
+        bool hasPreview = Config()->getPreviewValue();
+        if (hasPreview && DisassemblyPreview::isXRefFromComment(offsetFrom, line)) {
+            // Only show the tooltip if the text under cursor is an address when hovering over auto
+            // generated XRef comment
+            RVA xrefFrom = DisassemblyPreview::getXRefFromWord(offsetFrom, word);
+            if (xrefFrom != RVA_INVALID) {
+                DisassemblyPreview::showDisasPreviewAt(this, pointOfEvent, xrefFrom);
+            }
+            return true;
+        }
+        if (hasPreview && DisassemblyPreview::showDisasPreview(this, pointOfEvent, offsetFrom)) {
             return true;
         }
         if (Config()->getShowVarTooltips()
-            && DisassemblyPreview::showDebugValueTooltip(
-                    this, helpEvent->globalPos(), cursorForWord.selectedText(), offsetFrom)) {
+            && DisassemblyPreview::showDebugValueTooltip(this, pointOfEvent, word, offsetFrom)) {
             return true;
         }
     }

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -651,7 +651,8 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
 
             RVA offset = DisassemblyHelper::readDisassemblyOffset(cursor);
 
-            if (DisassemblyHelper::isXRefFromComment(offset, cursor.block().text().trimmed())) {
+            if (Core()->getConfigb("asm.xrefs")
+                && DisassemblyHelper::isXRefFromComment(offset, cursor.block().text())) {
                 RVA xrefFrom = DisassemblyHelper::getXRefFromWord(offset, selectedText);
                 if (xrefFrom != RVA_INVALID) {
                     seekable->seek(xrefFrom);
@@ -684,7 +685,8 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
         const QString line = cursorForWord.block().text().trimmed();
 
         bool hasPreview = Config()->getPreviewValue();
-        if (hasPreview && DisassemblyHelper::isXRefFromComment(offsetFrom, line)) {
+        if (hasPreview && Core()->getConfigb("asm.xrefs")
+            && DisassemblyHelper::isXRefFromComment(offsetFrom, line)) {
             // Only show the tooltip if the text under cursor is an address when hovering over auto
             // generated XRef comment, this will show the preview of the caller where this offset is
             // called


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Fixes the incorrect seek and preview shown while hovering/double clicking on XREF comment in disassembly and graph widgets. 
Since an "XREF from" comment can contain multiple address in a single line, hovering/clicking on each address shows its respective preview. Clicking and hovering on the symbol name does nothing in the XREF comment for now, that can be handled in a separate PR IMO (if required)

Previously double clicking or (previewing) on symbol name either did nothing or seeked to wrong address 

Note: Since I couldn't find an API function to get the XREF comment for a specific offset through rizin, I had to resort to string matching

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

Make sure to check the "Show preview when hovering" in `Edit->Preferences->Disassembly` and `Edit->Preferences->Graph` and "Show x-refs" in the `Comments` subsection in `Edit->Preferences->Disassembly`

* Download this binary: [https://t.me/cutter_re/50349](https://t.me/cutter_re/50349) (Could also use a different binary)
* Open in cutter
* Seek to `0x77c5c0fc`
* Try hovering over and double clicking the address part (after the @) in `; CODE XREF from sym.USER32.dll_OpenClipboard @ 0x77c5c208` both in disassembly and graph
* Seek to `0x77c2f18f`
* Try hovering over and double clicking any of the addresses in the following (both in disassembly and graph) 
```
; XREFS: CALL 0x77c2f4f5  CALL 0x77c59e67  CALL 0x77c5a1f6  
  ; XREFS: CALL 0x77c5a931  CALL 0x77c5b261  CALL 0x77c6f760  
  ; XREFS: CALL 0x77c6f9da  CALL 0x77c6fafe  CALL 0x77c6fca1  
  ; XREFS: CALL 0x77c7fe35  CALL 0x77cc197e  CALL 0x77cc1def  
  ; XREFS: CALL 0x77cc270d  CALL 0x77cc2928  CALL 0x77cc3451  
  ; XREFS: CALL 0x77cc4484  CALL 0x77cc4f34  CALL 0x77cc58ee  
  ; XREFS: CALL 0x77cc5c0d 
```
* Also check it doesn't randomly show address previews on user comments (Although I do think this is a good feature to let the user add a comment containing an address and show preview/seek to it if it is a valid offset, but that's a job of different PR)

**Comparsion**

**Before:**
![before-xref-disasm](https://github.com/user-attachments/assets/8dcd32a2-1074-4154-8892-07957108cb68)
Seeks and shows preview of incorrect offset (shows the preview of data pointed to by the next immediate instruction) 

**After**
![after-xref-disasm](https://github.com/user-attachments/assets/be0d2aae-151f-4eff-a489-3556e69b70d2)
Seeks to and shows the preview of the caller 

![after-xref-disasm-extra](https://github.com/user-attachments/assets/b5cd4d96-65a7-44c3-8ba7-2c0c7ea40fea)

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3096 