### PR TITLE
Refactor: remove duplicate code for handling word under cursor

### DIFF
--- a/src/common/DisassemblyHelper.cpp
+++ b/src/common/DisassemblyHelper.cpp
@@ -42,3 +42,47 @@ RVA DisassemblyHelper::readDisassemblyOffset(QTextCursor tc)
 
     return userData->line.offset;
 }
+
+DisassemblyHelper::TargetContext DisassemblyHelper::getContextFromCursor(QTextCursor tc)
+{
+    tc.select(QTextCursor::WordUnderCursor);
+    TargetContext ctx;
+    ctx.word = tc.selectedText();
+    ctx.line = tc.block().text();
+    ctx.offset = DisassemblyHelper::readDisassemblyOffset(tc);
+    return ctx;
+}
+
+DisassemblyHelper::TargetAction DisassemblyHelper::resolveTarget(const TargetContext &ctx,
+                                                                 TargetFilter filter)
+{
+    TargetAction res = { RVA_INVALID, TargetType::None };
+
+    if (filter == TargetFilter::All || filter == TargetFilter::XRefCommentOnly) {
+        // Xref comments need special handling to show preview for each caller offset
+        bool showXRefComments = Core()->getConfigb("asm.xrefs");
+        if (showXRefComments && isXRefFromComment(ctx.offset, ctx.line)) {
+            res.offset = getXRefFromWord(ctx.offset, ctx.word);
+            res.type = TargetType::XRefComment;
+            return res;
+        }
+    }
+
+    if (filter == TargetFilter::All) {
+        // check for local variables
+        XrefDescription xref = Core()->getFirstXRefForVariable(ctx.word, ctx.offset);
+        if (!xref.from_str.isEmpty() || !xref.to_str.isEmpty()) {
+            res.offset = xref.from;
+            res.type = TargetType::VariableName;
+            return res;
+        }
+
+        // check for types
+        if (Core()->typeExists(ctx.word)) {
+            res.type = TargetType::TypeName;
+            return res;
+        }
+    }
+
+    return res;
+}

--- a/src/common/DisassemblyHelper.h
+++ b/src/common/DisassemblyHelper.h
@@ -22,6 +22,43 @@ public:
  */
 namespace DisassemblyHelper {
 
+/**
+ * @brief Identifies what kind of item was clicked or hovered
+ */
+enum class TargetType {
+    VariableName,
+    TypeName,
+    XRefComment,
+    None,
+};
+
+/**
+ * @brief Data used to figure out what is under the mouse
+ */
+struct TargetContext
+{
+    RVA offset;
+    QString word;
+    QString line;
+};
+
+/**
+ * @brief What was found after checking the context
+ */
+struct TargetAction
+{
+    RVA offset;
+    TargetType type;
+};
+
+/**
+ * @brief Filter to control how deep the search goes
+ */
+enum class TargetFilter {
+    All,
+    XRefCommentOnly,
+};
+
 DisassemblyTextBlockUserData *getUserData(const QTextBlock &block);
 
 /**
@@ -46,6 +83,20 @@ bool isXRefFromComment(RVA offset, const QString &line);
  */
 RVA readDisassemblyOffset(QTextCursor tc);
 
+/**
+ * @brief Gets the text and address at the current cursor position
+ * @param tc The cursor to check
+ * @return TargetContext containing info about the offset, word and line at the cursor
+ */
+TargetContext getContextFromCursor(QTextCursor tc);
+
+/**
+ * @brief Identifies what a context points to (like a variable or type)
+ * @param ctx The context found at the cursor
+ * @param filter Limits what kind of items to look for
+ * @return The result containing the address and type found
+ */
+TargetAction resolveTarget(const TargetContext &ctx, TargetFilter filter = TargetFilter::All);
 }
 
 #endif // DISASSEMBLYHELPER_H

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -131,3 +131,35 @@ bool DisassemblyPreview::showDebugValueTooltip(QWidget *parent, const QPoint &po
     // Else show preview for value?
     return false;
 }
