### PR TITLE
Fix wheelEvent in disassembly

### DIFF
--- a/src/widgets/AddressRangeScrollBar.cpp
+++ b/src/widgets/AddressRangeScrollBar.cpp
@@ -183,13 +183,17 @@ RVA AddressRangeScrollBar::rangeSize()
 
 void AddressRangeScrollBar::showTransientScrollBar()
 {
-    QWheelEvent eventBegin(QPointF(0, 0), QPointF(0, 0), QPoint(0, 0), QPoint(0, 0), Qt::NoButton,
-                           Qt::NoModifier, Qt::ScrollBegin, false);
-    QScrollBar::wheelEvent(&eventBegin);
-
-    QWheelEvent eventEnd(QPointF(0, 0), QPointF(0, 0), QPoint(0, 0), QPoint(0, 0), Qt::NoButton,
-                         Qt::NoModifier, Qt::ScrollEnd, false);
-    QScrollBar::wheelEvent(&eventEnd);
+    const Qt::ScrollPhase phases[] = { Qt::ScrollBegin, Qt::ScrollEnd };
+    for (const auto &phase : phases) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        QWheelEvent event(QPointF(0, 0), QPointF(0, 0), QPoint(0, 0), QPoint(0, 0), Qt::NoButton,
+                          Qt::NoModifier, phase, false);
+#else
+        QWheelEvent event(QPointF(0, 0), QPointF(0, 0), QPoint(0, 0), QPoint(0, 0), 0, Qt::Vertical,
+                          Qt::NoButton, Qt::NoModifier, phase);
+#endif
+        QScrollBar::wheelEvent(&event);
+    }
 }
 
 void AddressRangeScrollBar::wheelEvent(QWheelEvent *event)

--- a/src/widgets/AddressRangeScrollBar.cpp
+++ b/src/widgets/AddressRangeScrollBar.cpp
@@ -181,9 +181,15 @@ RVA AddressRangeScrollBar::rangeSize()
     return endOffset - beginOffset;
 }
 
-void AddressRangeScrollBar::repostWheelEvent(QWheelEvent *event)
+void AddressRangeScrollBar::showTransientScrollBar()
 {
-    QScrollBar::wheelEvent(event);
+    QWheelEvent eventBegin(QPointF(0, 0), QPointF(0, 0), QPoint(0, 0), QPoint(0, 0), Qt::NoButton,
+                           Qt::NoModifier, Qt::ScrollBegin, false);
+    QScrollBar::wheelEvent(&eventBegin);
+
+    QWheelEvent eventEnd(QPointF(0, 0), QPointF(0, 0), QPoint(0, 0), QPoint(0, 0), Qt::NoButton,
+                         Qt::NoModifier, Qt::ScrollEnd, false);
+    QScrollBar::wheelEvent(&eventEnd);
 }
 
 void AddressRangeScrollBar::wheelEvent(QWheelEvent *event)

--- a/src/widgets/AddressRangeScrollBar.h
+++ b/src/widgets/AddressRangeScrollBar.h
@@ -17,15 +17,14 @@ public:
     RVA rangeSize();
 
     /**
-     * @brief Reposts a wheel event to this scrollbar to synchronize its visual state
+     * @brief Sends fake wheelEvent to the parent QScrollBar
      *
      * This allows external widgets (like side panels or text edits) to notify the
-     * scrollbar of wheel activity. It is needed for systems which have the option to show the
-     * scrollbar only while scrolling (when using Cutter's "Native" theme)
-     *
-     * @param event The original QWheelEvent to be processed by the scrollbar
+     * scrollbar of wheel activity. It is needed for systems (like MacOS) which have the option to
+     * enable transient scrollbars meaning the ability to show the scrollbar only while scrolling
+     * and hiding it later (when using Cutter's "Native" theme)
      */
-    void repostWheelEvent(QWheelEvent *event);
+    void showTransientScrollBar();
 signals:
     void hideScrollBar();
     void showScrollBar();

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -126,7 +126,7 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main)
     connect(mDisasScrollArea, &DisassemblyScrollArea::disassemblyResized, this,
             &DisassemblyWidget::updateMaxLines);
     connect(mDisasScrollArea, &DisassemblyScrollArea::wheelEventTriggered, this,
-            &DisassemblyWidget::repostWheelEvent);
+            &DisassemblyWidget::showTransientScrollBar);
 
     connectCursorPositionChanged(false);
 
@@ -219,9 +219,9 @@ QList<DisassemblyLine> DisassemblyWidget::getLines()
     return lines;
 }
 
-void DisassemblyWidget::repostWheelEvent(QWheelEvent *event)
+void DisassemblyWidget::showTransientScrollBar()
 {
-    mDisasScrollArea->verticalScrollBar()->repostWheelEvent(event);
+    mDisasScrollArea->verticalScrollBar()->showTransientScrollBar();
 }
 
 void DisassemblyWidget::refreshIfInRange(RVA offset)
@@ -807,7 +807,6 @@ void DisassemblyScrollArea::wheelEvent(QWheelEvent *event)
         return;
     }
 
