### PR TITLE
decompiler: Implement variable values tooltip in debugging

### DIFF
--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -537,7 +537,7 @@ void DecompilerWidget::showVariableTooltip(QHelpEvent *event, RzCodeAnnotation *
     } else {
         // TODO: track the value of the synthetic/untracked variables and show it in the tooltip.
         tooltipContent = QString("<b>%1</b><br><i>(Synthetic/Untracked Variable)</i>")
-        .arg(QString::fromUtf8(annotation->variable.name));
+                                 .arg(QString::fromUtf8(annotation->variable.name));
     }
     QToolTip::showText(event->globalPos(), tooltipContent, ui->textEdit);
 }
@@ -563,15 +563,19 @@ QString DecompilerWidget::formatVarValue(RzAnalysisVar *var)
             if (stackAddr != 0) {
                 ut64 pointedAddr = 0;
                 int ptrSize = core->analysis->bits / 8;
-                int pointedAddr_state = rz_io_read_at_mapped(core->io, stackAddr, (ut8*)&pointedAddr, ptrSize);
+                int pointedAddr_state =
+                        rz_io_read_at_mapped(core->io, stackAddr, (ut8 *)&pointedAddr, ptrSize);
                 if (pointedAddr_state > 0 && pointedAddr != 0) {
                     ut8 buf[256];
-                    int str_state = rz_io_read_at_mapped(core->io, pointedAddr, buf, sizeof(buf) - 1);
+                    int str_state =
+                            rz_io_read_at_mapped(core->io, pointedAddr, buf, sizeof(buf) - 1);
                     if (str_state != 0) {
-                        buf[sizeof(buf)-1] = 0;
+                        buf[sizeof(buf) - 1] = 0;
                         if (isprint(buf[0]) || buf[0] == '\0') {
-                        displayValue += QString("<br><font color='#f1c40f'>value: \"%1\"</font>")
-                            .arg(QString::fromUtf8(reinterpret_cast<const char*>(buf)));
+                            displayValue +=
+                                    QString("<br><font color='#f1c40f'>value: \"%1\"</font>")
+                                            .arg(QString::fromUtf8(
+                                                    reinterpret_cast<const char *>(buf)));
                         }
                     }
                 }
@@ -580,23 +584,23 @@ QString DecompilerWidget::formatVarValue(RzAnalysisVar *var)
     }
     rz_mem_free(rawVal);
     return QString("<b>%1</b> (%2)<br>Value: %3")
