### PR TITLE
Fix shortcut for Rename operates on wrong line/address (#2631)

### DIFF
--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -736,6 +736,8 @@ void DisassemblyWidget::on_seekChanged(RVA offset, CutterCore::SeekHistoryType t
         refreshDisasm(topOffsetHistory[topOffsetHistoryPos]);
     }
     mCtxMenu->setOffset(offset);
+    // after seek it will select curret instruction and updates renaming options
+    mCtxMenu->setCurHighlightedWord(curHighlightedWord);
 }
 
 void DisassemblyWidget::fontsUpdatedSlot()


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

This change resolves issue [#2631](https://github.com/rizinorg/cutter/issues/2631), where rename using shortcut operates on wrong line/address.

**Problem**
When a user uses shortcut for renaming(N) a function and using seek bar, seeks to a address which triggers `on_seekChanged` and cursor position is updated but `setCurHighlightedWord` which updates renaming options is not used.

**Fix**
This modification adds `setCurHighlightedWord` at current cursor so it correctly triggers renaming options.


**Test plan (required)**
The following is example of this bug:
<video src="https://github.com/user-attachments/assets/68434e57-2d74-4eec-a812-ef52de06e6a2" controls preload></video>


After modification, now after seek it correctly renames line/function
<video src="https://github.com/user-attachments/assets/d88cae5c-bf3b-4e26-9dcc-57bdcebb4b24" controls preload></video>

**Closing issues**
closes [#2631](https://github.com/rizinorg/cutter/issues/2631) 