-    emit wheelEventTriggered(event);
     accumScrollWheelDeltaY += event->angleDelta().y();
     // Delta is reported in 1/8 of a degree
     // eg. 120 units * 1/8 = 15 degrees
@@ -818,6 +817,7 @@ void DisassemblyScrollArea::wheelEvent(QWheelEvent *event)
         accumScrollWheelDeltaY -= lineDelta * lineCount;
         emit scrollLines(-lineCount);
     }
+    emit wheelEventTriggered();
 }
 
 qreal DisassemblyTextEdit::textOffset() const
@@ -874,11 +874,11 @@ DisassemblyLeftPanel::DisassemblyLeftPanel(DisassemblyWidget *disas)
 
 void DisassemblyLeftPanel::wheelEvent(QWheelEvent *event)
 {
-    this->disas->repostWheelEvent(event);
 
     int count = -(event->angleDelta() / 15).y();
     count -= (count > 0 ? 5 : -5);
 
+    this->disas->showTransientScrollBar();
     this->disas->scrollInstructions(count);
 }
 

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -52,11 +52,9 @@ public slots:
     QList<DisassemblyLine> getLines();
 
     /**
-     * @brief Reposts a wheel event to vertical scrollbar
-     *
-     * @param event The original QWheelEvent to be processed by the scrollbar
+     * @brief Forces the transient vertical scrollbar to appear on scroll
      */
-    void repostWheelEvent(QWheelEvent *event);
+    void showTransientScrollBar();
 protected slots:
     void on_seekChanged(RVA offset, CutterCore::SeekHistoryType type);
     void refreshIfInRange(RVA offset);
@@ -124,7 +122,7 @@ public:
 signals:
     void scrollLines(int lines, bool clampToScrollBarRange = false);
     void disassemblyResized();
-    void wheelEventTriggered(QWheelEvent *event);
+    void wheelEventTriggered();
 
 protected:
     bool viewportEvent(QEvent *event) override;

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -728,11 +728,11 @@ void HexWidget::mouseReleaseEvent(QMouseEvent *event)
 
 void HexWidget::wheelEvent(QWheelEvent *event)
 {
-    vScrollBar->repostWheelEvent(event);
 
     // according to Qt doc 1 row per 5 degrees, angle measured in 1/8 of degree
     int dy = event->angleDelta().y() / (8 * 5);
     scrollLines(dy);
+    vScrollBar->showTransientScrollBar();
 }
 
 bool HexWidget::validCharForEdit(QChar digit)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

When handling the visibility of transient scrollbars in #3546 I added a tweak that sent the wheelEvent to the parent QScrollbar inside AddressRangeScrollBar. This is needed as the original QScrollbar class needs to be notified of a wheelEvent to "wake up" the transient scrollbar. However looking at the source code of QScrollbar, the wheelEvent function in it also changes the position of the scrollbar which in turn emits the valueChanged (and other) signals effectively updating the scrollbar twice (once by our widget, and second by the QScrollbar) causing wrong calculation of visible bytes in disassembly (see gifs at the end).

Wasn't able to reproduce it on macos and windows, but on linux its obvious when scrolling slowly. I'm sure it's present on windows and mac aswell just not that visible

To fix this, instead of sending the same event to the parent scrollbar (which is already handled by our widget) we can send a temporary event which does nothing but "waking up" the scrollbar
```cpp
void AddressRangeScrollBar::showTransientScrollBar()
{
    // show transient scrollbar, as everything else is 0, all the logic, apart from transient visibility handling, will be ignored
    // see https://codebrowser.dev/qt5/qtbase/src/widgets/widgets/qscrollbar.cpp.html#497
    QWheelEvent eventBegin(QPointF(0, 0), QPointF(0, 0), QPoint(0, 0), QPoint(0, 0), Qt::NoButton,
                           Qt::NoModifier, Qt::ScrollBegin, false);
    QScrollBar::wheelEvent(&eventBegin);

    // hide transient scrollbar
    QWheelEvent eventEnd(QPointF(0, 0), QPointF(0, 0), QPoint(0, 0), QPoint(0, 0), Qt::NoButton,
                         Qt::NoModifier, Qt::ScrollEnd, false);
    QScrollBar::wheelEvent(&eventEnd);
}
``` 
Essentially does the same thing by creating empty wheelEvent objects

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

* Open cutter with any binary
* On macOS select the "Native" theme and make sure `Settings->Appearance->Show scroll bars->When Scrolling` is selected in  system settings
* Try scrolling up and down through trackpad or mouse wheel really slowly in disassembly
* Observe it scrolls fine now and also wakes up the transient scrollbar 
* Check the hexdump scrollbar aswell, It should also "wake up" when scrolling
* Meanwhile check all other functions of the scrollbar as well to make sure everything is working as expected

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Screenshots/Gifs**
Observe the first instruction

**Before:**
![disasm-scroll-before](https://github.com/user-attachments/assets/2da3b8cd-5426-4fa1-9e32-4895d8eba612)

**After**
![disasm-scroll-fix](https://github.com/user-attachments/assets/1bba3a56-5a30-4602-8d1a-4f52a9d971cd)

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
