### PR TITLE
Add tooltip for disassembly values

### DIFF
--- a/src/common/DisassemblyHelper.cpp
+++ b/src/common/DisassemblyHelper.cpp
@@ -55,10 +55,43 @@ RVA DisassemblyHelper::readDisassemblyArrow(QTextCursor tc)
 
 DisassemblyHelper::TargetContext DisassemblyHelper::getContextFromCursor(QTextCursor tc)
 {
+    int originalPos = tc.position();
     tc.select(QTextCursor::WordUnderCursor);
+    QString word = tc.selectedText();
+    QString line = tc.block().text();
+    int lineStart = tc.block().position();
+    int posInLine = originalPos - lineStart;
+
+    int openBracket = line.lastIndexOf('[', posInLine);
+    int closeBracket = line.indexOf(']', posInLine);
+
+    if (openBracket != -1 && closeBracket != -1) {
+        bool isInside = true;
+        for (int i = openBracket + 1; i < posInLine; ++i) {
+            if (line[i] == ']') {
+                isInside = false;
+                break;
+            }
+        }
+        if (isInside) {
+            for (int i = posInLine; i < closeBracket; ++i) {
+                if (line[i] == '[') {
+                    isInside = false;
+                    break;
+                }
+            }
+        }
+
+        if (isInside) {
+            tc.setPosition(lineStart + openBracket);
+            tc.setPosition(lineStart + closeBracket + 1, QTextCursor::KeepAnchor);
+            word = tc.selectedText();
+        }
+    }
+
     TargetContext ctx;
-    ctx.word = tc.selectedText();
-    ctx.line = tc.block().text();
+    ctx.word = word;
+    ctx.line = line;
     ctx.offset = DisassemblyHelper::readDisassemblyOffset(tc);
     ctx.arrow = DisassemblyHelper::readDisassemblyArrow(tc);
     return ctx;

--- a/src/common/DisassemblyHelper.cpp
+++ b/src/common/DisassemblyHelper.cpp
@@ -129,7 +129,7 @@ DisassemblyHelper::TargetAction DisassemblyHelper::resolveTarget(const TargetCon
         }
     }
 
-    if (filter & TargetFilter::Variables) {
+    if (filter & TargetFilter::VariableValues) {
         QString inner = ctx.word;
         if (inner.startsWith('[') && inner.endsWith(']')) {
             inner = inner.mid(1, inner.length() - 2);
@@ -145,11 +145,13 @@ DisassemblyHelper::TargetAction DisassemblyHelper::resolveTarget(const TargetCon
                 }
             }
         }
+    }
 
-        XrefDescription xref = Core()->getFirstXRefForVariable(inner, ctx.offset);
+    if (filter & TargetFilter::VariableXrefs) {
+        XrefDescription xref = Core()->getFirstXRefForVariable(ctx.word, ctx.offset);
         if (!xref.from_str.isEmpty() || !xref.to_str.isEmpty()) {
             res.value = xref.from;
-            res.type = TargetType::VariableName;
+            res.type = TargetType::VariableXRef;
             return res;
         }
     }

--- a/src/common/DisassemblyHelper.cpp
+++ b/src/common/DisassemblyHelper.cpp
@@ -1,5 +1,22 @@
 #include "DisassemblyHelper.h"
 #include "Cutter.h"
+#include "rz_types_base.h"
+
+typedef struct mmio_lookup_context
+{
+    QString selected;
+    RVA mmio_address;
+} mmio_lookup_context_t;
+
+static bool lookup_mmio_addr_cb(void *user, const ut64 key, const void *value)
+{
+    mmio_lookup_context_t *ctx = (mmio_lookup_context_t *)user;
+    if (ctx->selected == (const char *)value) {
+        ctx->mmio_address = key;
+        return false;
+    }
+    return true;
+}
 
 DisassemblyTextBlockUserData::DisassemblyTextBlockUserData(const DisassemblyLine &line)
     : line { line }
