### PR TITLE
Docking is made non-mandatory 

### DIFF
--- a/src/dialogs/preferences/ShortcutOptionsWidget.cpp
+++ b/src/dialogs/preferences/ShortcutOptionsWidget.cpp
@@ -32,7 +32,7 @@ void ShortcutOptionsWidget::populateShortcutTree()
         { "Debug", tr("Debug") },           { "Functions", tr("Functions") },
         { "Omnibar", tr("Omnibar") },       { "Exports", tr("Exports") },
         { "Imports", tr("Imports") },       { "Overview", tr("Graph Overview") },
-        { "Docking", tr("Docking")},
+        { "Docking", tr("Docking") },
     };
 
     QHash<QString, QTreeWidgetItem *> prefixToItem;

--- a/src/dialogs/preferences/ShortcutOptionsWidget.cpp
+++ b/src/dialogs/preferences/ShortcutOptionsWidget.cpp
@@ -32,6 +32,7 @@ void ShortcutOptionsWidget::populateShortcutTree()
         { "Debug", tr("Debug") },           { "Functions", tr("Functions") },
         { "Omnibar", tr("Omnibar") },       { "Exports", tr("Exports") },
         { "Imports", tr("Imports") },       { "Overview", tr("Graph Overview") },
+        { "Docking", tr("Docking")},
     };
 
     QHash<QString, QTreeWidgetItem *> prefixToItem;

--- a/src/shortcuts/DefaultShortcuts.cpp
+++ b/src/shortcuts/DefaultShortcuts.cpp
@@ -329,11 +329,11 @@ const QHash<QString, Shortcut> &getDefaultShortcuts()
             QT_TRANSLATE_NOOP("SearchBarWidget", "Show Search Bar Options Menu"),
             "SearchBarWidget" } },
 
-        //Docking
-        {"Docking.toggle",
-          {{Qt::Key_Alt},
-          QT_TRANSLATE_NOOP("CutterDockWidget","Enable/Disable Docking"),
-          "CutterDockWidget"}},
+        // Docking
+        { "Docking.toggle",
+          { { Qt::Key_Alt },
+            QT_TRANSLATE_NOOP("CutterDockWidget", "Enable/Disable Docking"),
+            "CutterDockWidget" } },
 
     };
     return defaultShortcuts;

--- a/src/shortcuts/DefaultShortcuts.cpp
+++ b/src/shortcuts/DefaultShortcuts.cpp
@@ -329,6 +329,12 @@ const QHash<QString, Shortcut> &getDefaultShortcuts()
             QT_TRANSLATE_NOOP("SearchBarWidget", "Show Search Bar Options Menu"),
             "SearchBarWidget" } },
 
+        //Docking
+        {"Docking.toggle",
+          {{Qt::Key_Alt},
+          QT_TRANSLATE_NOOP("CutterDockWidget","Enable/Disable Docking"),
+          "CutterDockWidget"}},
+
     };
     return defaultShortcuts;
 }

--- a/src/shortcuts/ShortcutManager.cpp
+++ b/src/shortcuts/ShortcutManager.cpp
@@ -33,6 +33,32 @@ QKeySequence ShortcutManager::getKeySequence(const QString &id)
     return sequences.isEmpty() ? QKeySequence() : sequences.first();
 }
 