+
+bool DisassemblyPreview::showTooltip(QWidget *parent, const QPoint &globalPos,
+                                     const DisassemblyHelper::TargetContext &ctx, bool hasPreview)
+{
+    bool isWordEmpty = ctx.word.isEmpty();
+    if (hasPreview) {
+        if (!isWordEmpty) {
+            auto ta = DisassemblyHelper::resolveTarget(
+                    ctx, DisassemblyHelper::TargetFilter::XRefCommentOnly);
+            if (ta.type == DisassemblyHelper::TargetType::XRefComment) {
+                if (ta.offset != RVA_INVALID) {
+                    showDisasPreviewAt(parent, globalPos, ta.offset);
+                }
+                // consume the event even if the text under cursor is not an address, this prevents
+                // jumping to incorrect offset (offset pointed to by the next instruction line)
+                // when double clicking on auto generated XREF comment
+                return true;
+            }
+        }
+
+        if (showDisasPreview(parent, globalPos, ctx.offset)) {
+            return true;
+        }
+    }
+
+    if (Config()->getShowVarTooltips() && !isWordEmpty
+        && showDebugValueTooltip(parent, globalPos, ctx.word, ctx.offset)) {
+        return true;
+    }
+
+    return false;
+}

--- a/src/common/DisassemblyPreview.h
+++ b/src/common/DisassemblyPreview.h
@@ -3,6 +3,7 @@
 
 #include <QTextBlockUserData>
 #include "core/CutterDescriptions.h"
+#include "DisassemblyHelper.h"
 
 class QWidget;
 
@@ -38,5 +39,15 @@ bool showDisasPreviewAt(QWidget *parent, const QPoint &pointOfEvent, const RVA o
 bool showDebugValueTooltip(QWidget *parent, const QPoint &pointOfEvent, const QString &selectedText,
                            const RVA offset);
 
+/**
+ * @brief Displays a tooltip or preview window based on the item under the cursor
+ * @param parent The widget that owns and positions the tooltip
+ * @param globalPos The screen position where the tooltip should appear
+ * @param ctx The context identifying the word and address under the mouse
+ * @param hasPreview The config value indicating whether preview should be shown for the widget
+ * @return True if a tooltip was shown or the event was handled, false otherwise
+ */
+bool showTooltip(QWidget *parent, const QPoint &globalPos,
+                 const DisassemblyHelper::TargetContext &ctx, bool hasPreview);
 }
 #endif

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3983,15 +3983,10 @@ QString CutterCore::getTypeAsC(QString name)
     return result;
 }
 
-bool CutterCore::isValidTypeName(const QString &typeName)
+bool CutterCore::typeExists(const QString &typeName)
 {
-    const auto &types = getAllTypes();
-    for (const auto &t : types) {
-        if (t.type == typeName) {
-            return true;
-        }
-    }
-    return false;
+    CORE_LOCK();
+    return rz_type_exists(core->analysis->typedb, typeName.toUtf8().constData());
 }
 
 bool CutterCore::isAddressMapped(RVA addr)

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -703,11 +703,11 @@ public:
     QString getTypeAsC(QString name);
 
     /**
-     * @brief Check if a type name exists
+     * @brief Check if a type exists using its name
      * @param typeName Name of the type to validate
      * @return true if the type exists, false otherwise
      */
