### PR TITLE
Added support for search in XRef dialogue

### DIFF
--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -9,7 +9,7 @@
 #include <QJsonArray>
 
 XrefsDialog::XrefsDialog(MainWindow *parent, bool hideXrefFrom)
-    : QDialog(parent), addr(0), toModel(this), fromModel(this), ui(new Ui::XrefsDialog)
+    : QDialog(parent), addr(0), toModel(this),toProxyModel(&toModel), fromModel(this),fromProxyModel(&fromModel), ui(new Ui::XrefsDialog)
 {
     ui->setupUi(this);
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
@@ -17,8 +17,9 @@ XrefsDialog::XrefsDialog(MainWindow *parent, bool hideXrefFrom)
     ui->toTreeWidget->setMainWindow(parent);
     ui->fromTreeWidget->setMainWindow(parent);
 
-    ui->toTreeWidget->setModel(&toModel);
-    ui->fromTreeWidget->setModel(&fromModel);
+    ui->toTreeWidget->setModel(&toProxyModel);
+    ui->fromTreeWidget->setModel(&fromProxyModel);
+
 
     ui->toTreeWidget->getItemContextMenu()->toggleBreakpointAction(true);
     ui->fromTreeWidget->getItemContextMenu()->toggleBreakpointAction(true);
@@ -44,7 +45,8 @@ XrefsDialog::XrefsDialog(MainWindow *parent, bool hideXrefFrom)
             &XrefsDialog::onToTreeWidgetItemSelectionChanged);
     connect(ui->fromTreeWidget->selectionModel(), &QItemSelectionModel::selectionChanged, this,
             &XrefsDialog::onFromTreeWidgetItemSelectionChanged);
-
+    connect(ui->fromQuickFilter,&QuickFilterView::filterTextChanged,&fromProxyModel,&QSortFilterProxyModel::setFilterWildcard);
+    connect(ui->toQuickFilter,&QuickFilterView::filterTextChanged,&toProxyModel,&QSortFilterProxyModel::setFilterWildcard);
     // Don't create recursive xref dialogs
     auto toContextMenu = ui->toTreeWidget->getItemContextMenu();
     connect(toContextMenu, &AddressableItemContextMenu::xrefsTriggered, this, &QWidget::close);
@@ -317,3 +319,19 @@ RVA XrefModel::address(const QModelIndex &index) const
     const auto &xref = xrefs.at(index.row());
     return to ? xref.from : xref.to;
 }
+
+bool XrefModel::getTo() const{
+    return to;
+}
+
+XrefFilterProxyModel::XrefFilterProxyModel(XrefModel * source_model, QObject *parent)
+    : AddressableFilterProxyModel(source_model,parent),to(source_model->getTo())
+{
+}
+
+bool XrefFilterProxyModel::filterAcceptsRow(int row,const QModelIndex & parent) const{
+    QModelIndex index = sourceModel()->index(row,0,parent);
+    XrefDescription xref = index.data(XrefModel::FlagDescriptionRole).value<XrefDescription>();
+    return qhelpers::filterStringContains( to ? xref.to_str:xref.from_str,this);
+}
+

--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -7,6 +7,9 @@
 #include "core/MainWindow.h"
 
 #include <QJsonArray>
+#include <QShortcut>
+#include "shortcuts/ShortcutManager.h"
+#include <QApplication>
 
 XrefsDialog::XrefsDialog(MainWindow *parent, bool hideXrefFrom)
     : QDialog(parent),
@@ -54,6 +57,30 @@ XrefsDialog::XrefsDialog(MainWindow *parent, bool hideXrefFrom)
             &QSortFilterProxyModel::setFilterWildcard);
     connect(ui->toQuickFilter, &QuickFilterView::filterTextChanged, &toProxyModel,
             &QSortFilterProxyModel::setFilterWildcard);
+
+    // SearchWidget shortcuts
+
+    QShortcut *searchShortcut = Shortcuts()->makeQShortcut("General.showFilter", ui->toTreeWidget);
+    QShortcut *clearShortcut = Shortcuts()->makeQShortcut("General.clearFilter", ui->toTreeWidget);
+
+    connect(searchShortcut, &QShortcut::activated, this, [this]() {
+        QWidget *fw = QApplication::focusWidget();
+        if (ui->toTreeWidget->isAncestorOf(fw)) {
+            ui->toQuickFilter->showFilter();
+        } else if (ui->fromTreeWidget->isAncestorOf(fw)) {
+            ui->fromQuickFilter->showFilter();
+        }
+    });
+
+    connect(clearShortcut, &QShortcut::activated, this, [this]() {
+        QWidget *fw = QApplication::focusWidget();
+        if (ui->toTreeWidget->isAncestorOf(fw)) {
+            ui->toQuickFilter->clearFilter();
+        } else if (ui->fromTreeWidget->isAncestorOf(fw)) {
+            ui->fromQuickFilter->clearFilter();
+        }
+    });
+
     // Don't create recursive xref dialogs
     auto toContextMenu = ui->toTreeWidget->getItemContextMenu();
     connect(toContextMenu, &AddressableItemContextMenu::xrefsTriggered, this, &QWidget::close);
