### PR TITLE
Add mnemonics to main menu

### DIFF
--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -58,7 +58,7 @@
      </rect>
     </property>
     <property name="title">
-     <string>File</string>
+     <string>&amp;File</string>
     </property>
     <widget class="QMenu" name="menuSetMode">
      <property name="toolTip">
@@ -94,7 +94,7 @@
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
-     <string>View</string>
+     <string>&amp;View</string>
     </property>
     <property name="tabsOnTop" stdset="0">
      <bool>false</bool>

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -58,7 +58,7 @@
      </rect>
     </property>
     <property name="title">
-     <string>File</string>
+     <string>&File</string>
     </property>
     <widget class="QMenu" name="menuSetMode">
      <property name="toolTip">
@@ -94,7 +94,7 @@
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
-     <string>View</string>
+     <string>&View</string>
     </property>
     <property name="tabsOnTop" stdset="0">
      <bool>false</bool>
@@ -130,13 +130,13 @@
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
-     <string>Tools</string>
+     <string>&Tools</string>
     </property>
     <addaction name="actionBaseFind"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
-     <string>Help</string>
+     <string>&Help</string>
     </property>
     <addaction name="actionAbout"/>
     <addaction name="actionIssue"/>
@@ -144,7 +144,7 @@
    </widget>
    <widget class="QMenu" name="menuEdit">
     <property name="title">
-     <string>Edit</string>
+     <string>&Edit</string>
     </property>
     <addaction name="actionBackward"/>
     <addaction name="actionForward"/>
@@ -153,7 +153,7 @@
    </widget>
    <widget class="QMenu" name="menuWindows">
     <property name="title">
-     <string>Windows</string>
+     <string>&Windows</string>
     </property>
     <widget class="QMenu" name="menuPlugins">
      <property name="title">
@@ -182,7 +182,7 @@
    </widget>
    <widget class="QMenu" name="menuDebug">
     <property name="title">
-     <string>Debug</string>
+     <string>&Debug</string>
     </property>
    </widget>
    <addaction name="menuFile"/>

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -167,7 +167,7 @@
     </widget>
     <widget class="QMenu" name="menuAddDebugWidgets">
      <property name="title">
-      <string>Debug...</string>
+      <string>&Debug...</string>
      </property>
     </widget>
     <addaction name="actionExtraDecompiler"/>

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -58,7 +58,7 @@
      </rect>
     </property>
     <property name="title">
-     <string>&amp;File</string>
+     <string>File</string>
     </property>
     <widget class="QMenu" name="menuSetMode">
      <property name="toolTip">
@@ -94,7 +94,7 @@
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
-     <string>&amp;View</string>
+     <string>View</string>
     </property>
     <property name="tabsOnTop" stdset="0">
      <bool>false</bool>

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -58,7 +58,7 @@
      </rect>
     </property>
     <property name="title">
-     <string>&File</string>
+     <string>&amp;File</string>
     </property>
     <widget class="QMenu" name="menuSetMode">
      <property name="toolTip">
@@ -94,7 +94,7 @@
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
-     <string>&View</string>
+     <string>&amp;View</string>
     </property>
     <property name="tabsOnTop" stdset="0">
      <bool>false</bool>
@@ -130,13 +130,13 @@
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
-     <string>&Tools</string>
+     <string>&amp;Tools</string>
     </property>
     <addaction name="actionBaseFind"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
-     <string>&Help</string>
+     <string>&amp;Help</string>
     </property>
     <addaction name="actionAbout"/>
     <addaction name="actionIssue"/>
@@ -144,7 +144,7 @@
    </widget>
    <widget class="QMenu" name="menuEdit">
     <property name="title">
-     <string>&Edit</string>
+     <string>&amp;Edit</string>
     </property>
     <addaction name="actionBackward"/>
     <addaction name="actionForward"/>
@@ -153,7 +153,7 @@
    </widget>
    <widget class="QMenu" name="menuWindows">
     <property name="title">
-     <string>&Windows</string>
+     <string>&amp;Windows</string>
     </property>
     <widget class="QMenu" name="menuPlugins">
      <property name="title">
@@ -167,7 +167,7 @@
     </widget>
     <widget class="QMenu" name="menuAddDebugWidgets">
      <property name="title">
-      <string>&Debug...</string>
+      <string>&amp;Debug...</string>
      </property>
     </widget>
     <addaction name="actionExtraDecompiler"/>
@@ -182,7 +182,7 @@
    </widget>
    <widget class="QMenu" name="menuDebug">
     <property name="title">
-     <string>&Debug</string>
+     <string>&amp;Debug</string>
     </property>
    </widget>
    <addaction name="menuFile"/>


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

This PR adds keyboard mnemonics to top-level menu items in `MainWindow.ui`.

By adding `&` to menu titles (e.g., `&File`, `&Edit`, `&View`), users can navigate the menu using keyboard shortcuts like:
- Alt + F → File menu
- Alt + E → Edit menu

This improves accessibility and keyboard usability.

Changes are minimal and only affect top-level menu labels.

**Test plan (required)**

1. Build and run Cutter
2. Press Alt key
3. Observe highlighted letters in menu
4. Press:
   - Alt + F → opens File menu
   - Alt + E → opens Edit menu

Expected: Menus open correctly using keyboard

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

Closes #3518
