### PR TITLE
Fix Xrefs dialog exceeding screen width for long flag names

### DIFF
--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -7,6 +7,8 @@
 #include "core/MainWindow.h"
 
 #include <QJsonArray>
+#include <QGuiApplication>
+#include <QScreen>
 
 XrefsDialog::XrefsDialog(MainWindow *parent, bool hideXrefFrom)
     : QDialog(parent), addr(0), toModel(this), fromModel(this), ui(new Ui::XrefsDialog)
@@ -185,6 +187,9 @@ void XrefsDialog::fillRefsForAddress(RVA addr, QString name, bool whole_function
     qhelpers::adjustColumns(ui->fromTreeWidget, fromModel.columnCount(), 0);
     qhelpers::adjustColumns(ui->toTreeWidget, toModel.columnCount(), 0);
 
+    // Limit dialog width to screen width
+    resize(qMin(width(), qApp->primaryScreen()->availableGeometry().width()), height());
+
     // Automatically select the first line
     if (!qhelpers::selectFirstItem(ui->toTreeWidget)) {
         qhelpers::selectFirstItem(ui->fromTreeWidget);
@@ -205,6 +210,9 @@ void XrefsDialog::fillRefsForVariable(QString nameOfVariable, RVA offset)
     // Adjust columns to content
     qhelpers::adjustColumns(ui->fromTreeWidget, fromModel.columnCount(), 0);
     qhelpers::adjustColumns(ui->toTreeWidget, toModel.columnCount(), 0);
+
+    // Limit dialog width to screen width
+    resize(qMin(width(), qApp->primaryScreen()->availableGeometry().width()), height());
 
     // Automatically select the first line
     if (!qhelpers::selectFirstItem(ui->toTreeWidget)) {


### PR DESCRIPTION


**Your checklist for this pull request**
- [x] I've read the [[guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html)](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [[coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [[documentation](https://cutter.re/docs/user-docs.html)](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

When opening the XRefs dialog for a flag with a very long name, the dialog window stretches wider than the screen width, making it unusable.

This PR fixes the issue by limiting the dialog width to the available screen width after adjusting columns to content. The fix uses `QGuiApplication::primaryScreen()->availableGeometry().width()` and is applied in both `fillRefsForAddress` and `fillRefsForVariable` functions.



**Test plan (required)**

1. Open Cutter and load any binary (e.g. notepad.exe)
2. Find or create a flag with a very long name
3. Right-click on it and select XRefs
4. Verify the dialog opens without exceeding the screen width

**Closing issues**

closes #3300