@@ -332,6 +359,14 @@ bool XrefModel::getTo() const
     return to;
 }
 
+const XrefDescription *XrefModel::description(const QModelIndex &index) const
+{
+    if (index.row() < xrefs.size()) {
+        return &xrefs.at(index.row());
+    }
+    return nullptr;
+}
+
 XrefFilterProxyModel::XrefFilterProxyModel(XrefModel *source_model, QObject *parent)
     : AddressableFilterProxyModel(source_model, parent), to(source_model->getTo())
 {
@@ -342,4 +377,22 @@ bool XrefFilterProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) 
     QModelIndex index = sourceModel()->index(row, 0, parent);
     XrefDescription xref = index.data(XrefModel::FlagDescriptionRole).value<XrefDescription>();
     return qhelpers::filterStringContains(to ? xref.to_str : xref.from_str, this);
+}
+
+bool XrefFilterProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const
+{
+    auto source = static_cast<XrefModel *>(sourceModel());
+    auto left_item = source->description(left);
+    auto right_item = source->description(right);
+
+    switch (left.column()) {
+    case XrefModel::OFFSET:
+        return to ? left_item->to < right_item->to : left_item->from < right_item->from;
+
+    case XrefModel::TYPE:
+        return left_item->type < right_item->type;
+    default:
+        return sourceModel()->data(left, Qt::DisplayRole).toString()
+                < sourceModel()->data(right, Qt::DisplayRole).toString();
+    }
 }

--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -61,7 +61,7 @@ XrefsDialog::XrefsDialog(MainWindow *parent, bool hideXrefFrom)
     // SearchWidget shortcuts
 
     QShortcut *searchShortcut = Shortcuts()->makeQShortcut("General.showFilter", ui->toTreeWidget);
-    QShortcut *clearShortcut = Shortcuts()->makeQShortcut("General.clearFilter", ui->toTreeWidget);
+    QShortcut *clearShortcut = Shortcuts()->makeQShortcut("General.clearFilter", ui->fromQuickFilter);
 
     connect(searchShortcut, &QShortcut::activated, this, [this]() {
         QWidget *fw = QApplication::focusWidget();
@@ -72,11 +72,11 @@ XrefsDialog::XrefsDialog(MainWindow *parent, bool hideXrefFrom)
         }
     });
 
-    connect(clearShortcut, &QShortcut::activated, this, [this]() {
+    connect(clearShortcut, &QShortcut::activated,[this]() {
         QWidget *fw = QApplication::focusWidget();
-        if (ui->toTreeWidget->isAncestorOf(fw)) {
+        if (ui->toQuickFilter->isAncestorOf(fw)) {
             ui->toQuickFilter->clearFilter();
-        } else if (ui->fromTreeWidget->isAncestorOf(fw)) {
+        } else if (ui->fromQuickFilter->isAncestorOf(fw)) {
             ui->fromQuickFilter->clearFilter();
         }
     });

--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -9,7 +9,13 @@
 #include <QJsonArray>
 
 XrefsDialog::XrefsDialog(MainWindow *parent, bool hideXrefFrom)
-    : QDialog(parent), addr(0), toModel(this),toProxyModel(&toModel), fromModel(this),fromProxyModel(&fromModel), ui(new Ui::XrefsDialog)
+    : QDialog(parent),
+      addr(0),
+      toModel(this),
+      toProxyModel(&toModel),
+      fromModel(this),
+      fromProxyModel(&fromModel),
+      ui(new Ui::XrefsDialog)
 {
     ui->setupUi(this);
     setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint));
@@ -19,7 +25,6 @@ XrefsDialog::XrefsDialog(MainWindow *parent, bool hideXrefFrom)
 
     ui->toTreeWidget->setModel(&toProxyModel);
     ui->fromTreeWidget->setModel(&fromProxyModel);
-
 
     ui->toTreeWidget->getItemContextMenu()->toggleBreakpointAction(true);
     ui->fromTreeWidget->getItemContextMenu()->toggleBreakpointAction(true);
@@ -45,8 +50,10 @@ XrefsDialog::XrefsDialog(MainWindow *parent, bool hideXrefFrom)
             &XrefsDialog::onToTreeWidgetItemSelectionChanged);
     connect(ui->fromTreeWidget->selectionModel(), &QItemSelectionModel::selectionChanged, this,
             &XrefsDialog::onFromTreeWidgetItemSelectionChanged);
-    connect(ui->fromQuickFilter,&QuickFilterView::filterTextChanged,&fromProxyModel,&QSortFilterProxyModel::setFilterWildcard);
-    connect(ui->toQuickFilter,&QuickFilterView::filterTextChanged,&toProxyModel,&QSortFilterProxyModel::setFilterWildcard);
+    connect(ui->fromQuickFilter, &QuickFilterView::filterTextChanged, &fromProxyModel,
+            &QSortFilterProxyModel::setFilterWildcard);
+    connect(ui->toQuickFilter, &QuickFilterView::filterTextChanged, &toProxyModel,
+            &QSortFilterProxyModel::setFilterWildcard);
     // Don't create recursive xref dialogs
     auto toContextMenu = ui->toTreeWidget->getItemContextMenu();
     connect(toContextMenu, &AddressableItemContextMenu::xrefsTriggered, this, &QWidget::close);
@@ -320,18 +327,19 @@ RVA XrefModel::address(const QModelIndex &index) const
     return to ? xref.from : xref.to;
 }
 
