### PR TITLE
Follow conditional branching targets in Disassembly and Graph

### DIFF
--- a/src/common/DisassemblyHelper.cpp
+++ b/src/common/DisassemblyHelper.cpp
@@ -43,6 +43,16 @@ RVA DisassemblyHelper::readDisassemblyOffset(QTextCursor tc)
     return userData->line.offset;
 }
 
+RVA DisassemblyHelper::readDisassemblyArrow(QTextCursor tc)
+{
+    auto userData = getUserData(tc.block());
+    if (!userData) {
+        return RVA_INVALID;
+    }
+
+    return userData->line.arrow;
+}
+
 DisassemblyHelper::TargetContext DisassemblyHelper::getContextFromCursor(QTextCursor tc)
 {
     tc.select(QTextCursor::WordUnderCursor);
@@ -50,16 +60,17 @@ DisassemblyHelper::TargetContext DisassemblyHelper::getContextFromCursor(QTextCu
     ctx.word = tc.selectedText();
     ctx.line = tc.block().text();
     ctx.offset = DisassemblyHelper::readDisassemblyOffset(tc);
+    ctx.arrow = DisassemblyHelper::readDisassemblyArrow(tc);
     return ctx;
 }
 
 DisassemblyHelper::TargetAction DisassemblyHelper::resolveTarget(const TargetContext &ctx,
-                                                                 TargetFilter filter)
+                                                                 int filter)
 {
     TargetAction res = { RVA_INVALID, TargetType::None };
 
-    if (filter == TargetFilter::All || filter == TargetFilter::XRefCommentOnly) {
-        // Xref comments need special handling to show preview for each caller offset
+    // Xref comments need special handling to show preview for each caller offset
+    if (filter & TargetFilter::XRefComments) {
         bool showXRefComments = Core()->getConfigb("asm.xrefs");
         if (showXRefComments && isXRefFromComment(ctx.offset, ctx.line)) {
             res.offset = getXRefFromWord(ctx.offset, ctx.word);
@@ -68,18 +79,26 @@ DisassemblyHelper::TargetAction DisassemblyHelper::resolveTarget(const TargetCon
         }
     }
 
-    if (filter == TargetFilter::All) {
-        // check for local variables
+    if (filter & TargetFilter::Variables) {
         XrefDescription xref = Core()->getFirstXRefForVariable(ctx.word, ctx.offset);
         if (!xref.from_str.isEmpty() || !xref.to_str.isEmpty()) {
             res.offset = xref.from;
             res.type = TargetType::VariableName;
             return res;
         }
+    }
 
-        // check for types
+    if (filter & TargetFilter::Types) {
         if (Core()->typeExists(ctx.word)) {
             res.type = TargetType::TypeName;
+            return res;
+        }
+    }
+
+    if (filter & TargetFilter::Arrows) {
+        if (ctx.arrow != RVA_INVALID) {
+            res.type = TargetType::Arrow;
+            res.offset = ctx.arrow;
             return res;
         }
     }

--- a/src/common/DisassemblyHelper.h
+++ b/src/common/DisassemblyHelper.h
@@ -29,6 +29,7 @@ enum class TargetType {
     VariableName,
     TypeName,
     XRefComment,
+    Arrow,
     None,
 };
 
@@ -38,6 +39,7 @@ enum class TargetType {
 struct TargetContext
 {
     RVA offset;
+    RVA arrow;
     QString word;
     QString line;
 };
@@ -54,9 +56,13 @@ struct TargetAction
 /**
  * @brief Filter to control how deep the search goes
  */
-enum class TargetFilter {
-    All,
-    XRefCommentOnly,
+enum TargetFilter {
+    XRefComments = 1 << 0,
+    Variables = 1 << 1,
+    Types = 1 << 2,
+    Arrows = 1 << 3,
+
+    All = XRefComments | Variables | Types | Arrows
 };
 
 DisassemblyTextBlockUserData *getUserData(const QTextBlock &block);
@@ -83,6 +89,12 @@ bool isXRefFromComment(RVA offset, const QString &line);
  */
 RVA readDisassemblyOffset(QTextCursor tc);
 
+/*!
+ * @brief Reads the arrow offset for the cursor position
+ * @return Offset the arrow points to
+ */
+RVA readDisassemblyArrow(QTextCursor tc);
+
 /**
  * @brief Gets the text and address at the current cursor position
  * @param tc The cursor to check
@@ -96,7 +108,7 @@ TargetContext getContextFromCursor(QTextCursor tc);
  * @param filter Limits what kind of items to look for
  * @return The result containing the address and type found
  */
-TargetAction resolveTarget(const TargetContext &ctx, TargetFilter filter = TargetFilter::All);
+TargetAction resolveTarget(const TargetContext &ctx, int filter = TargetFilter::All);
 }
 
 #endif // DISASSEMBLYHELPER_H

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -7,6 +7,8 @@
 #include <QToolTip>
 #include <QProcessEnvironment>
 
+namespace DH = DisassemblyHelper;
+
 QString DisassemblyPreview::getToolTipStyleSheet()
 {
     return QString { "QToolTip { border-width: 1px; max-width: %1px;"
@@ -133,22 +135,24 @@ bool DisassemblyPreview::showDebugValueTooltip(QWidget *parent, const QPoint &po
 }
 
 bool DisassemblyPreview::showTooltip(QWidget *parent, const QPoint &globalPos,
-                                     const DisassemblyHelper::TargetContext &ctx, bool hasPreview)
+                                     const DH::TargetContext &ctx, bool hasPreview)
 {
     bool isWordEmpty = ctx.word.isEmpty();
     if (hasPreview) {
-        if (!isWordEmpty) {
-            auto ta = DisassemblyHelper::resolveTarget(
-                    ctx, DisassemblyHelper::TargetFilter::XRefCommentOnly);
-            if (ta.type == DisassemblyHelper::TargetType::XRefComment) {
-                if (ta.offset != RVA_INVALID) {
-                    showDisasPreviewAt(parent, globalPos, ta.offset);
-                }
-                // consume the event even if the text under cursor is not an address, this prevents
-                // jumping to incorrect offset (offset pointed to by the next instruction line)
-                // when double clicking on auto generated XREF comment
-                return true;
+        auto ta = DH::resolveTarget(ctx, DH::XRefComments | DH::Arrows);
+
+        if (!isWordEmpty && ta.type == DH::TargetType::XRefComment) {
+            if (ta.offset != RVA_INVALID) {
+                showDisasPreviewAt(parent, globalPos, ta.offset);
             }
+            // consume the event even if the text under cursor is not an address, this prevents
+            // jumping to incorrect offset (offset pointed to by the next instruction line)
+            // when double clicking on auto generated XREF comment
+            return true;
+        }
+
+        if (ta.type == DH::TargetType::Arrow && showDisasPreviewAt(parent, globalPos, ta.offset)) {
+            return true;
         }
 
         if (showDisasPreview(parent, globalPos, ctx.offset)) {
@@ -162,14 +166,4 @@ bool DisassemblyPreview::showTooltip(QWidget *parent, const QPoint &globalPos,
     }
 
     return false;
-}
-
-RVA DisassemblyPreview::readDisassemblyArrow(QTextCursor tc)
-{
-    auto userData = getUserData(tc.block());
-    if (!userData && userData->line.arrow != RVA_INVALID) {
-        return RVA_INVALID;
-    }
-
-    return userData->line.arrow;
 }

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -163,3 +163,13 @@ bool DisassemblyPreview::showTooltip(QWidget *parent, const QPoint &globalPos,
 
     return false;
 }
+
+RVA DisassemblyPreview::readDisassemblyArrow(QTextCursor tc)
+{
+    auto userData = getUserData(tc.block());
+    if (!userData && userData->line.arrow != RVA_INVALID) {
+        return RVA_INVALID;
+    }
+
+    return userData->line.arrow;
+}

--- a/src/common/DisassemblyPreview.h
+++ b/src/common/DisassemblyPreview.h
@@ -49,12 +49,5 @@ bool showDebugValueTooltip(QWidget *parent, const QPoint &pointOfEvent, const QS
  */
 bool showTooltip(QWidget *parent, const QPoint &globalPos,
                  const DisassemblyHelper::TargetContext &ctx, bool hasPreview);
-RVA readDisassemblyOffset(QTextCursor tc);
-
-/*!
- * @brief Reads the arrow offset for the cursor position
- * @return The jump address of the hovered asm text
- */
-RVA readDisassemblyArrow(QTextCursor tc);
 }
 #endif

--- a/src/common/DisassemblyPreview.h
+++ b/src/common/DisassemblyPreview.h
@@ -49,5 +49,12 @@ bool showDebugValueTooltip(QWidget *parent, const QPoint &pointOfEvent, const QS
  */
 bool showTooltip(QWidget *parent, const QPoint &globalPos,
                  const DisassemblyHelper::TargetContext &ctx, bool hasPreview);
+RVA readDisassemblyOffset(QTextCursor tc);
+
+/*!
+ * @brief Reads the arrow offset for the cursor position
+ * @return The jump address of the hovered asm text
+ */
+RVA readDisassemblyArrow(QTextCursor tc);
 }
 #endif

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -582,11 +582,14 @@ bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
 
 void DisassemblerGraphView::keyPressEvent(QKeyEvent *event)
 {
-    // pressing enter at last instruction of the block seeks to true path if valid
     if (event->key() == Qt::Key_Return && seekable) {
-        RVA truePath = getTruePathForOffset(seekable->getOffset());
+        RVA offset = seekable->getOffset();
+        // pressing enter at last instruction of the block seeks to true path if valid
+        RVA truePath = getTruePathForOffset(offset);
         if (truePath != RVA_INVALID) {
             seekable->seek(truePath);
+        } else {
+            seekable->seekToReference(offset);
         }
     }
 

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -32,6 +32,8 @@
 
 #include <cmath>
 
+namespace DH = DisassemblyHelper;
+
 DisassemblerGraphView::DisassemblerGraphView(QWidget *parent, CutterSeekable *seekable,
                                              MainWindow *mainWindow,
                                              QList<QAction *> additionalMenuActions)
@@ -563,10 +565,11 @@ bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
             // Don't preview anything for a small scale
             if (getViewScale() >= 0.8) {
                 auto token = getToken(inst, pos.x());
-                DisassemblyHelper::TargetContext ctx;
+                DH::TargetContext ctx;
                 ctx.offset = offsetFrom;
                 ctx.word = token ? token->content : QString();
                 ctx.line = inst->plainText;
+                ctx.arrow = getTruePathForOffset(offsetFrom);
                 if (DisassemblyPreview::showTooltip(this, helpEvent->globalPos(), ctx,
                                                     Config()->getGraphPreview())) {
                     return true;
@@ -575,6 +578,19 @@ bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
         }
     }
     return CutterGraphView::eventFilter(obj, event);
+}
+
+void DisassemblerGraphView::keyPressEvent(QKeyEvent *event)
+{
+    // pressing enter at last instruction of the block seeks to true path if valid
+    if (event->key() == Qt::Key_Return && seekable) {
+        RVA truePath = getTruePathForOffset(seekable->getOffset());
+        if (truePath != RVA_INVALID) {
+            seekable->seek(truePath);
+        }
+    }
+
+    CutterGraphView::keyPressEvent(event);
 }
 
 RVA DisassemblerGraphView::getAddrForMouseEvent(GraphBlock &block, QPoint *point)
@@ -667,6 +683,18 @@ QRectF DisassemblerGraphView::getInstrRect(GraphView::GraphBlock &block, RVA add
         currentLine += instr.text.lines.size();
     }
     return QRectF();
+}
+
+RVA DisassemblerGraphView::getTruePathForOffset(RVA offset)
+{
+    DisassemblyBlock *db = blockForAddress(offset);
+    if (db && !db->instrs.empty()) {
+        Instr lastInstruction = db->instrs.back();
+        if (lastInstruction.addr == offset) {
+            return db->true_path;
+        }
+    }
+    return RVA_INVALID;
 }
 
 void DisassemblerGraphView::showInstruction(GraphView::GraphBlock &block, RVA addr)
@@ -939,57 +967,27 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
         return;
     }
 
-    DisassemblyHelper::TargetContext ctx;
+    DH::TargetContext ctx;
     ctx.word = highlight_token ? highlight_token->content : QString();
     ctx.line = instr->plainText;
     ctx.offset = getAddrForMouseEvent(block, &pos);
+    ctx.arrow = getTruePathForOffset(ctx.offset);
 
-    DisassemblyHelper::TargetAction ta = DisassemblyHelper::resolveTarget(ctx);
+    DH::TargetAction ta = DH::resolveTarget(ctx);
     switch (ta.type) {
-    case DisassemblyHelper::TargetType::TypeName:
+    case DH::TargetType::TypeName:
         Core()->showTypeInTypesWidget(ctx.word);
         break;
-    case DisassemblyHelper::TargetType::XRefComment:
-    case DisassemblyHelper::TargetType::VariableName:
+    case DH::TargetType::XRefComment:
+    case DH::TargetType::VariableName:
+    case DH::TargetType::Arrow:
         if (ta.offset != RVA_INVALID) {
             seekable->seek(ta.offset);
         }
         break;
-    case DisassemblyHelper::TargetType::None:
+    case DH::TargetType::None:
         seekable->seekToReference(ctx.offset);
         break;
-    }
-    RVA arrow = NULL;
-    RVA offset = getAddrForMouseEvent(block, &pos);
-    DisassemblyBlock *db = blockForAddress(offset);
-
-    Instr lastInstruction = db->instrs.back();
-
-    // Handle the blocks without any paths
-    if (offset == lastInstruction.addr && db->false_path == RVA_INVALID
-        && db->true_path == RVA_INVALID) {
-        return;
-    }
-
-    // Handle the blocks with just one path
-    if (offset == lastInstruction.addr && db->false_path == RVA_INVALID) {
-        seekable->seek(db->true_path);
-        return;
-    }
-
-    // Handle blocks with two paths
-    if (offset == lastInstruction.addr && db->false_path != RVA_INVALID) {
-        // gets the offset for the next instruction
-        RVA nextOffset = lastInstruction.addr + lastInstruction.size;
-        // sets "arrow" to the path that isn't going to the next offset
-        if (db->false_path == nextOffset) {
-            arrow = db->true_path;
-        } else if (db->true_path == nextOffset) {
-            arrow = db->false_path;
-        }
-
-        seekable->seek(arrow);
-        return;
     }
 }
 

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -959,6 +959,38 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
         seekable->seekToReference(ctx.offset);
         break;
     }
+    RVA arrow = NULL;
+    RVA offset = getAddrForMouseEvent(block, &pos);
+    DisassemblyBlock *db = blockForAddress(offset);
+
+    Instr lastInstruction = db->instrs.back();
+
+    // Handle the blocks without any paths
+    if (offset == lastInstruction.addr && db->false_path == RVA_INVALID
+        && db->true_path == RVA_INVALID) {
+        return;
+    }
+
+    // Handle the blocks with just one path
+    if (offset == lastInstruction.addr && db->false_path == RVA_INVALID) {
+        seekable->seek(db->true_path);
+        return;
+    }
+
+    // Handle blocks with two paths
+    if (offset == lastInstruction.addr && db->false_path != RVA_INVALID) {
+        // gets the offset for the next instruction
+        RVA nextOffset = lastInstruction.addr + lastInstruction.size;
+        // sets "arrow" to the path that isn't going to the next offset
+        if (db->false_path == nextOffset) {
+            arrow = db->true_path;
+        } else if (db->true_path == nextOffset) {
+            arrow = db->false_path;
+        }
+
+        seekable->seek(arrow);
+        return;
+    }
 }
 
 void DisassemblerGraphView::blockHelpEvent(GraphView::GraphBlock &block, QHelpEvent *event,

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -140,6 +140,7 @@ protected:
     void contextMenuEvent(QContextMenuEvent *event) override;
     void restoreCurrentBlock() override;
     bool eventFilter(QObject *obj, QEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
 
 private slots:
     void showExportDialog() override;
@@ -173,6 +174,12 @@ private:
      * @return
      */
     QRectF getInstrRect(GraphView::GraphBlock &block, RVA addr) const;
+    /**
+     * @brief Get the true path address if the offset represents the last instruction of block
+     * @param offset Offset to check
+     * @return RVA Offset for true path
+     */
+    RVA getTruePathForOffset(RVA offset);
     void showInstruction(GraphView::GraphBlock &block, RVA addr);
     const Instr *instrForAddress(RVA addr);
     DisassemblyBlock *blockForAddress(RVA addr);

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -27,6 +27,8 @@
 #include <cmath>
 #include <cstring>
 
+namespace DH = DisassemblyHelper;
+
 DisassemblyWidget::DisassemblyWidget(MainWindow *main)
     : MemoryDockWidget(MemoryWidgetType::Disassembly, main),
       mCtxMenu(new DisassemblyContextMenu(this, main)),
@@ -386,7 +388,7 @@ void DisassemblyWidget::highlightCurrentLine()
     highlightSelection.cursor = cursor;
     highlightSelection.cursor.movePosition(QTextCursor::Start);
     while (true) {
-        RVA lineOffset = DisassemblyHelper::readDisassemblyOffset(highlightSelection.cursor);
+        RVA lineOffset = DH::readDisassemblyOffset(highlightSelection.cursor);
         if (lineOffset == seekable->getOffset()) {
             highlightSelection.format.setBackground(highlightColor);
             highlightSelection.format.setProperty(QTextFormat::FullWidthSelection, true);
@@ -421,7 +423,7 @@ void DisassemblyWidget::highlightPCLine()
     highlightSelection.cursor.movePosition(QTextCursor::Start);
     if (PCAddr != RVA_INVALID) {
         while (true) {
-            RVA lineOffset = DisassemblyHelper::readDisassemblyOffset(highlightSelection.cursor);
+            RVA lineOffset = DH::readDisassemblyOffset(highlightSelection.cursor);
             if (lineOffset == PCAddr) {
                 highlightSelection.format.setBackground(highlightPCColor);
                 highlightSelection.format.setProperty(QTextFormat::FullWidthSelection, true);
@@ -454,7 +456,7 @@ void DisassemblyWidget::showDisasContextMenu(const QPoint &pt)
 RVA DisassemblyWidget::readCurrentDisassemblyOffset()
 {
     QTextCursor tc = mDisasTextEdit->textCursor();
-    return DisassemblyHelper::readDisassemblyOffset(tc);
+    return DH::readDisassemblyOffset(tc);
 }
 
 void DisassemblyWidget::updateCursorPosition()
@@ -481,7 +483,7 @@ void DisassemblyWidget::updateCursorPosition()
         cursor.movePosition(QTextCursor::Start);
 
         while (true) {
-            RVA lineOffset = DisassemblyHelper::readDisassemblyOffset(cursor);
+            RVA lineOffset = DH::readDisassemblyOffset(cursor);
             if (lineOffset == offset) {
                 if (cursorLineOffset > 0) {
                     cursor.movePosition(QTextCursor::Down, QTextCursor::MoveAnchor,
@@ -542,7 +544,7 @@ void DisassemblyWidget::cursorPositionChanged()
     cursorCharOffset = c.positionInBlock();
     while (c.blockNumber() > 0) {
         c.movePosition(QTextCursor::PreviousBlock);
-        if (DisassemblyHelper::readDisassemblyOffset(c) != offset) {
+        if (DH::readDisassemblyOffset(c) != offset) {
             break;
         }
         cursorLineOffset++;
@@ -628,18 +630,7 @@ void DisassemblyWidget::moveCursorRelative(bool up, bool page)
 
 void DisassemblyWidget::jumpToOffsetUnderCursor(const QTextCursor &cursor)
 {
-<<<<<<< HEAD
-    RVA offset = DisassemblyHelper::readDisassemblyOffset(cursor);
-=======
-    // Handles "jmp" and conditonal jump instructions
-    RVA arrow = DisassemblyPreview::readDisassemblyArrow(cursor);
-    if (arrow != RVA_INVALID) {
-        seekable->seek(arrow);
-    }
-
-    // Handles "call" and "lea" instructions
-    RVA offset = DisassemblyPreview::readDisassemblyOffset(cursor);
->>>>>>> 5ed0f334 (Fix "return" key in disassembler widget (#3090))
+    RVA offset = DH::readDisassemblyOffset(cursor);
     seekable->seekToReference(offset);
 }
 
@@ -650,32 +641,32 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
 
         if (mouseEvent->button() == Qt::LeftButton) {
-            auto ctx = DisassemblyHelper::getContextFromCursor(
-                    mDisasTextEdit->cursorForPosition(mouseEvent->pos()));
+            auto ctx =
+                    DH::getContextFromCursor(mDisasTextEdit->cursorForPosition(mouseEvent->pos()));
 
-            DisassemblyHelper::TargetAction ta = DisassemblyHelper::resolveTarget(ctx);
+            DH::TargetAction ta = DH::resolveTarget(ctx);
             switch (ta.type) {
-            case DisassemblyHelper::TargetType::TypeName:
+            case DH::TargetType::TypeName:
                 Core()->showTypeInTypesWidget(ctx.word);
                 break;
-            case DisassemblyHelper::TargetType::XRefComment:
-            case DisassemblyHelper::TargetType::VariableName:
+            case DH::TargetType::XRefComment:
+            case DH::TargetType::VariableName:
+            case DH::TargetType::Arrow:
                 if (ta.offset != RVA_INVALID) {
                     seekable->seek(ta.offset);
                 }
                 break;
-            case DisassemblyHelper::TargetType::None:
+            case DH::TargetType::None:
                 seekable->seekToReference(ctx.offset);
                 break;
             }
             return true;
         }
-    } else if (Config()->getPreviewValue() && event->type() == QEvent::ToolTip
-               && obj == mDisasTextEdit->viewport()) {
+    } else if ((Config()->getPreviewValue() || Config()->getShowVarTooltips())
+               && event->type() == QEvent::ToolTip && obj == mDisasTextEdit->viewport()) {
         QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
 
-        auto ctx = DisassemblyHelper::getContextFromCursor(
-                mDisasTextEdit->cursorForPosition(helpEvent->pos()));
+        auto ctx = DH::getContextFromCursor(mDisasTextEdit->cursorForPosition(helpEvent->pos()));
 
         return DisassemblyPreview::showTooltip(this, helpEvent->globalPos(), ctx,
                                                Config()->getPreviewValue());
@@ -688,7 +679,12 @@ void DisassemblyWidget::keyPressEvent(QKeyEvent *event)
 {
     if (event->key() == Qt::Key_Return) {
         const QTextCursor cursor = mDisasTextEdit->textCursor();
-        jumpToOffsetUnderCursor(cursor);
+        auto ta = DH::resolveTarget(DH::getContextFromCursor(cursor), DH::TargetFilter::Arrows);
+        if (ta.type == DH::TargetType::Arrow) {
+            seekable->seek(ta.offset);
+        } else {
+            jumpToOffsetUnderCursor(cursor);
+        }
     }
 
     MemoryDockWidget::keyPressEvent(event);

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -628,7 +628,18 @@ void DisassemblyWidget::moveCursorRelative(bool up, bool page)
 
 void DisassemblyWidget::jumpToOffsetUnderCursor(const QTextCursor &cursor)
 {
+<<<<<<< HEAD
     RVA offset = DisassemblyHelper::readDisassemblyOffset(cursor);
+=======
+    // Handles "jmp" and conditonal jump instructions
+    RVA arrow = DisassemblyPreview::readDisassemblyArrow(cursor);
+    if (arrow != RVA_INVALID) {
+        seekable->seek(arrow);
+    }
+
+    // Handles "call" and "lea" instructions
+    RVA offset = DisassemblyPreview::readDisassemblyOffset(cursor);
+>>>>>>> 5ed0f334 (Fix "return" key in disassembler widget (#3090))
     seekable->seekToReference(offset);
 }
 
@@ -659,8 +670,8 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
             }
             return true;
         }
-    } else if ((Config()->getPreviewValue() || Config()->getShowVarTooltips())
-               && event->type() == QEvent::ToolTip && obj == mDisasTextEdit->viewport()) {
+    } else if (Config()->getPreviewValue() && event->type() == QEvent::ToolTip
+               && obj == mDisasTextEdit->viewport()) {
         QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
 
         auto ctx = DisassemblyHelper::getContextFromCursor(


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

Rebase of [PR #3146](https://github.com/rizinorg/cutter/pull/3146/) to work with `DisassemblyHelper`
This PR does the following:
* Pressing enter key or double clicking on a branch instruction will now seek to its target/destination/true_path (arrow) in both disassembly and graph
* Hovering over branch instruction will show the preview of target/destination in both disassembly and graph

Smaller changes in this PR:
* Changes the `TypeFilter` to a bit mask (don't know why I didn't do this in the original [PR #3559](https://github.com/rizinorg/cutter/pull/3559))
* Uses `namespace DH = DisassemblyHelper;` because `DisassemblyHelper::TargetType::<NAME>` is long  

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

For preview to be shown make sure `Show preview on hover` is set to true in both disassembly and graphs

* Open any binary in cutter
* Go to any branch instruction
* Try hovering, double clicking and pressing enter
* Observe it correctly shows preview and seeks to the target address
* Now try the same things on any non branch instruction
* If the non branch instruction has a reference to an address it should show the preview / seek to that address, if not nothing should happen on hover, enter and double click

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3090
closes #3146 