-        .arg(QString::fromUtf8(var->name), typeStr, displayValue);
+            .arg(QString::fromUtf8(var->name), typeStr, displayValue);
 }
 
 bool DecompilerWidget::eventFilter(QObject *obj, QEvent *event)
 {
-    if (event->type() == QEvent::ToolTip &&
-        Config()->getShowVarTooltips() &&
-        (obj == ui->textEdit || obj == ui->textEdit->viewport())) {
+    if (event->type() == QEvent::ToolTip && Config()->getShowVarTooltips()
+        && (obj == ui->textEdit || obj == ui->textEdit->viewport())) {
         QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
         QTextCursor cursor = ui->textEdit->cursorForPosition(helpEvent->pos());
         size_t pos = cursor.position();
         void *iter;
-        rz_vector_foreach(&this->code->annotations, iter) {
+        rz_vector_foreach(&this->code->annotations, iter)
+        {
             RzCodeAnnotation *annotation = (RzCodeAnnotation *)iter;
             if (pos >= annotation->start && pos < annotation->end) {
-                if (annotation->type == RZ_CODE_ANNOTATION_TYPE_LOCAL_VARIABLE ||
-                    annotation->type == RZ_CODE_ANNOTATION_TYPE_FUNCTION_PARAMETER) {
+                if (annotation->type == RZ_CODE_ANNOTATION_TYPE_LOCAL_VARIABLE
+                    || annotation->type == RZ_CODE_ANNOTATION_TYPE_FUNCTION_PARAMETER) {
                     showVariableTooltip(helpEvent, annotation);
                     return true;
                 }

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -20,6 +20,7 @@
 #include <QTextBlockUserData>
 #include <QScrollBar>
 #include <QAbstractSlider>
+#include <qtooltip.h>
 
 DecompilerWidget::DecompilerWidget(MainWindow *main)
     : MemoryDockWidget(MemoryWidgetType::Decompiler, main),
@@ -519,8 +520,91 @@ void DecompilerWidget::seekToReference()
     seekable->seekToReference(offsetForPosition(pos));
 }
 
+void DecompilerWidget::showVariableTooltip(QHelpEvent *event, RzCodeAnnotation *annotation)
+{
+    if (!annotation->variable.name) {
+        return;
+    }
+    RzCoreLocked core = Core()->lock();
+    RzAnalysisFunction *fcn = rz_analysis_get_function_at(core->analysis, decompiledFunctionAddr);
+    if (!fcn) {
+        return;
+    }
+    RzAnalysisVar *var = rz_analysis_function_get_var_byname(fcn, annotation->variable.name);
+    QString tooltipContent;
+    if (var) {
+        tooltipContent = formatVarValue(var);
+    } else {
+        // TODO: track the value of the synthetic/untracked variables and show it in the tooltip.
+        tooltipContent = QString("<b>%1</b><br><i>(Synthetic/Untracked Variable)</i>")
+        .arg(QString::fromUtf8(annotation->variable.name));
+    }
+    QToolTip::showText(event->globalPos(), tooltipContent, ui->textEdit);
+}
+
+QString DecompilerWidget::formatVarValue(RzAnalysisVar *var)
+{
+    RzCoreLocked core = Core()->lock();
+    QString typeStr = "unknown data type";
+    if (var && var->type) {
+        char *type = rz_type_as_string(core->analysis->typedb, var->type);
+        if (type) {
+            typeStr = QString::fromUtf8(type);
+            rz_mem_free(type);
+        }
+    }
+    char *rawVal = rz_core_analysis_var_display(core, var, false);
+    QString displayValue = rawVal ? QString::fromUtf8(rawVal).trimmed() : "??";
+    if (rawVal && typeStr.trimmed().contains("*")) {
+        char *eq = strchr(rawVal, '=');
+        if (eq) {
+            QString left = QString::fromUtf8(rawVal, eq - rawVal).trimmed();
+            ut64 stackAddr = rz_num_math(core->num, left.toUtf8().constData());
+            if (stackAddr != 0) {
+                ut64 pointedAddr = 0;
+                int ptrSize = core->analysis->bits / 8;
+                int pointedAddr_state = rz_io_read_at_mapped(core->io, stackAddr, (ut8*)&pointedAddr, ptrSize);
+                if (pointedAddr_state > 0 && pointedAddr != 0) {
+                    ut8 buf[256];
+                    int str_state = rz_io_read_at_mapped(core->io, pointedAddr, buf, sizeof(buf) - 1);
+                    if (str_state != 0) {
+                        buf[sizeof(buf)-1] = 0;
+                        if (isprint(buf[0]) || buf[0] == '\0') {
+                        displayValue += QString("<br><font color='#f1c40f'>value: \"%1\"</font>")
+                            .arg(QString::fromUtf8(reinterpret_cast<const char*>(buf)));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    rz_mem_free(rawVal);
+    return QString("<b>%1</b> (%2)<br>Value: %3")
+        .arg(QString::fromUtf8(var->name), typeStr, displayValue);
+}
+
 bool DecompilerWidget::eventFilter(QObject *obj, QEvent *event)
 {
+    if (event->type() == QEvent::ToolTip &&
+        Config()->getShowVarTooltips() &&
+        (obj == ui->textEdit || obj == ui->textEdit->viewport())) {
+        QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
+        QTextCursor cursor = ui->textEdit->cursorForPosition(helpEvent->pos());
+        size_t pos = cursor.position();
+        void *iter;
+        rz_vector_foreach(&this->code->annotations, iter) {
+            RzCodeAnnotation *annotation = (RzCodeAnnotation *)iter;
+            if (pos >= annotation->start && pos < annotation->end) {
+                if (annotation->type == RZ_CODE_ANNOTATION_TYPE_LOCAL_VARIABLE ||
+                    annotation->type == RZ_CODE_ANNOTATION_TYPE_FUNCTION_PARAMETER) {
+                    showVariableTooltip(helpEvent, annotation);
+                    return true;
+                }
+            }
+        }
+        QToolTip::hideText();
+        return true;
+    }
     if (event->type() == QEvent::MouseButtonDblClick
         && (obj == ui->textEdit || obj == ui->textEdit->viewport())) {
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -557,7 +557,10 @@ QString DecompilerWidget::formatVarValue(RzAnalysisVar *var)
         const int bits = core->rasm->bits;
         const int ptrSize = bits / 8;
         if (var->storage.type == RZ_ANALYSIS_VAR_STORAGE_REG) {
-            pointedAddr = rz_debug_reg_get(core->dbg, var->storage.reg);
+            auto reg = Core()->getRegisterRefValue(QString::fromUtf8(var->storage.reg));
+            if (!reg.name.isEmpty()) {
+                pointedAddr = Core()->math(reg.value);
+            }
         } else if (var->storage.type == RZ_ANALYSIS_VAR_STORAGE_STACK) {
             ut64 stackAddr = rz_core_analysis_var_addr(core, var);
             ut8 ptrBuf[8];

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -534,10 +534,6 @@ void DecompilerWidget::showVariableTooltip(QHelpEvent *event, RzCodeAnnotation *
     QString tooltipContent;
     if (var) {
         tooltipContent = formatVarValue(var);
-    } else {
-        // TODO: track the value of the synthetic/untracked variables and show it in the tooltip.
-        tooltipContent = QString("<b>%1</b><br><i>(Synthetic/Untracked Variable)</i>")
-                                 .arg(QString::fromUtf8(annotation->variable.name));
     }
     QToolTip::showText(event->globalPos(), tooltipContent, ui->textEdit);
 }
@@ -555,36 +551,32 @@ QString DecompilerWidget::formatVarValue(RzAnalysisVar *var)
     }
     char *rawVal = rz_core_analysis_var_display(core, var, false);
     QString displayValue = rawVal ? QString::fromUtf8(rawVal).trimmed() : "??";
-    if (rawVal && typeStr.trimmed().contains("*")) {
-        char *eq = strchr(rawVal, '=');
-        if (eq) {
-            QString left = QString::fromUtf8(rawVal, eq - rawVal).trimmed();
-            ut64 stackAddr = rz_num_math(core->num, left.toUtf8().constData());
-            if (stackAddr != 0) {
-                ut64 pointedAddr = 0;
-                int ptrSize = core->analysis->bits / 8;
-                int pointedAddr_state =
-                        rz_io_read_at_mapped(core->io, stackAddr, (ut8 *)&pointedAddr, ptrSize);
-                if (pointedAddr_state > 0 && pointedAddr != 0) {
-                    ut8 buf[256];
-                    int str_state =
-                            rz_io_read_at_mapped(core->io, pointedAddr, buf, sizeof(buf) - 1);
-                    if (str_state != 0) {
-                        buf[sizeof(buf) - 1] = 0;
-                        if (isprint(buf[0]) || buf[0] == '\0') {
-                            displayValue +=
-                                    QString("<br><font color='#f1c40f'>value: \"%1\"</font>")
-                                            .arg(QString::fromUtf8(
-                                                    reinterpret_cast<const char *>(buf)));
-                        }
-                    }
+    rz_mem_free(rawVal);
+    if (typeStr.contains("*")) {
+        ut64 pointedAddr = 0;
+        int ptrSize = core->analysis->bits / 8;
+        bool pointedAddr_state = false;
+        if (var->storage.type == RZ_ANALYSIS_VAR_STORAGE_REG) {
+            pointedAddr = rz_debug_reg_get(core->dbg, var->storage.reg);
+            pointedAddr_state = (pointedAddr != 0);
+        } else if (var->storage.type == RZ_ANALYSIS_VAR_STORAGE_STACK) {
+            ut64 stackAddr = rz_core_analysis_var_addr(core, var);
+            pointedAddr_state =
+                    rz_io_read_at_mapped(core->io, stackAddr, (ut8 *)&pointedAddr, ptrSize);
+        }
+        if (pointedAddr_state && pointedAddr) {
+            ut8 buf[256];
+            bool str_state = rz_io_read_at_mapped(core->io, pointedAddr, buf, sizeof(buf) - 1);
+            if (str_state) {
+                size_t len = strnlen((const char *)buf, sizeof(buf));
+                if (len > 0 && rz_str_is_printable((const char *)buf)) {
+                    QString str = QString::fromUtf8((const char *)buf, len);
+                    displayValue += QString("\nvalue: \"%1\"").arg(str);
                 }
             }
         }
     }
-    rz_mem_free(rawVal);
-    return QString("<b>%1</b> (%2)<br>Value: %3")
-            .arg(QString::fromUtf8(var->name), typeStr, displayValue);
+    return QString("%1 (%2)\nValue: %3").arg(QString::fromUtf8(var->name), typeStr, displayValue);
 }
 
 bool DecompilerWidget::eventFilter(QObject *obj, QEvent *event)

--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -554,29 +554,31 @@ QString DecompilerWidget::formatVarValue(RzAnalysisVar *var)
     rz_mem_free(rawVal);
     if (typeStr.contains("*")) {
         ut64 pointedAddr = 0;
-        int ptrSize = core->analysis->bits / 8;
-        bool pointedAddr_state = false;
+        const int bits = core->rasm->bits;
+        const int ptrSize = bits / 8;
         if (var->storage.type == RZ_ANALYSIS_VAR_STORAGE_REG) {
             pointedAddr = rz_debug_reg_get(core->dbg, var->storage.reg);
-            pointedAddr_state = (pointedAddr != 0);
         } else if (var->storage.type == RZ_ANALYSIS_VAR_STORAGE_STACK) {
             ut64 stackAddr = rz_core_analysis_var_addr(core, var);
-            pointedAddr_state =
-                    rz_io_read_at_mapped(core->io, stackAddr, (ut8 *)&pointedAddr, ptrSize);
+            ut8 ptrBuf[8];
+            if (rz_io_read_at_mapped(core->io, stackAddr, ptrBuf, ptrSize)) {
+                pointedAddr = rz_read_ble(ptrBuf, core->rasm->big_endian, bits);
+            }
         }
-        if (pointedAddr_state && pointedAddr) {
+        if (pointedAddr) {
             ut8 buf[256];
             bool str_state = rz_io_read_at_mapped(core->io, pointedAddr, buf, sizeof(buf) - 1);
             if (str_state) {
                 size_t len = strnlen((const char *)buf, sizeof(buf));
                 if (len > 0 && rz_str_is_printable((const char *)buf)) {
-                    QString str = QString::fromUtf8((const char *)buf, len);
+                    QString str = QString::fromUtf8((const char *)buf, len).toHtmlEscaped();
                     displayValue += QString("\nvalue: \"%1\"").arg(str);
                 }
             }
         }
     }
-    return QString("%1 (%2)\nValue: %3").arg(QString::fromUtf8(var->name), typeStr, displayValue);
+    return QString("%1 (%2)\nValue: %3")
+        .arg(QString::fromUtf8(var->name).toHtmlEscaped(), typeStr, displayValue);
 }
 
 bool DecompilerWidget::eventFilter(QObject *obj, QEvent *event)

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -258,7 +258,6 @@ private:
 
     void showVariableTooltip(QHelpEvent *event, RzCodeAnnotation *annotation);
     QString formatVarValue(RzAnalysisVar *var);
-
 };
 
 #endif // DECOMPILERWIDGET_H

--- a/src/widgets/DecompilerWidget.h
+++ b/src/widgets/DecompilerWidget.h
@@ -1,6 +1,7 @@
 #ifndef DECOMPILERWIDGET_H
 #define DECOMPILERWIDGET_H
 
+#include <QHelpEvent>
 #include <QTextEdit>
 #include <memory>
 
@@ -254,6 +255,10 @@ private:
     void setCode(RzAnnotatedCode *code);
 
     void setHighlighter(bool annotationBasedHighlighter);
+
+    void showVariableTooltip(QHelpEvent *event, RzCodeAnnotation *annotation);
+    QString formatVarValue(RzAnalysisVar *var);
+
 };
 
 #endif // DECOMPILERWIDGET_H


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This PR enhances the decompiler's variable tooltips by implementing live string dereferencing as mentioned in #3344.

[cutter - decompiler tooltips.webm](https://github.com/user-attachments/assets/8addbee5-8fd1-4884-b046-fa7e336cf6b3)

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

Start a debug session and try moving to different break points and hover over various variables and check the tooltip.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
it doesn't fully close #3344 or #2532 as it currently handles only explicitly tracked analysis variables.

**Limitations**

Synthetic/Untracked Variables: Does not currently handle variables that Rizin hasn't fully analyzed or "Synthetic" variables generated by the decompiler.

---
**Configuration Toggle:** Would you like me to add a checkbox in the Preferences settings to enable/disable this feature? Currently, it is always active