-    bool isValidTypeName(const QString &typeName);
+    bool typeExists(const QString &typeName);
 
     /**
      * @brief Highlight a specific type in the Types widget

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -542,7 +542,6 @@ bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
         && event->type() == QEvent::Type::ToolTip) {
 
         QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
-        QPoint pointOfEvent = helpEvent->globalPos();
         QPoint point = viewToLogicalCoordinates(helpEvent->pos());
 
         if (auto block = getBlockContaining(point)) {
@@ -564,28 +563,13 @@ bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
             // Don't preview anything for a small scale
             if (getViewScale() >= 0.8) {
                 auto token = getToken(inst, pos.x());
-                bool hasPreview = Config()->getGraphPreview();
-                if (hasPreview && Core()->getConfigb("asm.xrefs")
-                    && DisassemblyHelper::isXRefFromComment(offsetFrom, inst->plainText)) {
-                    if (!token) {
-                        return true;
-                    }
-                    RVA xrefFrom = DisassemblyHelper::getXRefFromWord(offsetFrom, token->content);
-                    if (xrefFrom != RVA_INVALID) {
-                        DisassemblyPreview::showDisasPreviewAt(this, pointOfEvent, xrefFrom);
-                    }
+                DisassemblyHelper::TargetContext ctx;
+                ctx.offset = offsetFrom;
+                ctx.word = token ? token->content : QString();
+                ctx.line = inst->plainText;
+                if (DisassemblyPreview::showTooltip(this, helpEvent->globalPos(), ctx,
+                                                    Config()->getGraphPreview())) {
                     return true;
-                }
-                if (hasPreview
-                    && DisassemblyPreview::showDisasPreview(this, pointOfEvent, offsetFrom)) {
-                    return true;
-                }
-                if (Config()->getShowVarTooltips() && inst) {
-                    if (token
-                        && DisassemblyPreview::showDebugValueTooltip(this, pointOfEvent,
-                                                                     token->content, offsetFrom)) {
-                        return true;
-                    }
                 }
             }
         }
@@ -950,39 +934,31 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
 {
     Q_UNUSED(event);
 
-    if (!highlight_token) {
-        return;
-    }
-
     Instr *instr = getInstrForMouseEvent(block, &pos);
     if (!instr) {
         return;
     }
 
-    QString selectedText = highlight_token->content;
-    if (Core()->isValidTypeName(selectedText)) {
-        Core()->showTypeInTypesWidget(selectedText);
-        return;
-    }
+    DisassemblyHelper::TargetContext ctx;
+    ctx.word = highlight_token ? highlight_token->content : QString();
+    ctx.line = instr->plainText;
+    ctx.offset = getAddrForMouseEvent(block, &pos);
 
-    RVA offset = getAddrForMouseEvent(block, &pos);
-
-    if (Core()->getConfigb("asm.xrefs")
-        && DisassemblyHelper::isXRefFromComment(offset, instr->plainText)) {
-        RVA xrefFrom = DisassemblyHelper::getXRefFromWord(offset, selectedText);
-        if (xrefFrom != RVA_INVALID) {
-            seekable->seek(xrefFrom);
+    DisassemblyHelper::TargetAction ta = DisassemblyHelper::resolveTarget(ctx);
+    switch (ta.type) {
+    case DisassemblyHelper::TargetType::TypeName:
+        Core()->showTypeInTypesWidget(ctx.word);
+        break;
+    case DisassemblyHelper::TargetType::XRefComment:
+    case DisassemblyHelper::TargetType::VariableName:
+        if (ta.offset != RVA_INVALID) {
+            seekable->seek(ta.offset);
         }
-        return;
+        break;
+    case DisassemblyHelper::TargetType::None:
+        seekable->seekToReference(ctx.offset);
+        break;
     }
-
-    XrefDescription firstXref = Core()->getFirstXRefForVariable(selectedText, instr->addr);
-    if (!firstXref.from_str.isEmpty() || !firstXref.to_str.isEmpty()) {
-        seekable->seek(firstXref.from);
-        return;
-    }
-
-    seekable->seekToReference(offset);
 }
 
 void DisassemblerGraphView::blockHelpEvent(GraphView::GraphBlock &block, QHelpEvent *event,

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -639,70 +639,35 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
 
         if (mouseEvent->button() == Qt::LeftButton) {
-            QTextCursor cursor = mDisasTextEdit->cursorForPosition(mouseEvent->pos());
-            cursor.select(QTextCursor::WordUnderCursor);
+            auto ctx = DisassemblyHelper::getContextFromCursor(
+                    mDisasTextEdit->cursorForPosition(mouseEvent->pos()));
 
-            const QString selectedText = cursor.selectedText();
-
-            if (Core()->isValidTypeName(selectedText)) {
-                Core()->showTypeInTypesWidget(selectedText);
-                return true;
-            }
-
-            RVA offset = DisassemblyHelper::readDisassemblyOffset(cursor);
-
-            if (Core()->getConfigb("asm.xrefs")
-                && DisassemblyHelper::isXRefFromComment(offset, cursor.block().text())) {
-                RVA xrefFrom = DisassemblyHelper::getXRefFromWord(offset, selectedText);
-                if (xrefFrom != RVA_INVALID) {
-                    seekable->seek(xrefFrom);
+            DisassemblyHelper::TargetAction ta = DisassemblyHelper::resolveTarget(ctx);
+            switch (ta.type) {
+            case DisassemblyHelper::TargetType::TypeName:
+                Core()->showTypeInTypesWidget(ctx.word);
+                break;
+            case DisassemblyHelper::TargetType::XRefComment:
+            case DisassemblyHelper::TargetType::VariableName:
+                if (ta.offset != RVA_INVALID) {
+                    seekable->seek(ta.offset);
                 }
-                // consume the event even if the text under cursor is not an address, this prevents
-                // jumping to incorrect offset (offset pointed to by the next instruction line)
-                // when double clicking on auto generated XREF comment
-                return true;
+                break;
+            case DisassemblyHelper::TargetType::None:
+                seekable->seekToReference(ctx.offset);
+                break;
             }
-
-            XrefDescription firstXref = Core()->getFirstXRefForVariable(selectedText, offset);
-            if (!firstXref.from_str.isEmpty() || !firstXref.to_str.isEmpty()) {
-                seekable->seek(firstXref.from);
-                return true;
-            }
-
-            jumpToOffsetUnderCursor(cursor);
             return true;
         }
     } else if ((Config()->getPreviewValue() || Config()->getShowVarTooltips())
                && event->type() == QEvent::ToolTip && obj == mDisasTextEdit->viewport()) {
         QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
-        auto cursorForWord = mDisasTextEdit->cursorForPosition(helpEvent->pos());
-        cursorForWord.select(QTextCursor::WordUnderCursor);
 
-        RVA offsetFrom = DisassemblyHelper::readDisassemblyOffset(cursorForWord);
+        auto ctx = DisassemblyHelper::getContextFromCursor(
+                mDisasTextEdit->cursorForPosition(helpEvent->pos()));
 
-        const QPoint pointOfEvent = helpEvent->globalPos();
-        const QString word = cursorForWord.selectedText();
-        const QString line = cursorForWord.block().text().trimmed();
-
-        bool hasPreview = Config()->getPreviewValue();
-        if (hasPreview && Core()->getConfigb("asm.xrefs")
-            && DisassemblyHelper::isXRefFromComment(offsetFrom, line)) {
-            // Only show the tooltip if the text under cursor is an address when hovering over auto
-            // generated XRef comment, this will show the preview of the caller where this offset is
-            // called
-            RVA xrefFrom = DisassemblyHelper::getXRefFromWord(offsetFrom, word);
-            if (xrefFrom != RVA_INVALID) {
-                DisassemblyPreview::showDisasPreviewAt(this, pointOfEvent, xrefFrom);
-            }
-            return true;
-        }
-        if (hasPreview && DisassemblyPreview::showDisasPreview(this, pointOfEvent, offsetFrom)) {
-            return true;
-        }
-        if (Config()->getShowVarTooltips()
-            && DisassemblyPreview::showDebugValueTooltip(this, pointOfEvent, word, offsetFrom)) {
-            return true;
-        }
+        return DisassemblyPreview::showTooltip(this, helpEvent->globalPos(), ctx,
+                                               Config()->getPreviewValue());
     }
 
     return MemoryDockWidget::eventFilter(obj, event);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

* This PR moves all logic for checking the word under cursor for double click event and tooltip event into `DisassemblyHelper` instead of being duplicated in both `DisassemblyWidget` and `DisassemblerGraphView`
* Also changes the `isValidTypeName()` func to `typeExists()` which uses `rz_type_exists()` (should be faster than copying and linearly searching through a QList) 

Doesn't add anything new in terms of functionality

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

Make sure `Show preview when hovering` is set to true in both disassembly and graph in `Edit->Preferences`

* Open any binary in cutter
* In DisassemblyWidget Hover over any instruction that references any offset, observe it shows a preview
* Double clicking on it should jump to the reference
* Test the same in Graph Widget
* Also test the previews after disabling the `Show preview when hovering`
* Also make sure clicking on any type jumps to the Types widget correctly

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3190 