@@ -106,16 +123,32 @@ DisassemblyHelper::TargetAction DisassemblyHelper::resolveTarget(const TargetCon
     if (filter & TargetFilter::XRefComments) {
         bool showXRefComments = Core()->getConfigb("asm.xrefs");
         if (showXRefComments && isXRefFromComment(ctx.offset, ctx.line)) {
-            res.offset = getXRefFromWord(ctx.offset, ctx.word);
+            res.value = getXRefFromWord(ctx.offset, ctx.word);
             res.type = TargetType::XRefComment;
             return res;
         }
     }
 
     if (filter & TargetFilter::Variables) {
-        XrefDescription xref = Core()->getFirstXRefForVariable(ctx.word, ctx.offset);
+        QString inner = ctx.word;
+        if (inner.startsWith('[') && inner.endsWith(']')) {
+            inner = inner.mid(1, inner.length() - 2);
+        }
+
+        if (ctx.offset != RVA_INVALID) {
+            auto vars = Core()->getVariables(ctx.offset);
+            for (auto &var : vars) {
+                if (var.name == inner) {
+                    res.value = Core()->math(var.value);
+                    res.type = TargetType::VariableValue;
+                    return res;
+                }
+            }
+        }
+
+        XrefDescription xref = Core()->getFirstXRefForVariable(inner, ctx.offset);
         if (!xref.from_str.isEmpty() || !xref.to_str.isEmpty()) {
-            res.offset = xref.from;
+            res.value = xref.from;
             res.type = TargetType::VariableName;
             return res;
         }
@@ -131,8 +164,43 @@ DisassemblyHelper::TargetAction DisassemblyHelper::resolveTarget(const TargetCon
     if (filter & TargetFilter::Arrows) {
         if (ctx.arrow != RVA_INVALID) {
             res.type = TargetType::Arrow;
-            res.offset = ctx.arrow;
+            res.value = ctx.arrow;
             return res;
+        }
+    }
+
+    if (!ctx.word.isEmpty()) {
+        if (filter & TargetFilter::Registers) {
+            const auto reg = Core()->getRegisterRefValue(ctx.word);
+            if (!reg.name.isEmpty()) {
+                res.type = TargetType::Register;
+                res.value = Core()->math(reg.value);
+                return res;
+            }
+        }
+
+        if (filter & TargetFilter::MMIO) {
+            mmio_lookup_context_t mmio_ctx;
+            mmio_ctx.selected = ctx.word;
+            mmio_ctx.mmio_address = RVA_INVALID;
+            auto core = Core()->lock();
+            RzPlatformTarget *arch_target = core->analysis->arch_target;
+            if (arch_target && arch_target->profile) {
+                ht_up_foreach(arch_target->profile->registers_mmio, lookup_mmio_addr_cb, &mmio_ctx);
+            }
+            if (mmio_ctx.mmio_address != RVA_INVALID) {
+                res.value = mmio_ctx.mmio_address;
+                res.type = TargetType::MMIO;
+                return res;
+            }
+        }
+
+        if (filter & TargetFilter::Memory) {
+            if (ctx.word.startsWith('[') && ctx.word.endsWith(']')) {
+                res.value = Core()->math(ctx.word);
+                res.type = TargetType::Memory;
+                return res;
+            }
         }
     }
 

--- a/src/common/DisassemblyHelper.cpp
+++ b/src/common/DisassemblyHelper.cpp
@@ -70,15 +70,10 @@ RVA DisassemblyHelper::readDisassemblyArrow(QTextCursor tc)
     return userData->line.arrow;
 }
 
-DisassemblyHelper::TargetContext DisassemblyHelper::getContextFromCursor(QTextCursor tc)
+DisassemblyHelper::BracketResult DisassemblyHelper::findBracketRange(const QString &line,
+                                                                     int posInLine)
 {
-    int originalPos = tc.position();
-    tc.select(QTextCursor::WordUnderCursor);
-    QString word = tc.selectedText();
-    QString line = tc.block().text();
-    int lineStart = tc.block().position();
-    int posInLine = originalPos - lineStart;
-
+    BracketResult res;
     int openBracket = line.lastIndexOf('[', posInLine);
     int closeBracket = line.indexOf(']', posInLine);
 
@@ -100,10 +95,29 @@ DisassemblyHelper::TargetContext DisassemblyHelper::getContextFromCursor(QTextCu
         }
 
         if (isInside) {
-            tc.setPosition(lineStart + openBracket);
-            tc.setPosition(lineStart + closeBracket + 1, QTextCursor::KeepAnchor);
-            word = tc.selectedText();
+            res.found = true;
+            res.start = openBracket;
+            res.length = (closeBracket - openBracket) + 1;
+            res.content = line.mid(res.start, res.length);
         }
+    }
+    return res;
+}
+
+DisassemblyHelper::TargetContext DisassemblyHelper::getContextFromCursor(QTextCursor tc)
+{
+    int originalPos = tc.position();
+    tc.select(QTextCursor::WordUnderCursor);
+    QString word = tc.selectedText();
+    QString line = tc.block().text();
+    int lineStart = tc.block().position();
+    int posInLine = originalPos - lineStart;
+
+    auto bracketRes = findBracketRange(line, posInLine);
+    if (bracketRes.found) {
+        tc.setPosition(lineStart + bracketRes.start);
+        tc.setPosition(lineStart + bracketRes.start + bracketRes.length, QTextCursor::KeepAnchor);
+        word = bracketRes.content;
     }
 
     TargetContext ctx;

--- a/src/common/DisassemblyHelper.cpp
+++ b/src/common/DisassemblyHelper.cpp
@@ -212,7 +212,15 @@ DisassemblyHelper::TargetAction DisassemblyHelper::resolveTarget(const TargetCon
         }
 
         if (filter & TargetFilter::Memory) {
-            if (ctx.word.startsWith('[') && ctx.word.endsWith(']')) {
+            QString stripped = ctx.word;
+            if (stripped.startsWith('[') && stripped.endsWith(']')) {
+                stripped = stripped.mid(1, stripped.length() - 2);
+            } else {
+                return res;
+            }
+
+            if (Core()->isValidInputNumValue(stripped)
+                || !Core()->getRegisterRefValue(stripped).name.isEmpty()) {
                 res.value = Core()->math(ctx.word);
                 res.type = TargetType::Memory;
                 return res;

--- a/src/common/DisassemblyHelper.cpp
+++ b/src/common/DisassemblyHelper.cpp
@@ -215,15 +215,12 @@ DisassemblyHelper::TargetAction DisassemblyHelper::resolveTarget(const TargetCon
             QString stripped = ctx.word;
             if (stripped.startsWith('[') && stripped.endsWith(']')) {
                 stripped = stripped.mid(1, stripped.length() - 2);
-            } else {
-                return res;
-            }
-
-            if (Core()->isValidInputNumValue(stripped)
-                || !Core()->getRegisterRefValue(stripped).name.isEmpty()) {
-                res.value = Core()->math(ctx.word);
-                res.type = TargetType::Memory;
-                return res;
+                if (Core()->isValidInputNumValue(stripped)
+                    || Core()->isValidInputNumValue(ctx.word)) {
+                    res.value = Core()->math(ctx.word);
+                    res.type = TargetType::Memory;
+                    return res;
+                }
             }
         }
     }

--- a/src/common/DisassemblyHelper.h
+++ b/src/common/DisassemblyHelper.h
@@ -26,7 +26,7 @@ namespace DisassemblyHelper {
  * @brief Identifies what kind of item was clicked or hovered
  */
 enum class TargetType {
-    VariableName,
+    VariableXRef,
     VariableValue,
     TypeName,
     XRefComment,
@@ -62,14 +62,17 @@ struct TargetAction
  */
 enum TargetFilter {
     XRefComments = 1 << 0,
-    Variables = 1 << 1,
-    Types = 1 << 2,
-    Arrows = 1 << 3,
-    Registers = 1 << 4,
-    Memory = 1 << 5,
-    MMIO = 1 << 6,
+    VariableXrefs = 1 << 1,
+    VariableValues = 1 << 2,
+    Types = 1 << 3,
+    Arrows = 1 << 4,
+    Registers = 1 << 5,
+    Memory = 1 << 6,
+    MMIO = 1 << 7,
 
-    All = XRefComments | Variables | Types | Arrows | Registers | Memory | MMIO
+    Standard = XRefComments | VariableXrefs | Types | Arrows,
+    Debug = Registers | Memory | MMIO | VariableValues,
+    All = Standard | Debug
 };
 
 DisassemblyTextBlockUserData *getUserData(const QTextBlock &block);

--- a/src/common/DisassemblyHelper.h
+++ b/src/common/DisassemblyHelper.h
@@ -27,9 +27,13 @@ namespace DisassemblyHelper {
  */
 enum class TargetType {
     VariableName,
+    VariableValue,
     TypeName,
     XRefComment,
     Arrow,
+    Register,
+    Memory,
+    MMIO,
     None,
 };
 
@@ -49,7 +53,7 @@ struct TargetContext
  */
 struct TargetAction
 {
-    RVA offset;
+    RVA value;
     TargetType type;
 };
 
@@ -61,8 +65,11 @@ enum TargetFilter {
     Variables = 1 << 1,
     Types = 1 << 2,
     Arrows = 1 << 3,
+    Registers = 1 << 4,
+    Memory = 1 << 5,
+    MMIO = 1 << 6,
 
-    All = XRefComments | Variables | Types | Arrows
+    All = XRefComments | Variables | Types | Arrows | Registers | Memory | MMIO
 };
 
 DisassemblyTextBlockUserData *getUserData(const QTextBlock &block);

--- a/src/common/DisassemblyHelper.h
+++ b/src/common/DisassemblyHelper.h
@@ -75,7 +75,26 @@ enum TargetFilter {
     All = Standard | Debug
 };
 
+/**
+ * @brief Result of bracket detection
+ */
+struct BracketResult
+{
+    bool found = false;
+    int start = -1;
+    int length = 0;
+    QString content;
+};
+
 DisassemblyTextBlockUserData *getUserData(const QTextBlock &block);
+
+/**
+ * @brief Finds the range and content of a bracketed expression under a given position
+ * @param line The text line to search in
+ * @param posInLine The cursor position within the line
+ * @return BracketResult containing the found range and content
+ */
+BracketResult findBracketRange(const QString &line, int posInLine);
 
 /**
  * @brief Finds the source (from) address of an XRef based on the text word under the cursor

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -135,7 +135,8 @@ bool DisassemblyPreview::showTooltip(QWidget *parent, const QPoint &globalPos,
         }
     }
 
-    if (Config()->getShowVarTooltips() && !isWordEmpty) {
+    if (Config()->getShowVarTooltips() && (Core()->currentlyDebugging || Core()->currentlyEmulating)
+        && !isWordEmpty) {
         auto ta = DH::resolveTarget(ctx, DH::Debug);
         if (ta.type != DH::TargetType::None && showDebugValueTooltip(parent, globalPos, ta, ctx)) {
             return true;

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -85,15 +85,11 @@ bool DisassemblyPreview::showDebugValueTooltip(QWidget *parent, const QPoint &po
         return false;
 
     if (selectedText.at(0).isLetter()) {
-        {
-            const auto registerRefs = Core()->getRegisterRefValues();
-            for (auto &reg : registerRefs) {
-                if (reg.name == selectedText) {
-                    auto msg = QString("reg %1 = %2").arg(reg.name, reg.value);
-                    QToolTip::showText(pointOfEvent, msg, parent);
-                    return true;
-                }
-            }
+        const auto reg = Core()->getRegisterRefValue(selectedText);
+        if (!reg.name.isEmpty()) {
+            auto msg = QString("reg %1 = %2").arg(reg.name, reg.value);
+            QToolTip::showText(pointOfEvent, msg, parent);
+            return true;
         }
 
         if (offset != RVA_INVALID) {

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -114,11 +114,9 @@ bool DisassemblyPreview::showTooltip(QWidget *parent, const QPoint &globalPos,
 {
     bool isWordEmpty = ctx.word.isEmpty();
     if (hasPreview) {
-        auto ta = DH::resolveTarget(ctx, DH::XRefComments | DH::Arrows | DH::Variables);
+        auto ta = DH::resolveTarget(ctx, DH::XRefComments | DH::Arrows);
 
-        if (!isWordEmpty
-            && (ta.type == DH::TargetType::XRefComment
-                || ta.type == DH::TargetType::VariableName)) {
+        if (!isWordEmpty && ta.type == DH::TargetType::XRefComment) {
             if (ta.value != RVA_INVALID) {
                 showDisasPreviewAt(parent, globalPos, ta.value);
             }

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -136,9 +136,7 @@ bool DisassemblyPreview::showTooltip(QWidget *parent, const QPoint &globalPos,
     }
 
     if (Config()->getShowVarTooltips() && !isWordEmpty) {
-        auto ta = DH::resolveTarget(ctx,
-                                    DH::TargetFilter::Registers | DH::TargetFilter::Variables
-                                            | DH::TargetFilter::Memory | DH::TargetFilter::MMIO);
+        auto ta = DH::resolveTarget(ctx, DH::Debug);
         if (ta.type != DH::TargetType::None && showDebugValueTooltip(parent, globalPos, ta, ctx)) {
             return true;
         }

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -63,92 +63,44 @@ bool DisassemblyPreview::showDisasPreviewAt(QWidget *parent, const QPoint &point
     return false;
 }
 
-typedef struct mmio_lookup_context
+bool DisassemblyPreview::showDebugValueTooltip(QWidget *parent, const QPoint &pointOfEvent,
+                                               const DH::TargetAction &ta,
+                                               const DH::TargetContext &ctx)
 {
-    QString selected;
-    RVA mmio_address;
-} mmio_lookup_context_t;
-
-static bool lookup_mmio_addr_cb(void *user, const ut64 key, const void *value)
-{
-    mmio_lookup_context_t *ctx = (mmio_lookup_context_t *)user;
-    if (ctx->selected == (const char *)value) {
-        ctx->mmio_address = key;
+    QString msg;
+    switch (ta.type) {
+    case DH::TargetType::Register: {
+        msg = QString("reg %1 = 0x%2").arg(ctx.word).arg(ta.value, 0, 16);
+        auto fcn = Core()->functionIn(ta.value);
+        if (fcn) {
+            msg += QString(" (%1)").arg(fcn->name);
+        }
+        break;
+    }
+    case DH::TargetType::VariableValue: {
+        msg = QString("var %1 = 0x%2").arg(ctx.word).arg(ta.value, 0, 16);
+        break;
+    }
+    case DH::TargetType::MMIO: {
+        int len = 8; // TODO: Determine proper len of mmio address for the cpu
+        auto core = Core()->lock();
+        if (char *r = rz_core_print_hexdump_or_hexdiff_str(core, RZ_OUTPUT_MODE_STANDARD, ta.value,
+                                                           len, false)) {
+            msg = QString("mmio %1 %2").arg(ctx.word, QString::fromUtf8(r).trimmed());
+            free(r);
+        }
+        break;
+    }
+    case DH::TargetType::Memory: {
+        ut64 addr = Core()->math(ctx.word.mid(1, ctx.word.length() - 2));
+        msg = QString("%1 = 0x%2 -> 0x%3").arg(ctx.word).arg(addr, 0, 16).arg(ta.value, 0, 16);
+        break;
+    }
+    default:
         return false;
     }
-    return true;
-}
 
-bool DisassemblyPreview::showDebugValueTooltip(QWidget *parent, const QPoint &pointOfEvent,
-                                               const QString &selectedText, const RVA offset)
-{
-    if (selectedText.isEmpty())
-        return false;
-
-    if (selectedText.at(0).isLetter()) {
-        const auto reg = Core()->getRegisterRefValue(selectedText);
-        if (!reg.name.isEmpty()) {
-            ut64 val = Core()->math(reg.value);
-            auto fcn = Core()->functionIn(val);
-            auto msg = QString("reg %1 = %2").arg(reg.name, reg.value);
-            if (fcn) {
-                msg += QString(" (%1)").arg(fcn->name);
-            }
-            QToolTip::showText(pointOfEvent, msg, parent);
-            return true;
-        }
-
-        if (offset != RVA_INVALID) {
-            auto vars = Core()->getVariables(offset);
-            for (auto &var : vars) {
-                if (var.name == selectedText) {
-                    auto msg = QString("var %1 = %2").arg(var.name, var.value);
-                    QToolTip::showText(pointOfEvent, msg, parent);
-                    return true;
-                }
-            }
-        }
-
-        {
-            // Lookup MMIO address
-            mmio_lookup_context_t ctx;
-            ctx.selected = selectedText;
-            ctx.mmio_address = RVA_INVALID;
-            auto core = Core()->lock();
-            RzPlatformTarget *arch_target = core->analysis->arch_target;
-            if (arch_target && arch_target->profile) {
-                ht_up_foreach(arch_target->profile->registers_mmio, lookup_mmio_addr_cb, &ctx);
-            }
-            if (ctx.mmio_address != RVA_INVALID) {
-                int len = 8; // TODO: Determine proper len of mmio address for the cpu
-                if (char *r = rz_core_print_hexdump_or_hexdiff_str(core, RZ_OUTPUT_MODE_STANDARD,
-                                                                   ctx.mmio_address, len, false)) {
-                    auto val = QString::fromUtf8(r).trimmed().split("\n").last();
-                    auto msg = QString("mmio %1 %2").arg(selectedText, val);
-                    free(r);
-                    QToolTip::showText(pointOfEvent, msg, parent);
-                    return true;
-                }
-            }
-        }
-    } else if (selectedText.startsWith('[') && selectedText.endsWith(']')) {
-        QString innerExpr = selectedText.mid(1, selectedText.length() - 2);
-
-        if (offset != RVA_INVALID) {
-            auto vars = Core()->getVariables(offset);
-            for (auto &var : vars) {
-                qDebug() << "var" << var.name << var.value << innerExpr;
-                if (var.name == innerExpr) {
-                    auto msg = QString("var %1 = %2").arg(var.name, var.value);
-                    QToolTip::showText(pointOfEvent, msg, parent);
-                    return true;
-                }
-            }
-        }
-
-        ut64 val = Core()->math(selectedText);
-        ut64 addr = Core()->math(innerExpr);
-        auto msg = QString("%1 = 0x%2 -> 0x%3").arg(selectedText).arg(addr, 0, 16).arg(val, 0, 16);
+    if (!msg.isEmpty()) {
         QToolTip::showText(pointOfEvent, msg, parent);
         return true;
     }
@@ -162,11 +114,13 @@ bool DisassemblyPreview::showTooltip(QWidget *parent, const QPoint &globalPos,
 {
     bool isWordEmpty = ctx.word.isEmpty();
     if (hasPreview) {
-        auto ta = DH::resolveTarget(ctx, DH::XRefComments | DH::Arrows);
+        auto ta = DH::resolveTarget(ctx, DH::XRefComments | DH::Arrows | DH::Variables);
 
-        if (!isWordEmpty && ta.type == DH::TargetType::XRefComment) {
-            if (ta.offset != RVA_INVALID) {
-                showDisasPreviewAt(parent, globalPos, ta.offset);
+        if (!isWordEmpty
+            && (ta.type == DH::TargetType::XRefComment
+                || ta.type == DH::TargetType::VariableName)) {
+            if (ta.value != RVA_INVALID) {
+                showDisasPreviewAt(parent, globalPos, ta.value);
             }
             // consume the event even if the text under cursor is not an address, this prevents
             // jumping to incorrect offset (offset pointed to by the next instruction line)
@@ -174,7 +128,7 @@ bool DisassemblyPreview::showTooltip(QWidget *parent, const QPoint &globalPos,
             return true;
         }
 
-        if (ta.type == DH::TargetType::Arrow && showDisasPreviewAt(parent, globalPos, ta.offset)) {
+        if (ta.type == DH::TargetType::Arrow && showDisasPreviewAt(parent, globalPos, ta.value)) {
             return true;
         }
 
@@ -183,9 +137,13 @@ bool DisassemblyPreview::showTooltip(QWidget *parent, const QPoint &globalPos,
         }
     }
 
-    if (Config()->getShowVarTooltips() && !isWordEmpty
-        && showDebugValueTooltip(parent, globalPos, ctx.word, ctx.offset)) {
-        return true;
+    if (Config()->getShowVarTooltips() && !isWordEmpty) {
+        auto ta = DH::resolveTarget(ctx,
+                                    DH::TargetFilter::Registers | DH::TargetFilter::Variables
+                                            | DH::TargetFilter::Memory | DH::TargetFilter::MMIO);
+        if (ta.type != DH::TargetType::None && showDebugValueTooltip(parent, globalPos, ta, ctx)) {
+            return true;
+        }
     }
 
     return false;

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -1,5 +1,6 @@
 #include "DisassemblyPreview.h"
 #include "Configuration.h"
+#include "rz_types_base.h"
 #include "widgets/GraphView.h"
 
 #include <QCoreApplication>
@@ -87,7 +88,12 @@ bool DisassemblyPreview::showDebugValueTooltip(QWidget *parent, const QPoint &po
     if (selectedText.at(0).isLetter()) {
         const auto reg = Core()->getRegisterRefValue(selectedText);
         if (!reg.name.isEmpty()) {
+            ut64 val = Core()->math(reg.value);
+            auto fcn = Core()->functionIn(val);
             auto msg = QString("reg %1 = %2").arg(reg.name, reg.value);
+            if (fcn) {
+                msg += QString(" (%1)").arg(fcn->name);
+            }
             QToolTip::showText(pointOfEvent, msg, parent);
             return true;
         }
@@ -125,7 +131,15 @@ bool DisassemblyPreview::showDebugValueTooltip(QWidget *parent, const QPoint &po
                 }
             }
         }
+    } else if (selectedText.startsWith('[') && selectedText.endsWith(']')) {
+        QString innerExpr = selectedText.mid(1, selectedText.length() - 2);
+        ut64 val = Core()->math(selectedText);
+        ut64 addr = Core()->math(innerExpr);
+        auto msg = QString("%1 = 0x%2 -> 0x%3").arg(selectedText).arg(addr, 0, 16).arg(val, 0, 16);
+        QToolTip::showText(pointOfEvent, msg, parent);
+        return true;
     }
+
     // Else show preview for value?
     return false;
 }

--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -133,6 +133,19 @@ bool DisassemblyPreview::showDebugValueTooltip(QWidget *parent, const QPoint &po
         }
     } else if (selectedText.startsWith('[') && selectedText.endsWith(']')) {
         QString innerExpr = selectedText.mid(1, selectedText.length() - 2);
+
+        if (offset != RVA_INVALID) {
+            auto vars = Core()->getVariables(offset);
+            for (auto &var : vars) {
+                qDebug() << "var" << var.name << var.value << innerExpr;
+                if (var.name == innerExpr) {
+                    auto msg = QString("var %1 = %2").arg(var.name, var.value);
+                    QToolTip::showText(pointOfEvent, msg, parent);
+                    return true;
+                }
+            }
+        }
+
         ut64 val = Core()->math(selectedText);
         ut64 addr = Core()->math(innerExpr);
         auto msg = QString("%1 = 0x%2 -> 0x%3").arg(selectedText).arg(addr, 0, 16).arg(val, 0, 16);

--- a/src/common/DisassemblyPreview.h
+++ b/src/common/DisassemblyPreview.h
@@ -36,8 +36,9 @@ bool showDisasPreviewAt(QWidget *parent, const QPoint &pointOfEvent, const RVA o
  * @brief Show a QToolTip that shows the value of the highlighted register, variable, or memory
  * @return True if the tooltip is shown
  */
-bool showDebugValueTooltip(QWidget *parent, const QPoint &pointOfEvent, const QString &selectedText,
-                           const RVA offset);
+bool showDebugValueTooltip(QWidget *parent, const QPoint &pointOfEvent,
+                           const DisassemblyHelper::TargetAction &ta,
+                           const DisassemblyHelper::TargetContext &ctx);
 
 /**
  * @brief Displays a tooltip or preview window based on the item under the cursor

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1904,7 +1904,7 @@ RegisterRefValueDescription CutterCore::getRegisterRefValue(const QString &regNa
     }
     desc.name = ri->name;
     ut64 value = rz_reg_get_value(getReg(), ri);
-    desc.value = "0x" + QString::number(value, 16);
+    desc.value = RzAddressString(value);
     desc.ref = rz_core_analysis_hasrefs(core, value, RZ_OUTPUT_MODE_STANDARD);
     return desc;
 }

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1109,6 +1109,11 @@ void CutterCore::createSignature(const QString &filepath)
                              tr("Written %1 signatures to %2.").arg(n_modules).arg(filepath));
 }
 
+bool CutterCore::isValidInputNumValue(const QString &expression)
+{
+    return rz_is_valid_input_num_value(NULL, expression.toUtf8().constData());
+}
+
 ut64 CutterCore::math(const QString &expr)
 {
     CORE_LOCK();

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1111,7 +1111,8 @@ void CutterCore::createSignature(const QString &filepath)
 
 bool CutterCore::isValidInputNumValue(const QString &expression)
 {
-    return rz_is_valid_input_num_value(NULL, expression.toUtf8().constData());
+    CORE_LOCK();
+    return rz_is_valid_input_num_value(core ? core->num : NULL, expression.toUtf8().constData());
 }
 
 ut64 CutterCore::math(const QString &expr)

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1894,6 +1894,21 @@ QVector<RegisterRefValueDescription> CutterCore::getRegisterRefValues()
     return result;
 }
 
+RegisterRefValueDescription CutterCore::getRegisterRefValue(const QString &regName)
+{
+    RegisterRefValueDescription desc;
+    CORE_LOCK();
+    RzRegItem *ri = rz_reg_get(getReg(), regName.toUtf8().constData(), -1);
+    if (!ri) {
+        return desc;
+    }
+    desc.name = ri->name;
+    ut64 value = rz_reg_get_value(getReg(), ri);
+    desc.value = "0x" + QString::number(value, 16);
+    desc.ref = rz_core_analysis_hasrefs(core, value, RZ_OUTPUT_MODE_STANDARD);
+    return desc;
+}
+
 QString CutterCore::getRegisterName(QString registerRole)
 {
     if (!currentlyDebugging) {

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -742,6 +742,7 @@ public:
      */
     QList<RegisterRef> getRegisterRefs(int depth = 6);
     QVector<RegisterRefValueDescription> getRegisterRefValues();
+    RegisterRefValueDescription getRegisterRefValue(const QString &regName);
     QList<VariableDescription> getVariables(RVA at);
     /**
      * @brief Fetches all the writes or reads to the specified local variable 'variableName'

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -387,6 +387,11 @@ public:
     void applySignature(const QString &filepath);
     void createSignature(const QString &filepath);
 
+    /**
+     * @brief Check if the numeric value is a valid input for Rizin
+     */
+    bool isValidInputNumValue(const QString &expression);
+
     /* Math functions */
     ut64 math(const QString &expr);
     ut64 num(const QString &expr);
@@ -742,8 +747,12 @@ public:
      */
     QList<RegisterRef> getRegisterRefs(int depth = 6);
     QVector<RegisterRefValueDescription> getRegisterRefValues();
-    RegisterRefValueDescription getRegisterRefValue(const QString &regName);
     QList<VariableDescription> getVariables(RVA at);
+
+    /**
+     * @brief Get the value of the register ref
+     */
+    RegisterRefValueDescription getRegisterRefValue(const QString &regName);
     /**
      * @brief Fetches all the writes or reads to the specified local variable 'variableName'
      * in the function in which the specified offset is a part of.

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -171,6 +171,7 @@ DisassemblerGraphView::~DisassemblerGraphView()
 {
     qDeleteAll(shortcuts);
     shortcuts.clear();
+    delete highlight_token;
 }
 
 void DisassemblerGraphView::refreshView()
@@ -566,10 +567,18 @@ bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
 
             // Don't preview anything for a small scale
             if (getViewScale() >= 0.8) {
-                auto token = getToken(inst, pos.x());
+                auto bracketValue = DH::findBracketRange(inst->plainText, pos.x());
+
                 DH::TargetContext ctx;
                 ctx.offset = offsetFrom;
-                ctx.word = token ? token->content : QString();
+                if (bracketValue.found) {
+                    ctx.word = bracketValue.content;
+                } else if (auto token = getToken(inst, pos.x())) {
+                    ctx.word = token->content;
+                    delete token;
+                } else {
+                    ctx.word = QString();
+                }
                 ctx.line = inst->plainText;
                 ctx.arrow = getTruePathForOffset(offsetFrom);
                 if (DisassemblyPreview::showTooltip(this, helpEvent->globalPos(), ctx,
@@ -900,6 +909,7 @@ void DisassemblerGraphView::blockClicked(GraphView::GraphBlock &block, QMouseEve
 
     currentBlockAddress = block.entry;
 
+    delete highlight_token;
     highlight_token = getToken(instr, pos.x());
 
     RVA addr = instr->addr;
@@ -973,7 +983,15 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
     }
 
     DH::TargetContext ctx;
-    ctx.word = highlight_token ? highlight_token->content : QString();
+    auto bracketValue = DH::findBracketRange(instr->plainText, pos.x());
+
+    if (bracketValue.found) {
+        ctx.word = bracketValue.content;
+    } else if (highlight_token) {
+        ctx.word = highlight_token->content;
+    } else {
+        ctx.word = QString();
+    }
     ctx.line = instr->plainText;
     ctx.offset = getAddrForMouseEvent(block, &pos);
     ctx.arrow = getTruePathForOffset(ctx.offset);

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -567,7 +567,8 @@ bool DisassemblerGraphView::eventFilter(QObject *obj, QEvent *event)
 
             // Don't preview anything for a small scale
             if (getViewScale() >= 0.8) {
-                auto bracketValue = DH::findBracketRange(inst->plainText, pos.x());
+                auto bracketValue = DH::findBracketRange(
+                        inst->plainText, mFontMetrics->position(inst->plainText, pos.x()));
 
                 DH::TargetContext ctx;
                 ctx.offset = offsetFrom;

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -984,10 +984,14 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
         Core()->showTypeInTypesWidget(ctx.word);
         break;
     case DH::TargetType::XRefComment:
+    case DH::TargetType::Register:
+    case DH::TargetType::Memory:
+    case DH::TargetType::MMIO:
+    case DH::TargetType::VariableValue:
     case DH::TargetType::VariableName:
     case DH::TargetType::Arrow:
-        if (ta.offset != RVA_INVALID) {
-            seekable->seek(ta.offset);
+        if (ta.value != RVA_INVALID) {
+            seekable->seek(ta.value);
         }
         break;
     case DH::TargetType::None:

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -978,7 +978,7 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
     ctx.offset = getAddrForMouseEvent(block, &pos);
     ctx.arrow = getTruePathForOffset(ctx.offset);
 
-    DH::TargetAction ta = DH::resolveTarget(ctx);
+    DH::TargetAction ta = DH::resolveTarget(ctx, DH::TargetFilter::Standard);
     switch (ta.type) {
     case DH::TargetType::TypeName:
         Core()->showTypeInTypesWidget(ctx.word);

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -984,11 +984,7 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
         Core()->showTypeInTypesWidget(ctx.word);
         break;
     case DH::TargetType::XRefComment:
-    case DH::TargetType::Register:
-    case DH::TargetType::Memory:
-    case DH::TargetType::MMIO:
-    case DH::TargetType::VariableValue:
-    case DH::TargetType::VariableName:
+    case DH::TargetType::VariableXRef:
     case DH::TargetType::Arrow:
         if (ta.value != RVA_INVALID) {
             seekable->seek(ta.value);

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -993,6 +993,8 @@ void DisassemblerGraphView::blockDoubleClicked(GraphView::GraphBlock &block, QMo
     case DH::TargetType::None:
         seekable->seekToReference(ctx.offset);
         break;
+    default:
+        break;
     }
 }
 

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -644,15 +644,14 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
             auto ctx =
                     DH::getContextFromCursor(mDisasTextEdit->cursorForPosition(mouseEvent->pos()));
 
-            DH::TargetAction ta = DH::resolveTarget(ctx);
+            DH::TargetAction ta = DH::resolveTarget(ctx, DisassemblyHelper::TargetFilter::Standard);
             switch (ta.type) {
             case DH::TargetType::TypeName:
                 Core()->showTypeInTypesWidget(ctx.word);
                 break;
             case DH::TargetType::XRefComment:
-            case DH::TargetType::VariableName:
+            case DH::TargetType::VariableXRef:
             case DH::TargetType::Arrow:
-            case DH::TargetType::Register:
                 if (ta.value != RVA_INVALID) {
                     seekable->seek(ta.value);
                 }

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -652,8 +652,9 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
             case DH::TargetType::XRefComment:
             case DH::TargetType::VariableName:
             case DH::TargetType::Arrow:
-                if (ta.offset != RVA_INVALID) {
-                    seekable->seek(ta.offset);
+            case DH::TargetType::Register:
+                if (ta.value != RVA_INVALID) {
+                    seekable->seek(ta.value);
                 }
                 break;
             case DH::TargetType::None:
@@ -681,7 +682,7 @@ void DisassemblyWidget::keyPressEvent(QKeyEvent *event)
         const QTextCursor cursor = mDisasTextEdit->textCursor();
         auto ta = DH::resolveTarget(DH::getContextFromCursor(cursor), DH::TargetFilter::Arrows);
         if (ta.type == DH::TargetType::Arrow) {
-            seekable->seek(ta.offset);
+            seekable->seek(ta.value);
         } else {
             jumpToOffsetUnderCursor(cursor);
         }

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -659,6 +659,8 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
             case DH::TargetType::None:
                 seekable->seekToReference(ctx.offset);
                 break;
+            default:
+                break;
             }
             return true;
         }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Enables previewing non-memory register values in the disassember view.

Value of the register is a non-memory:
Before:
<img width="370" height="144" alt="image" src="https://github.com/user-attachments/assets/37829da7-e27f-46c5-adbb-b275061bf9c3" />

After:
<img width="554" height="197" alt="image" src="https://github.com/user-attachments/assets/0a40b798-d689-4589-831b-cdea39c1f036" />

Value of variable is a non-memory (resolved address points to the dereferenced value):
Before:
<img width="527" height="102" alt="image" src="https://github.com/user-attachments/assets/878c9800-5c4d-4a16-8b44-f02306fd6809" />

After:
<img width="830" height="125" alt="image" src="https://github.com/user-attachments/assets/8359bcba-0542-4cba-a9e7-c84f67c98f28" />

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

- Open Cutter with any binary
- Enable the setting 'Show known variable values when hovering' in Edit -> Preferences.
- Open 'Disassembly' tab
- Start Debugging Session
- Hover over non-memory register values and non-memory values in the square brackets 

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->


**Closing issues**
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
Partially addresses https://github.com/rizinorg/cutter/issues/2532 by adding non-memory values previewing. I'm ready to also implement previewing the decompiler variables, but I want to receive initial feedback on the current progress first.