+Qt::KeyboardModifier ShortcutManager::getKeyboardModifier(const QString &id)
+{
+    QKeySequence sequence = getKeySequence(id);
+    if (sequence.isEmpty())
+        return Qt::NoModifier;
+    Qt::Key key = static_cast<Qt::Key>(sequence[0] & ~Qt::KeyboardModifierMask);
+    switch (key) {
+    case Qt::Key_Alt:
+        return Qt::AltModifier;
+        // case Qt::Key_Shift:
+        //     return Qt::ShiftModifier;
+
+        // case Qt::Key_Control:
+        //     return Qt::ControlModifier;
+
+        // case Qt::Key_Meta:
+        //     return Qt::MetaModifier;
+        // case Qt::Key_AltGr:
+        //     return Qt::GroupSwitchModifier;
+
+    default:
+        return Qt::NoModifier;
+    }
+    return Qt::NoModifier;
+}
+
 Shortcut ShortcutManager::getShortcut(const QString &id)
 {
     const auto &defaultShortcuts = getDefaultShortcuts();

--- a/src/shortcuts/ShortcutManager.cpp
+++ b/src/shortcuts/ShortcutManager.cpp
@@ -1,6 +1,7 @@
 #include "ShortcutManager.h"
 #include <QCoreApplication>
 #include <QDebug>
+#include <qglobal.h>
 
 Q_GLOBAL_STATIC(ShortcutManager, uniqueInstance)
 
@@ -37,7 +38,12 @@ Qt::KeyboardModifier ShortcutManager::convertKeyToModifer(const QKeySequence &se
 {
     if (sequence.isEmpty())
         return Qt::NoModifier;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     Qt::Key key = static_cast<Qt::Key>(sequence[0] & ~Qt::KeyboardModifierMask);
+#else
+    QKeyCombination combo = sequence[0];
+    Qt::Key key = combo.key();
+#endif
     switch (key) {
     case Qt::Key_Alt:
         return Qt::AltModifier;

--- a/src/shortcuts/ShortcutManager.cpp
+++ b/src/shortcuts/ShortcutManager.cpp
@@ -33,25 +33,24 @@ QKeySequence ShortcutManager::getKeySequence(const QString &id)
     return sequences.isEmpty() ? QKeySequence() : sequences.first();
 }
 
-Qt::KeyboardModifier ShortcutManager::getKeyboardModifier(const QString &id)
+Qt::KeyboardModifier ShortcutManager::convertKeyToModifer(const QKeySequence &sequence)
 {
-    QKeySequence sequence = getKeySequence(id);
     if (sequence.isEmpty())
         return Qt::NoModifier;
     Qt::Key key = static_cast<Qt::Key>(sequence[0] & ~Qt::KeyboardModifierMask);
     switch (key) {
     case Qt::Key_Alt:
         return Qt::AltModifier;
-        // case Qt::Key_Shift:
-        //     return Qt::ShiftModifier;
+    case Qt::Key_Shift:
+        return Qt::ShiftModifier;
 
-        // case Qt::Key_Control:
-        //     return Qt::ControlModifier;
+    case Qt::Key_Control:
+        return Qt::ControlModifier;
 
-        // case Qt::Key_Meta:
-        //     return Qt::MetaModifier;
-        // case Qt::Key_AltGr:
-        //     return Qt::GroupSwitchModifier;
+    case Qt::Key_Meta:
+        return Qt::MetaModifier;
+    case Qt::Key_AltGr:
+        return Qt::GroupSwitchModifier;
 
     default:
         return Qt::NoModifier;

--- a/src/shortcuts/ShortcutManager.h
+++ b/src/shortcuts/ShortcutManager.h
@@ -17,8 +17,8 @@ public:
 
     Shortcut getShortcut(const QString &id);
     QKeySequence getKeySequence(const QString &id);
-    Qt::KeyboardModifier convertKeyToModifer(const QString &id);
-    QList<QKeySequence> getKeySequences(const QKeySequence &sequence);
+    Qt::KeyboardModifier convertKeyToModifer(const QKeySequence &sequence);
+    QList<QKeySequence> getKeySequences(const QString &id);
     QHash<QString, Shortcut> getAllShortcuts();
 
     QAction *makeAction(const QString &id, QObject *parent);

--- a/src/shortcuts/ShortcutManager.h
+++ b/src/shortcuts/ShortcutManager.h
@@ -17,8 +17,8 @@ public:
 
     Shortcut getShortcut(const QString &id);
     QKeySequence getKeySequence(const QString &id);
-    Qt::KeyboardModifier getKeyboardModifier(const QString &id);
-    QList<QKeySequence> getKeySequences(const QString &id);
+    Qt::KeyboardModifier convertKeyToModifer(const QString &id);
+    QList<QKeySequence> getKeySequences(const QKeySequence &sequence);
     QHash<QString, Shortcut> getAllShortcuts();
 
     QAction *makeAction(const QString &id, QObject *parent);

--- a/src/shortcuts/ShortcutManager.h
+++ b/src/shortcuts/ShortcutManager.h
@@ -17,6 +17,7 @@ public:
 
     Shortcut getShortcut(const QString &id);
     QKeySequence getKeySequence(const QString &id);
+    Qt::KeyboardModifier getKeyboardModifier(const QString &id);
     QList<QKeySequence> getKeySequences(const QString &id);
     QHash<QString, Shortcut> getAllShortcuts();
 

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -4,7 +4,6 @@
 #include <QEvent>
 #include <QShortcut>
 #include <QApplication>
-#include <QKeySequence>
 
 CutterDockWidget::CutterDockWidget(MainWindow *parent, QAction *) : CutterDockWidget(parent) {}
 

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -21,7 +21,8 @@ bool CutterDockWidget::event(QEvent *event)
     if (event->type() == QEvent::Move || event->type() == QEvent::MouseMove) {
 
         Qt::KeyboardModifiers mods = QApplication::keyboardModifiers();
-        Qt::KeyboardModifier mod = Shortcuts()->getKeyboardModifier("Docking.toggle");
+        Qt::KeyboardModifier mod =
+                Shortcuts()->getKeyboardModifier(Shortcuts()->getKeySequence("Docking.toggle"));
 
         if (mods & mod) {
             setAllowedAreas(Qt::NoDockWidgetArea);

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -4,6 +4,8 @@
 #include <QEvent>
 #include <QShortcut>
 #include <QApplication>
+#include <QKeySequence>
+
 
 CutterDockWidget::CutterDockWidget(MainWindow *parent, QAction *) : CutterDockWidget(parent) {}
 
@@ -15,16 +17,40 @@ CutterDockWidget::CutterDockWidget(MainWindow *parent) : QDockWidget(parent), ma
     connect(toggleViewAction(), &QAction::triggered, this, &QWidget::raise);
 }
 
-/**
- * @brief On any event(targeting windowMove event) if the altmodifer is
- * pressed then the dock will be non dockable.
- */
-bool CutterDockWidget::event(QEvent *event)
+Qt::KeyboardModifier CutterDockWidget::keyToModifier()
 {
-    if (event->type() == QEvent::Move || event->type() == QEvent::MouseMove) {
-        Qt::KeyboardModifiers mods = QApplication::keyboardModifiers();
+    Qt::Key key = static_cast<Qt::Key>(
+            getDefaultShortcuts()["Docking.toggle"].keySequences[0][0]
+            & ~Qt::KeyboardModifierMask
+            );
+    switch (key) {
+    case Qt::Key_Shift:
+        return Qt::ShiftModifier;
 
-        if (mods & Qt::AltModifier) {
+    case Qt::Key_Control:
+        return Qt::ControlModifier;
+
+    case Qt::Key_Alt:
+        return Qt::AltModifier;
+
+    case Qt::Key_Meta:
+        return Qt::MetaModifier;
+    case Qt::Key_AltGr:
+        return Qt::GroupSwitchModifier;
+
+    default:
+        return Qt::NoModifier;
+    }
+}
+
+bool CutterDockWidget::event(QEvent *event) {
+
+    if (event->type() == QEvent::Move || event->type() == QEvent::MouseMove) {
+
+        Qt::KeyboardModifiers mods = QApplication::keyboardModifiers();
+        Qt::KeyboardModifier mod = keyToModifier();
+
+        if (mods & mod) {
             setAllowedAreas(Qt::NoDockWidgetArea);
         } else {
             setAllowedAreas(Qt::AllDockWidgetAreas);

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -22,7 +22,7 @@ bool CutterDockWidget::event(QEvent *event)
 
         Qt::KeyboardModifiers mods = QApplication::keyboardModifiers();
         Qt::KeyboardModifier mod =
-                Shortcuts()->getKeyboardModifier(Shortcuts()->getKeySequence("Docking.toggle"));
+                Shortcuts()->convertKeyToModifer(Shortcuts()->getKeySequence("Docking.toggle"));
 
         if (mods & mod) {
             setAllowedAreas(Qt::NoDockWidgetArea);

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -3,6 +3,7 @@
 
 #include <QEvent>
 #include <QShortcut>
+#include <QApplication>
 
 CutterDockWidget::CutterDockWidget(MainWindow *parent, QAction *) : CutterDockWidget(parent) {}
 
@@ -12,6 +13,24 @@ CutterDockWidget::CutterDockWidget(MainWindow *parent) : QDockWidget(parent), ma
     installEventFilter(this);
     updateIsVisibleToUser();
     connect(toggleViewAction(), &QAction::triggered, this, &QWidget::raise);
+}
+
+/**
+ * @brief On any event(targeting windowMove event) if the altmodifer is
+ * pressed then the dock will be non dockable.
+ */
+bool CutterDockWidget::event(QEvent *event)
+{
+    if (event->type() == QEvent::Move || event->type() == QEvent::MouseMove) {
+        Qt::KeyboardModifiers mods = QApplication::keyboardModifiers();
+
+        if (mods & Qt::AltModifier) {
+            setAllowedAreas(Qt::NoDockWidgetArea);
+        } else {
+            setAllowedAreas(Qt::AllDockWidgetAreas);
+        }
+    }
+    return QDockWidget::event(event);
 }
 
 CutterDockWidget::~CutterDockWidget() = default;

--- a/src/widgets/CutterDockWidget.cpp
+++ b/src/widgets/CutterDockWidget.cpp
@@ -6,7 +6,6 @@
 #include <QApplication>
 #include <QKeySequence>
 
-
 CutterDockWidget::CutterDockWidget(MainWindow *parent, QAction *) : CutterDockWidget(parent) {}
 
 CutterDockWidget::CutterDockWidget(MainWindow *parent) : QDockWidget(parent), mainWindow(parent)
@@ -17,38 +16,13 @@ CutterDockWidget::CutterDockWidget(MainWindow *parent) : QDockWidget(parent), ma
     connect(toggleViewAction(), &QAction::triggered, this, &QWidget::raise);
 }
 
-Qt::KeyboardModifier CutterDockWidget::keyToModifier()
+bool CutterDockWidget::event(QEvent *event)
 {
-    Qt::Key key = static_cast<Qt::Key>(
-            getDefaultShortcuts()["Docking.toggle"].keySequences[0][0]
-            & ~Qt::KeyboardModifierMask
-            );
-    switch (key) {
-    case Qt::Key_Shift:
-        return Qt::ShiftModifier;
-
-    case Qt::Key_Control:
-        return Qt::ControlModifier;
-
-    case Qt::Key_Alt:
-        return Qt::AltModifier;
-
-    case Qt::Key_Meta:
-        return Qt::MetaModifier;
-    case Qt::Key_AltGr:
-        return Qt::GroupSwitchModifier;
-
-    default:
-        return Qt::NoModifier;
-    }
-}
-
-bool CutterDockWidget::event(QEvent *event) {
 
     if (event->type() == QEvent::Move || event->type() == QEvent::MouseMove) {
 
         Qt::KeyboardModifiers mods = QApplication::keyboardModifiers();
-        Qt::KeyboardModifier mod = keyToModifier();
+        Qt::KeyboardModifier mod = Shortcuts()->getKeyboardModifier("Docking.toggle");
 
         if (mods & mod) {
             setAllowedAreas(Qt::NoDockWidgetArea);

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -3,8 +3,7 @@
 
 #include "core/CutterCommon.h"
 #include "common/RefreshDeferrer.h"
-#include "shortcuts/DefaultShortcuts.h"
-
+#include "shortcuts/ShortcutManager.h"
 #include <QDockWidget>
 #include <QPushButton>
 
@@ -121,14 +120,6 @@ protected:
     MainWindow *mainWindow;
 
 private:
-    /**
-     * @brief take keys from shortcut and convert it into keyboard modifier
-     * avoiding user confusion.
-     * TODO: a better method may be give a docking
-     * property to MainWindows event filter and setting a shortcut to toggling it
-     * on and off.
-     */
-    Qt::KeyboardModifier keyToModifier();
     bool docking = true;
     bool isTransient = false;
 

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -3,6 +3,7 @@
 
 #include "core/CutterCommon.h"
 #include "common/RefreshDeferrer.h"
+#include "shortcuts/DefaultShortcuts.h"
 
 #include <QDockWidget>
 #include <QPushButton>
@@ -108,14 +109,27 @@ public slots:
 
 protected:
     virtual QWidget *widgetToFocusOnRaise();
-
     void closeEvent(QCloseEvent *event) override;
+
+    /**
+     * @brief On any event(targeting windowMove event) if the altmodifer is
+     * pressed then the dock will be non dockable.
+     */
     bool event(QEvent *event) override;
     QString getDockNumber();
 
     MainWindow *mainWindow;
 
 private:
+    /**
+     * @brief take keys from shortcut and convert it into keyboard modifier
+     * avoiding user confusion.
+     * TODO: a better method may be give a docking
+     * property to MainWindows event filter and setting a shortcut to toggling it
+     * on and off.
+     */
+    Qt::KeyboardModifier keyToModifier();
+    bool docking = true;
     bool isTransient = false;
 
     bool isVisibleToUserCurrent = false;

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -119,7 +119,6 @@ protected:
     MainWindow *mainWindow;
 
 private:
-    bool docking = true;
     bool isTransient = false;
 
     bool isVisibleToUserCurrent = false;

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -5,7 +5,6 @@
 #include "common/RefreshDeferrer.h"
 #include "shortcuts/ShortcutManager.h"
 #include <QDockWidget>
-#include <QPushButton>
 
 class MainWindow;
 

--- a/src/widgets/CutterDockWidget.h
+++ b/src/widgets/CutterDockWidget.h
@@ -5,6 +5,7 @@
 #include "common/RefreshDeferrer.h"
 
 #include <QDockWidget>
+#include <QPushButton>
 
 class MainWindow;
 
@@ -109,6 +110,7 @@ protected:
     virtual QWidget *widgetToFocusOnRaise();
 
     void closeEvent(QCloseEvent *event) override;
+    bool event(QEvent *event) override;
     QString getDockNumber();
 
     MainWindow *mainWindow;


### PR DESCRIPTION
…me the widget starts to float

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.



**Detailed description**
This is an implementation of making window docking optional as wanted by issue #3095 . Basically it works like each time when the window starts to float from the dockerarea the widget gets a Qt::Window flag. Although more workarounds will be having to done for the minimizing and maximizing.


**Test plan (required)**
Enable View/Unlock Panels
For making it a window just click on the float dock button
For redocking/reattaching just grab on the floating title of the widget instead of the window decoration
For moving the window use the window decorations without any docking.

Before


https://github.com/user-attachments/assets/ff768db8-a803-4b04-8adb-8cddbc781584

After


https://github.com/user-attachments/assets/9dc6cf78-475a-41bb-90a7-2a8f824b6f41



Tested on KDE Plasma Wayland Qt6, Asahi Linux Fedora Remix.(don't think device specs matter)
Not tested on:
Mac
Windows

**Closing issues**

closes #3095 

Result:
Closable movable, maximizable windows which stays on top of the main window. Minimizing still to be implimented with a small fix.

