### PR TITLE
Fix: infinite loop and crash in search bar

### DIFF
--- a/src/widgets/SearchableTextEdit.cpp
+++ b/src/widgets/SearchableTextEdit.cpp
@@ -8,9 +8,8 @@ SearchableTextEdit::SearchableTextEdit(QWidget *parent) : QPlainTextEdit(parent)
 
 QPair<int, int> SearchableTextEdit::search(const QString &string, int options)
 {
-    m_searchCursors.clear();
+    m_searchResults.clear();
     m_currentIndex = -1;
-    m_searchedMatchLen = -1;
     m_highlightMatches = options & SearchOption::HighlightMatches;
 
     if (string.isEmpty()) {
@@ -34,7 +33,12 @@ QPair<int, int> SearchableTextEdit::search(const QString &string, int options)
         const QRegularExpression regex(string);
         while (!cursor.isNull() && !cursor.atEnd()) {
             cursor = doc->find(regex, cursor, flags);
-            handleMatch(cursor, originalCursor);
+
+            if (cursor.hasSelection()) {
+                handleMatch(cursor, originalCursor);
+            } else {
+                cursor.movePosition(QTextCursor::NextCharacter); // avoid infinite loop
+            }
         }
     } else {
         while (!cursor.isNull() && !cursor.atEnd()) {
@@ -44,14 +48,14 @@ QPair<int, int> SearchableTextEdit::search(const QString &string, int options)
     }
 
     // wrap around
-    if (m_currentIndex < 0 && !m_searchCursors.isEmpty()) {
+    if (m_currentIndex < 0 && !m_searchResults.isEmpty()) {
         m_currentIndex = 0;
     }
 
     scrollToCurrentIndex();
     highlightMatches();
 
-    return { m_currentIndex, m_searchCursors.size() };
+    return { m_currentIndex, m_searchResults.size() };
 }
 
 void SearchableTextEdit::handleMatch(const QTextCursor &currentCursor,
@@ -60,22 +64,27 @@ void SearchableTextEdit::handleMatch(const QTextCursor &currentCursor,
     if (!currentCursor.isNull()) {
 
         if (m_currentIndex < 0 && currentCursor.selectionEnd() >= originalCursor.selectionStart()) {
-            m_currentIndex = m_searchCursors.size();
+            m_currentIndex = m_searchResults.size();
         }
 
-        m_searchCursors.append(currentCursor);
+        int len = currentCursor.selectionEnd() - currentCursor.selectionStart();
+        m_searchResults.append(SearchResult { currentCursor.selectionStart(), len });
     }
 }
 
 void SearchableTextEdit::clearSearch()
 {
     this->setExtraSelections({});
-    m_searchCursors.clear();
+    m_searchResults.clear();
 }
 
 int SearchableTextEdit::findNext()
 {
-    m_currentIndex = (m_currentIndex + 1) % m_searchCursors.size();
+    if (m_searchResults.isEmpty()) {
+        return 0;
+    }
+
+    m_currentIndex = (m_currentIndex + 1) % m_searchResults.size();
 
     scrollToCurrentIndex();
     highlightMatches();
@@ -85,7 +94,11 @@ int SearchableTextEdit::findNext()
 
 int SearchableTextEdit::findPrev()
 {
-    int count = m_searchCursors.size();
+    if (m_searchResults.isEmpty()) {
+        return 0;
+    }
+
+    int count = m_searchResults.size();
     m_currentIndex = (m_currentIndex - 1 + count) % count;
     scrollToCurrentIndex();
     highlightMatches();
@@ -95,7 +108,11 @@ int SearchableTextEdit::findPrev()
 
 int SearchableTextEdit::findLast()
 {
-    m_currentIndex = m_searchCursors.size() - 1;
+    if (m_searchResults.isEmpty()) {
+        return 0;
+    }
+
+    m_currentIndex = m_searchResults.size() - 1;
 
     scrollToCurrentIndex();
     highlightMatches();
@@ -111,13 +128,15 @@ void SearchableTextEdit::resizeEvent(QResizeEvent *event)
 
 void SearchableTextEdit::highlightMatches()
 {
-    if (m_currentIndex < 0 || m_currentIndex >= m_searchCursors.size()) {
+    if (m_currentIndex < 0 || m_currentIndex >= m_searchResults.size()) {
         this->setExtraSelections({});
         return;
     }
 
+    QTextCursor cursor(this->document());
+
     if (!m_highlightMatches) {
-        const QTextCursor cursor = m_searchCursors[m_currentIndex];
+        mapCursorToResult(cursor, m_searchResults[m_currentIndex]);
         QTextEdit::ExtraSelection selection;
         selection.format.setBackground(ConfigColor("searchCurrent"));
         selection.cursor = cursor;
@@ -127,26 +146,25 @@ void SearchableTextEdit::highlightMatches()
 
     QPoint startPoint = QPoint(0, 0);
     int startPos = this->cursorForPosition(startPoint).position();
-    startPos -= m_searchedMatchLen;
-    startPos = startPos >= 0 ? startPos : 0;
 
     QPoint endPoint = QPoint(this->geometry().width(), this->geometry().height());
     auto endCursor = this->cursorForPosition(endPoint);
     int endPos = endCursor.position();
-    endPos += m_searchedMatchLen;
     endCursor.movePosition(QTextCursor::End);
-    endPos = endPos <= endCursor.position() ? endPos : endCursor.position();
+    int maxPos = endCursor.position();
 
     QList<QTextEdit::ExtraSelection> selections;
-    for (int i = 0; i < m_searchCursors.size(); ++i) {
-        const QTextCursor cursor = m_searchCursors[i];
-        int pos = cursor.selectionStart();
+    for (int i = 0; i < m_searchResults.size(); ++i) {
+        const auto res = m_searchResults[i];
+        mapCursorToResult(cursor, m_searchResults[i]);
+        int sPos = std::max(startPos - res.length, 0);
+        int ePos = std::min(endPos + res.length, maxPos);
         if (i == m_currentIndex) {
             QTextEdit::ExtraSelection selection;
             selection.format.setBackground(ConfigColor("searchCurrent"));
             selection.cursor = cursor;
             selections.append(selection);
-        } else if (pos >= startPos && pos < endPos) {
+        } else if (cursor.selectionStart() >= sPos && cursor.selectionEnd() <= ePos) {
             // only highlight visible matches
             QTextEdit::ExtraSelection selection;
             selection.format.setBackground(ConfigColor("searchHighlight"));
@@ -159,11 +177,12 @@ void SearchableTextEdit::highlightMatches()
 
 void SearchableTextEdit::scrollToCurrentIndex()
 {
-    if (m_currentIndex < 0 || m_currentIndex >= m_searchCursors.size()) {
+    if (m_currentIndex < 0 || m_currentIndex >= m_searchResults.size()) {
         return;
     }
 
-    QTextCursor scrollCursor = m_searchCursors[m_currentIndex];
+    QTextCursor scrollCursor(this->document());
+    mapCursorToResult(scrollCursor, m_searchResults[m_currentIndex]);
     scrollCursor.setPosition(scrollCursor.selectionStart());
     scrollCursor.clearSelection();
     this->setTextCursor(scrollCursor);

--- a/src/widgets/SearchableTextEdit.h
+++ b/src/widgets/SearchableTextEdit.h
@@ -39,13 +39,24 @@ public slots:
     void highlightMatches();
 
 private:
+    struct SearchResult
+    {
+        int position;
+        int length;
+    };
+
     int m_currentIndex;
-    QList<QTextCursor> m_searchCursors;
-    int m_searchedMatchLen;
+    QList<SearchResult> m_searchResults;
     bool m_highlightMatches;
 
     void handleMatch(const QTextCursor &currentCursor, const QTextCursor &originalCursor);
     void scrollToCurrentIndex();
+
+    inline void mapCursorToResult(QTextCursor &cursor, const SearchResult result)
+    {
+        cursor.setPosition(result.position);
+        cursor.setPosition(result.position + result.length, QTextCursor::KeepAnchor);
+    }
 };
 
 #endif // SEARCHABLETEXTEDIT_H


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Fixes the following issues that were missed in #3562:
* Infinite loop when searching for `.*` regex 
* Crash after clicking on findNext or findPrev when there are no valid matches found. This was caused due to "mod by 0"

Also `SearchableTextEdit` now stores two integers instead of `QTextCursor` objects for every found match. Total time taken for search is almost exactly the same however two integers should use far less memory than `QTextCursor`

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

* Open Cutter
* Open console widget
* Don't search for anything. Press find next 
* Observe it no longer crashes
* Select the "Match Regular Expression" option. (`Ctrl + o` then `R` as a shortcut)
* Type `.*` 
* Observe it no longer gets stuck in an infinite loop

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
