### PR TITLE
Fix empty space at bottom of Functions widget

### DIFF
--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -504,7 +504,9 @@ FunctionsWidget::FunctionsWidget(MainWindow *main)
     setModels(functionProxyModel);
     ui->treeView->sortByColumn(FunctionModel::NameColumn, Qt::AscendingOrder);
     ui->treeView->setExpandsOnDoubleClick(false);
-
+    ui->treeView->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    ui->treeView->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    
     titleContextMenu = new QMenu(this);
     auto viewTypeGroup = new QActionGroup(titleContextMenu);
     actionHorizontal.setCheckable(true);

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -505,7 +505,6 @@ FunctionsWidget::FunctionsWidget(MainWindow *main)
     ui->treeView->sortByColumn(FunctionModel::NameColumn, Qt::AscendingOrder);
     ui->treeView->setExpandsOnDoubleClick(false);
     ui->treeView->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    ui->treeView->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
 
     titleContextMenu = new QMenu(this);
     auto viewTypeGroup = new QActionGroup(titleContextMenu);

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -506,7 +506,7 @@ FunctionsWidget::FunctionsWidget(MainWindow *main)
     ui->treeView->setExpandsOnDoubleClick(false);
     ui->treeView->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     ui->treeView->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    
+
     titleContextMenu = new QMenu(this);
     auto viewTypeGroup = new QActionGroup(titleContextMenu);
     actionHorizontal.setCheckable(true);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the guidelines for contributing to this repository
- [x] I made sure to follow the project's coding style
- [ ] I've updated the documentation with the relevant information (if needed)
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

This pull request fixes the extra empty space visible at the bottom of the Functions widget.

The issue was caused by the tree view not expanding properly within the dock widget.  
This change updates the size policy of the tree view to allow it to expand correctly and enables the vertical scrollbar only when needed.

No functional behavior is changed; this is a UI/layout improvement only.


**Test plan (required)**

1. Open Cutter.
2. Load any binary with multiple detected functions.
3. Open the Functions widget.
4. Resize the window and dock area.

**Result:**
- The Functions widget no longer shows unnecessary empty space at the bottom.
- The tree view expands correctly.
- Vertical scrollbar appears only when required.


**Closing issues**

closes #2789