### PR TITLE
Fix file open failure after invalid IO mode

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -664,6 +664,8 @@ bool CutterCore::tryFile(QString path, bool rw)
         return true;
     }
     CORE_LOCK();
+    // clear info from previous fails
+    rz_cons_break_clear();
     RzCoreFile *cf;
     int flags = RZ_PERM_R;
     if (rw)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

This change resolves issue [#3548](https://github.com/rizinorg/cutter/issues/3548), where file fails to open after a invalid IO mode even when tried with correct IO mode.

**Problem**
When a user uses a invalid IO in this case `zip://` for a normal file it gives a error that its not a zip file, but after this when tried to open the same file with `file://` it returns `Select a new program or a previous one before continuing`.
It was happening because when one tries opening a normal file in `zip://` rizin fails to parse and trigger a internal interrupt which sets `breaked` flag to true and not clears it while closing. Now, when opened with `file://` it calls `CutterCore::tryFile()` which calls [rz_core_file_open](https://github.com/rizinorg/rizin/blob/dev/librz/core/cfile.c#L1188) which first checks of `breaked` flag which was set to true by previous attempt and always return `NULL` this cause `tryFile()` to return false.

**Fix**
This modification adds a call to [rz_cons_break_clear()](https://github.com/rizinorg/rizin/blob/dev/librz/cons/cons.c#L312) inside `CutterCore::tryFile()` right before calling `rz_core_file_open()`. This resets Rizin's break state, ensuring that any previous IO probe failures do not hinder the core state and block valid files from being loaded.


**Test plan (required)**
The following is example of this bug:
<video src="https://github.com/user-attachments/assets/859e6726-457e-4f1b-a659-3a145094af69" controls preload></video>

After modification, it correctly opens file
<video src="https://github.com/user-attachments/assets/1b10d913-9e6a-467e-8674-3b7f9a9dcc67" controls preload></video>

**Closing issues**
closes [#3548](https://github.com/rizinorg/cutter/issues/3548)