-bool XrefModel::getTo() const{
+bool XrefModel::getTo() const
+{
     return to;
 }
 
-XrefFilterProxyModel::XrefFilterProxyModel(XrefModel * source_model, QObject *parent)
-    : AddressableFilterProxyModel(source_model,parent),to(source_model->getTo())
+XrefFilterProxyModel::XrefFilterProxyModel(XrefModel *source_model, QObject *parent)
+    : AddressableFilterProxyModel(source_model, parent), to(source_model->getTo())
 {
 }
 
-bool XrefFilterProxyModel::filterAcceptsRow(int row,const QModelIndex & parent) const{
-    QModelIndex index = sourceModel()->index(row,0,parent);
+bool XrefFilterProxyModel::filterAcceptsRow(int row, const QModelIndex &parent) const
+{
+    QModelIndex index = sourceModel()->index(row, 0, parent);
     XrefDescription xref = index.data(XrefModel::FlagDescriptionRole).value<XrefDescription>();
-    return qhelpers::filterStringContains( to ? xref.to_str:xref.from_str,this);
+    return qhelpers::filterStringContains(to ? xref.to_str : xref.from_str, this);
 }
-

--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -61,7 +61,8 @@ XrefsDialog::XrefsDialog(MainWindow *parent, bool hideXrefFrom)
     // SearchWidget shortcuts
 
     QShortcut *searchShortcut = Shortcuts()->makeQShortcut("General.showFilter", ui->toTreeWidget);
-    QShortcut *clearShortcut = Shortcuts()->makeQShortcut("General.clearFilter", ui->fromQuickFilter);
+    QShortcut *clearShortcut =
+            Shortcuts()->makeQShortcut("General.clearFilter", ui->fromQuickFilter);
 
     connect(searchShortcut, &QShortcut::activated, this, [this]() {
         QWidget *fw = QApplication::focusWidget();
@@ -72,7 +73,7 @@ XrefsDialog::XrefsDialog(MainWindow *parent, bool hideXrefFrom)
         }
     });
 
-    connect(clearShortcut, &QShortcut::activated,[this]() {
+    connect(clearShortcut, &QShortcut::activated, [this]() {
         QWidget *fw = QApplication::focusWidget();
         if (ui->toQuickFilter->isAncestorOf(fw)) {
             ui->toQuickFilter->clearFilter();

--- a/src/dialogs/XrefsDialog.h
+++ b/src/dialogs/XrefsDialog.h
@@ -34,6 +34,8 @@ public:
 
     static QString xrefTypeString(const QString &type);
     bool getTo() const;
+
+    const XrefDescription *description(const QModelIndex &index) const;
 };
 
 class XrefFilterProxyModel : public AddressableFilterProxyModel
@@ -47,6 +49,7 @@ private:
 
 protected:
     bool filterAcceptsRow(int row, const QModelIndex &parent) const override;
+    bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
 };
 
 class MainWindow;

--- a/src/dialogs/XrefsDialog.h
+++ b/src/dialogs/XrefsDialog.h
@@ -41,8 +41,10 @@ class XrefFilterProxyModel : public AddressableFilterProxyModel
     Q_OBJECT
 public:
     XrefFilterProxyModel(XrefModel *source_model, QObject *parent = nullptr);
+
 private:
     bool to;
+
 protected:
     bool filterAcceptsRow(int row, const QModelIndex &parent) const override;
 };

--- a/src/dialogs/XrefsDialog.h
+++ b/src/dialogs/XrefsDialog.h
@@ -7,6 +7,7 @@
 #include "common/Highlighter.h"
 #include "core/Cutter.h"
 #include "common/AddressableItemModel.h"
+#include "QuickFilterView.h"
 
 class XrefModel : public AddressableItemModel<QAbstractListModel>
 {
@@ -32,6 +33,18 @@ public:
     RVA address(const QModelIndex &index) const override;
 
     static QString xrefTypeString(const QString &type);
+    bool getTo() const;
+};
+
+class XrefFilterProxyModel : public AddressableFilterProxyModel
+{
+    Q_OBJECT
+public:
+    XrefFilterProxyModel(XrefModel *source_model, QObject *parent = nullptr);
+private:
+    bool to;
+protected:
+    bool filterAcceptsRow(int row, const QModelIndex &parent) const override;
 };
 
 class MainWindow;
@@ -73,7 +86,9 @@ private:
     RVA addr;
     QString func_name;
     XrefModel toModel;
+    XrefFilterProxyModel toProxyModel;
     XrefModel fromModel;
+    XrefFilterProxyModel fromProxyModel;
 
     std::unique_ptr<Ui::XrefsDialog> ui;
 

--- a/src/dialogs/XrefsDialog.ui
+++ b/src/dialogs/XrefsDialog.ui
@@ -32,7 +32,7 @@
    <item>
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="handleWidth">
       <number>5</number>
@@ -50,12 +50,15 @@
         </widget>
        </item>
        <item>
+        <widget class="QuickFilterView" name="toQuickFilter" native="true"/>
+       </item>
+       <item>
         <widget class="AddressableItemList&lt;&gt;" name="toTreeWidget">
          <property name="frameShape">
-          <enum>QFrame::Box</enum>
+          <enum>QFrame::Shape::Box</enum>
          </property>
          <property name="frameShadow">
-          <enum>QFrame::Plain</enum>
+          <enum>QFrame::Shadow::Plain</enum>
          </property>
          <property name="indentation">
           <number>5</number>
@@ -73,12 +76,15 @@
         </widget>
        </item>
        <item>
+        <widget class="QuickFilterView" name="fromQuickFilter" native="true"/>
+       </item>
+       <item>
         <widget class="AddressableItemList&lt;&gt;" name="fromTreeWidget">
          <property name="frameShape">
-          <enum>QFrame::Box</enum>
+          <enum>QFrame::Shape::Box</enum>
          </property>
          <property name="frameShadow">
-          <enum>QFrame::Plain</enum>
+          <enum>QFrame::Shadow::Plain</enum>
          </property>
          <property name="indentation">
           <number>5</number>
@@ -102,16 +108,16 @@
        <item>
         <widget class="QPlainTextEdit" name="previewTextEdit">
          <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
+          <enum>QFrame::Shape::NoFrame</enum>
          </property>
          <property name="frameShadow">
-          <enum>QFrame::Plain</enum>
+          <enum>QFrame::Shadow::Plain</enum>
          </property>
          <property name="lineWidth">
           <number>0</number>
          </property>
          <property name="lineWrapMode">
-          <enum>QPlainTextEdit::NoWrap</enum>
+          <enum>QPlainTextEdit::LineWrapMode::NoWrap</enum>
          </property>
          <property name="readOnly">
           <bool>true</bool>
@@ -120,7 +126,7 @@
           <string notr="true"/>
          </property>
          <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+          <set>Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -131,10 +137,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::StandardButton::Close</set>
      </property>
     </widget>
    </item>
@@ -145,6 +151,13 @@
    <class>AddressableItemList&lt;&gt;</class>
    <extends>QTreeView</extends>
    <header>widgets/AddressableItemList.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QuickFilterView</class>
+   <extends>QWidget</extends>
+   <header>widgets/QuickFilterView.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

As mentioned in the GSoC microtask statement given for #1366. 
From the issue page.

> I think this should be added to the Class of this table view, or List view or whatever implemented there. So it should be available for every usage of this class instead of adding the filtering to each usage separately

So i modified the AddressableItemList's AddressableItemModel1 addressableModel's  type to AddressableFilterProxyModel. I think it is a dangerous model but just verify if i'm going in the right direction.

After:


https://github.com/user-attachments/assets/32185aab-77d9-456c-ab50-41430ef82e01





**Test plan (required)**

Open XrefDialog and Search in the QLineEdit.


clang-formatted

**Closing issues**

closes #1366 


A custom filter function/QSortFilterProxy will be required since now search only filters address column. And more important for failproof code.