### PR TITLE
Use jsdec `stable` instead of `master`

### DIFF
--- a/dist/bundle_jsdec.ps1
+++ b/dist/bundle_jsdec.ps1
@@ -2,7 +2,7 @@ $dist = $args[0]
 $python = Split-Path((Get-Command python.exe).Path)
 
 if (-not (Test-Path -Path 'jsdec' -PathType Container)) {
-    git clone https://github.com/rizinorg/jsdec.git --depth 1 --branch master
+    git clone https://github.com/rizinorg/jsdec.git --depth 1 --branch stable
 }
 cd jsdec
 & meson.exe --buildtype=release -Dc_args=-DDUK_USE_DATE_NOW_WINDOWS -Djsc_folder=".." --prefix=$dist p build

--- a/scripts/jsdec.sh
+++ b/scripts/jsdec.sh
@@ -7,7 +7,7 @@ SCRIPTPATH=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 cd "$SCRIPTPATH/.."
 
 if [[ ! -d jsdec ]]; then
-	git clone https://github.com/rizinorg/jsdec.git --depth 2 --branch master
+	git clone https://github.com/rizinorg/jsdec.git --depth 2 --branch stable
 fi
 
 cd jsdec


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [ ] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

As per discussion, since the jsdec `master` branch has been renamed to `stable`, this pr changes the jsdec scripts in the Cutter `test` branch accordingly.

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
...