### PR TITLE
Show less entries in Omnibar by default

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -999,3 +999,33 @@ int Configuration::getFunctionNameColWidth() const
 {
     return s.value("fcnNameColWidth", 400).toInt();
 }
+
+void Configuration::setOmnibarLimitEntries(bool value)
+{
+    s.setValue("omnibarLimitEntries", value);
+}
+
+bool Configuration::getOmnibarLimitEntries() const
+{
+    return s.value("omnibarLimitEntries", true).toBool();
+}
+
+void Configuration::setOmnibarEntriesCount(int count)
+{
+    s.setValue("omnibarEntriesCount", count);
+}
+
+int Configuration::getOmnibarEntriesCount() const
+{
+    return s.value("omnibarEntriesCount", 100).toInt();
+}
+
+void Configuration::setOmnibarEntriesIncrement(int count)
+{
+    s.setValue("omnibarEntriesIncrement", count);
+}
+
+int Configuration::getOmnibarEntriesIncrement() const
+{
+    return s.value("omnibarEntriesIncrement", 100).toInt();
+}

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -355,6 +355,29 @@ public:
     void setFunctionNameColWidth(int width);
     int getFunctionNameColWidth() const;
 
+    /**
+     * @brief Set whether to limit the number of entries when searching inside omnibar
+     *
+     * The limit is set through @ref setOmnibarEntriesCount
+     * @param value True to set limit, false otherwise
+     */
+    void setOmnibarLimitEntries(bool value);
+    bool getOmnibarLimitEntries() const;
+
+    /**
+     * @brief Set the default number of entries shown when searching inside omnibar
+     * @param count Number of entries to be shown inside omnibar
+     */
+    void setOmnibarEntriesCount(int count);
+    int getOmnibarEntriesCount() const;
+
+    /**
+     * @brief Number of entries to add to initial count when clicking on "Show More" inside omnibar
+     * @param count Number of entries to add
+     */
+    void setOmnibarEntriesIncrement(int count);
+    int getOmnibarEntriesIncrement() const;
+
 public slots:
     void refreshFont();
 signals:

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -762,11 +762,6 @@ void MainWindow::showProjectSaveError(RzProjectErr err)
                           tr("Failed to save project: %1").arg(QString::fromUtf8(s)));
 }
 
-void MainWindow::refreshOmniBar(const QStringList &flags)
-{
-    omnibar->refresh(flags);
-}
-
 void MainWindow::setFilename(const QString &fn)
 {
     // Add file name to window title

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -86,7 +86,6 @@ public:
     void readSettings();
     void saveSettings();
     void setFilename(const QString &fn);
-    void refreshOmniBar(const QStringList &flags);
 
     void addWidget(CutterDockWidget *widget);
     void addMemoryDockWidget(MemoryDockWidget *widget);

--- a/src/dialogs/preferences/InterfaceOptionsWidget.cpp
+++ b/src/dialogs/preferences/InterfaceOptionsWidget.cpp
@@ -10,6 +10,7 @@ InterfaceOptionsWidget::InterfaceOptionsWidget(PreferencesDialog *dialog)
     ui->setupUi(this);
 
     setUpQuickFilter();
+    setUpOmnibar();
     setUpFunctions();
 }
 
@@ -29,6 +30,30 @@ void InterfaceOptionsWidget::setUpFunctions()
 
     connect<void (QSpinBox::*)(int)>(ui->fcnTruncateSpinBox, &QSpinBox::valueChanged, Config(),
                                      &Configuration::setFunctionNameColWidth);
+}
+
+void InterfaceOptionsWidget::setUpOmnibar()
+{
+    const bool limitEntries = Config()->getOmnibarLimitEntries();
+    ui->omnibarCountCheckBox->setChecked(limitEntries);
+    ui->omnibarCountSpinBox->setValue(Config()->getOmnibarEntriesCount());
+
+    auto toggleWidgets = [this](bool enable) {
+        ui->omnibarCountSpinBox->setEnabled(enable);
+        ui->omnibarIncrementLabel->setEnabled(enable);
+        ui->omnibarIncrementSpinBox->setEnabled(enable);
+    };
+    toggleWidgets(limitEntries);
+    ui->omnibarIncrementSpinBox->setValue(Config()->getOmnibarEntriesIncrement());
+
+    connect(ui->omnibarCountCheckBox, &QCheckBox::toggled, this, [toggleWidgets](bool checked) {
+        Config()->setOmnibarLimitEntries(checked);
+        toggleWidgets(checked);
+    });
+    connect<void (QSpinBox::*)(int)>(ui->omnibarCountSpinBox, &QSpinBox::valueChanged, Config(),
+                                     &Configuration::setOmnibarEntriesCount);
+    connect<void (QSpinBox::*)(int)>(ui->omnibarIncrementSpinBox, &QSpinBox::valueChanged, Config(),
+                                     &Configuration::setOmnibarEntriesIncrement);
 }
 
 void InterfaceOptionsWidget::setUpQuickFilter()

--- a/src/dialogs/preferences/InterfaceOptionsWidget.h
+++ b/src/dialogs/preferences/InterfaceOptionsWidget.h
@@ -29,6 +29,7 @@ private:
     std::unique_ptr<Ui::InterfaceOptionsWidget> ui;
 
     void setUpFunctions();
+    void setUpOmnibar();
     void setUpQuickFilter();
 };
 

--- a/src/dialogs/preferences/InterfaceOptionsWidget.ui
+++ b/src/dialogs/preferences/InterfaceOptionsWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>633</width>
-    <height>361</height>
+    <width>678</width>
+    <height>417</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -39,8 +39,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>633</width>
-        <height>361</height>
+        <width>678</width>
+        <height>417</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="scrollLayout">
@@ -81,6 +81,75 @@
               </property>
               <property name="maximum">
                <number>9999</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="omnibarGroupBox">
+         <property name="title">
+          <string>Omnibar</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <property name="topMargin">
+           <number>24</number>
+          </property>
+          <item>
+           <layout class="QHBoxLayout" name="itemCountLayout">
+            <item>
+             <widget class="QCheckBox" name="omnibarCountCheckBox">
+              <property name="toolTip">
+               <string>Only show the number of entries equal to set value when searching inside omnibar. If unchecked all entries will be shown</string>
+              </property>
+              <property name="text">
+               <string>Limit entries by default to</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="omnibarCountSpinBox">
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>999999</number>
+              </property>
+              <property name="singleStep">
+               <number>10</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="itemCountIncrementLayout">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="omnibarIncrementLabel">
+              <property name="toolTip">
+               <string>Number of entries to add when clicking &quot;Show More&quot; inside omnibar</string>
+              </property>
+              <property name="text">
+               <string>On &quot;Show More&quot; increment entries by</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="omnibarIncrementSpinBox">
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>999999</number>
+              </property>
+              <property name="singleStep">
+               <number>10</number>
               </property>
              </widget>
             </item>

--- a/src/shortcuts/DefaultShortcuts.cpp
+++ b/src/shortcuts/DefaultShortcuts.cpp
@@ -288,6 +288,14 @@ const QHash<QString, Shortcut> &getDefaultShortcuts()
           { { QKeySequence(Qt::Key_Escape) },
             QT_TRANSLATE_NOOP("Omnibar", "Clear Omnibar"),
             "Omnibar" } },
+        { "Omnibar.showMore",
+          { { Qt::ControlModifier | Qt::Key_Return },
+            QT_TRANSLATE_NOOP("Omnibar", "Show More Completions"),
+            "Omnibar" } },
+        { "Omnibar.showAll",
+          { { Qt::ControlModifier | Qt::ShiftModifier | Qt::Key_Return },
+            QT_TRANSLATE_NOOP("Omnibar", "Show All Completions"),
+            "Omnibar" } },
 
         // Graph Overview
         { "Overview.zoomIn",

--- a/src/shortcuts/DefaultShortcuts.cpp
+++ b/src/shortcuts/DefaultShortcuts.cpp
@@ -289,11 +289,11 @@ const QHash<QString, Shortcut> &getDefaultShortcuts()
             QT_TRANSLATE_NOOP("Omnibar", "Clear Omnibar"),
             "Omnibar" } },
         { "Omnibar.showMore",
-          { { Qt::ControlModifier | Qt::Key_Return },
+          { { QKeySequence(Qt::ControlModifier | Qt::Key_Return) },
             QT_TRANSLATE_NOOP("Omnibar", "Show More Completions"),
             "Omnibar" } },
         { "Omnibar.showAll",
-          { { Qt::ControlModifier | Qt::ShiftModifier | Qt::Key_Return },
+          { { QKeySequence(Qt::ControlModifier | Qt::ShiftModifier | Qt::Key_Return) },
             QT_TRANSLATE_NOOP("Omnibar", "Show All Completions"),
             "Omnibar" } },
 

--- a/src/widgets/FlagsWidget.cpp
+++ b/src/widgets/FlagsWidget.cpp
@@ -266,12 +266,6 @@ void FlagsWidget::refreshFlags()
 
     // set the initial item count
     ui->filterLineEdit->setItemCount(flags_proxy_model->rowCount());
-
-    // TODO: this is not a very good place for the following:
-    QStringList flagNames;
-    for (const FlagDescription &i : flags_model->flags)
-        flagNames.append(i.name);
-    main->refreshOmniBar(flagNames);
 }
 
 void FlagsWidget::setScrollMode()

--- a/src/widgets/Omnibar.cpp
+++ b/src/widgets/Omnibar.cpp
@@ -7,8 +7,39 @@
 #include <QCompleter>
 #include <QShortcut>
 #include <QAbstractItemView>
+#include <QStringListModel>
+#include <QCollator>
+#include <QStandardItemModel>
+#include <QTimer>
+#include <QEvent>
+#include <QKeyEvent>
 
-Omnibar::Omnibar(MainWindow *main, QWidget *parent) : QLineEdit(parent), main(main)
+namespace {
+constexpr int DEFAULT_ITEM_COUNT = 100;
+}
+
+OmnibarCompleter::OmnibarCompleter(QObject *parent) : QCompleter(parent) {}
+
+QStringList OmnibarCompleter::splitPath(const QString &) const
+{
+    return QStringList("");
+}
+
+QString OmnibarCompleter::pathFromIndex(const QModelIndex &index) const
+{
+    int type = index.data(Qt::UserRole).toInt();
+
+    if (type == Omnibar::ShowMore || type == Omnibar::ShowAll) {
+        if (auto edit = qobject_cast<QLineEdit *>(widget())) {
+            return edit->text();
+        }
+    }
+
+    return QCompleter::pathFromIndex(index);
+}
+
+Omnibar::Omnibar(MainWindow *main, QWidget *parent)
+    : QLineEdit(parent), main(main), m_completerModel(new QStandardItemModel(this))
 {
     // QLineEdit basic features
     this->setMinimumHeight(16);
@@ -18,53 +49,108 @@ Omnibar::Omnibar(MainWindow *main, QWidget *parent) : QLineEdit(parent), main(ma
     this->setTextMargins(10, 0, 0, 0);
     this->setClearButtonEnabled(true);
 
-    connect(this, &QLineEdit::returnPressed, this, &Omnibar::on_gotoEntry_returnPressed);
+    connect(this, &QLineEdit::textEdited, this, [this](const QString &text) {
+        m_maxShownItems = DEFAULT_ITEM_COUNT; // reset the entries count to 100
+        handleSearch(text);
+    });
 
     // Esc clears omnibar
     QShortcut *clear_shortcut = Shortcuts()->makeQShortcut("Omnibar.clear", this);
     connect(clear_shortcut, &QShortcut::activated, this, &Omnibar::clear);
     clear_shortcut->setContext(Qt::WidgetWithChildrenShortcut);
-}
 
-void Omnibar::setupCompleter()
-{
     // Set gotoEntry completer for jump history
-    QCompleter *completer = new QCompleter(flags, this);
-    completer->setMaxVisibleItems(20);
-    completer->setCompletionMode(QCompleter::PopupCompletion);
-    completer->setModelSorting(QCompleter::CaseSensitivelySortedModel);
-    completer->setCaseSensitivity(Qt::CaseInsensitive);
-    completer->setFilterMode(Qt::MatchContains);
+    m_completer = new OmnibarCompleter(this);
+    m_completer->setModel(m_completerModel);
+    m_completer->setMaxVisibleItems(20);
+    m_completer->setFilterMode(Qt::MatchContains);
+    m_completer->setCompletionMode(QCompleter::PopupCompletion);
+    m_completer->popup()->installEventFilter(this);
+    m_completer->popup()->viewport()->installEventFilter(this);
 
-    this->setCompleter(completer);
+    this->setCompleter(m_completer);
+    this->installEventFilter(this);
+
+    connect(Core(), &CutterCore::flagsChanged, this, &Omnibar::refresh);
+    connect(Core(), &CutterCore::codeRebased, this, &Omnibar::refresh);
+    connect(Core(), &CutterCore::refreshAll, this, &Omnibar::refresh);
 }
 
-void Omnibar::refresh(const QStringList &flagList)
+bool Omnibar::eventFilter(QObject *obj, QEvent *event)
 {
-    flags = flagList;
+    QAbstractItemView *popup = m_completer->popup();
 
-    setupCompleter();
-}
+    if (((obj == popup || obj == this) && (event->type() == QEvent::KeyPress))
+        || (obj == popup->viewport() && event->type() == QEvent::MouseButtonPress)) {
 
-void Omnibar::restoreCompleter()
-{
-    QCompleter *completer = this->completer();
-    if (!completer) {
-        return;
+        QModelIndex index;
+
+        if (event->type() == QEvent::MouseButtonPress) {
+            QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+            if (mouseEvent->button() == Qt::LeftButton) {
+                index = popup->indexAt(mouseEvent->pos());
+            }
+        } else if (event->type() == QEvent::KeyPress) {
+            QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+
+            int keyInt = keyEvent->modifiers() | keyEvent->key();
+            QKeySequence eventSeq(keyInt);
+            if (eventSeq == Shortcuts()->getKeySequence("Omnibar.showMore")) {
+                handleShowMore(popup->currentIndex().row());
+                return true;
+            } else if (eventSeq == Shortcuts()->getKeySequence("Omnibar.showAll")) {
+                handleShowAll(popup->currentIndex().row());
+                return true;
+            } else if (keyEvent->key() == Qt::Key_Enter || keyEvent->key() == Qt::Key_Return) {
+                index = popup->currentIndex();
+            }
+        }
+
+        if (index.isValid()) {
+            int row = index.row();
+            int type = index.data(Qt::UserRole).toInt();
+
+            if (type == ItemType::ShowMore) {
+                handleShowMore(row);
+            } else if (type == ItemType::ShowAll) {
+                handleShowAll(row);
+            } else {
+                goToEntry();
+                popup->hide();
+            }
+            return true;
+        }
     }
-    completer->setFilterMode(Qt::MatchContains);
+    return QObject::eventFilter(obj, event);
+}
+
+void Omnibar::refresh()
+{
+    m_flags.clear();
+    const auto flags = Core()->getAllFlags();
+    for (const auto &f : flags) {
+        m_flags.append(f.name);
+    }
+
+    QCollator collator;
+    collator.setNumericMode(true);
+    collator.setCaseSensitivity(Qt::CaseInsensitive);
+    std::sort(m_flags.begin(), m_flags.end(), [&collator](const QString &a, const QString &b) {
+        return collator.compare(a, b) < 0;
+    });
+
+    handleSearch(this->text());
 }
 
 void Omnibar::clear()
 {
     QLineEdit::clear();
 
-    // Close the potential shown completer popup
-    clearFocus();
-    setFocus();
+    m_completerModel->clear();
+    m_completer->popup()->hide();
 }
 
-void Omnibar::on_gotoEntry_returnPressed()
+void Omnibar::goToEntry()
 {
     QString str = this->text();
     if (!str.isEmpty()) {
@@ -79,5 +165,87 @@ void Omnibar::on_gotoEntry_returnPressed()
 
     this->setText("");
     this->clearFocus();
-    this->restoreCompleter();
+}
+
+void Omnibar::handleSearch(const QString &Text, bool append)
+{
+    m_searchedText = Text;
+    m_matchCount = 0;
+
+    if (!append) {
+        m_completerModel->clear();
+        m_lastIndex = 0;
+    } else {
+        // remove "show more" and "show all" rows
+        m_completerModel->removeRows(m_completerModel->rowCount() - 2, 2);
+    }
+
+    if (Text.isEmpty()) {
+        return;
+    }
+
+    bool hasMore = false;
+    int itemsInModel = m_completerModel->rowCount();
+
+    for (int i = 0; i < m_flags.size(); ++i) {
+        const QString &flag = m_flags[i];
+        if (flag.contains(Text, Qt::CaseInsensitive)) {
+            if (itemsInModel < m_maxShownItems) {
+                if (!append || i > m_lastIndex) {
+                    QStandardItem *item = new QStandardItem(flag);
+                    item->setData(ItemType::Standard, Qt::UserRole);
+                    m_completerModel->appendRow(item);
+                    ++itemsInModel;
+                    m_lastIndex = i;
+                }
+            } else {
+                hasMore = true;
+            }
+            ++m_matchCount;
+        }
+    }
+
+    if (hasMore) {
+        auto addActionRow = [&](const QString &text, ItemType type) {
+            QStandardItem *actionItem = new QStandardItem(text);
+            actionItem->setData(type, Qt::UserRole);
+
+            QPalette palette = this->palette();
+            QColor placeholderColor = palette.color(QPalette::PlaceholderText);
+            actionItem->setForeground(placeholderColor);
+
+            QFont font = actionItem->font();
+            font.setItalic(true);
+            actionItem->setFont(font);
+
+            m_completerModel->appendRow(actionItem);
+        };
+
+        addActionRow(tr("Show More"), ItemType::ShowMore);
+        addActionRow(tr("Show All (%1 of %2)").arg(m_maxShownItems).arg(m_matchCount),
+                     ItemType::ShowAll);
+    }
+
+    m_completer->setCompletionPrefix("");
+    m_completer->complete();
+}
+
+void Omnibar::handleShowMore(int currentRow)
+{
+    if (m_maxShownItems >= m_matchCount) {
+        return;
+    }
+    m_maxShownItems = std::min(m_maxShownItems + DEFAULT_ITEM_COUNT, m_matchCount);
+    handleSearch(m_searchedText, true);
+    m_completer->popup()->setCurrentIndex(m_completerModel->index(currentRow, 0));
+}
+
+void Omnibar::handleShowAll(int currentRow)
+{
+    if (m_maxShownItems >= m_matchCount) {
+        return;
+    }
+    m_maxShownItems = m_matchCount;
+    handleSearch(m_searchedText, true);
+    m_completer->popup()->setCurrentIndex(m_completerModel->index(currentRow, 0));
 }

--- a/src/widgets/Omnibar.cpp
+++ b/src/widgets/Omnibar.cpp
@@ -14,10 +14,6 @@
 #include <QEvent>
 #include <QKeyEvent>
 
-namespace {
-constexpr int DEFAULT_ITEM_COUNT = 100;
-}
-
 OmnibarCompleter::OmnibarCompleter(QObject *parent) : QCompleter(parent) {}
 
 QStringList OmnibarCompleter::splitPath(const QString &) const
@@ -50,7 +46,7 @@ Omnibar::Omnibar(MainWindow *main, QWidget *parent)
     this->setClearButtonEnabled(true);
 
     connect(this, &QLineEdit::textEdited, this, [this](const QString &text) {
-        m_maxShownItems = DEFAULT_ITEM_COUNT; // reset the entries count to 100
+        m_maxShownItems = Config()->getOmnibarEntriesCount(); // reset entries count to default
         handleSearch(text);
     });
 
@@ -176,7 +172,7 @@ void Omnibar::handleSearch(const QString &Text, bool append)
         m_completerModel->clear();
         m_lastIndex = 0;
     } else {
-        // remove "show more" and "show all" rows
+        // remove "show more" and "show all" rows (last two)
         m_completerModel->removeRows(m_completerModel->rowCount() - 2, 2);
     }
 
@@ -190,7 +186,8 @@ void Omnibar::handleSearch(const QString &Text, bool append)
     for (int i = 0; i < m_flags.size(); ++i) {
         const QString &flag = m_flags[i];
         if (flag.contains(Text, Qt::CaseInsensitive)) {
-            if (itemsInModel < m_maxShownItems) {
+            const bool showAll = !Config()->getOmnibarLimitEntries();
+            if ((itemsInModel < m_maxShownItems) || showAll) {
                 if (!append || i > m_lastIndex) {
                     QStandardItem *item = new QStandardItem(flag);
                     item->setData(ItemType::Standard, Qt::UserRole);
@@ -235,7 +232,8 @@ void Omnibar::handleShowMore(int currentRow)
     if (m_maxShownItems >= m_matchCount) {
         return;
     }
-    m_maxShownItems = std::min(m_maxShownItems + DEFAULT_ITEM_COUNT, m_matchCount);
+    m_maxShownItems =
+            std::min(m_maxShownItems + Config()->getOmnibarEntriesIncrement(), m_matchCount);
     handleSearch(m_searchedText, true);
     m_completer->popup()->setCurrentIndex(m_completerModel->index(currentRow, 0));
 }

--- a/src/widgets/Omnibar.cpp
+++ b/src/widgets/Omnibar.cpp
@@ -208,7 +208,12 @@ void Omnibar::handleSearch(const QString &Text, bool append)
             actionItem->setData(type, Qt::UserRole);
 
             QPalette palette = this->palette();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
             QColor placeholderColor = palette.color(QPalette::PlaceholderText);
+#else
+            QColor placeholderColor = palette.color(QPalette::Text);
+            placeholderColor.setAlpha(128);
+#endif
             actionItem->setForeground(placeholderColor);
 
             QFont font = actionItem->font();

--- a/src/widgets/Omnibar.h
+++ b/src/widgets/Omnibar.h
@@ -2,8 +2,28 @@
 #define OMNIBAR_H
 
 #include <QLineEdit>
+#include <QCompleter>
 
 class MainWindow;
+class QStandardItemModel;
+
+class OmnibarCompleter : public QCompleter
+{
+public:
+    explicit OmnibarCompleter(QObject *parent = nullptr);
+
+    /**
+     * @brief Force the completer to match everything, since we are handling filtering on our own
+     */
+    QStringList splitPath(const QString &) const override;
+
+    /**
+     * @brief Do not auto-complete when selecting "Show More" or "Show All" entries
+     *
+     * Keeps the text the same for "Show More" and "Show All", auto-completes for other entries
+     */
+    QString pathFromIndex(const QModelIndex &index) const override;
+};
 
 class Omnibar : public QLineEdit
 {
@@ -11,21 +31,50 @@ class Omnibar : public QLineEdit
 public:
     explicit Omnibar(MainWindow *main, QWidget *parent = nullptr);
 
-    void refresh(const QStringList &flagList);
+    void refresh();
+
+    enum ItemType { Standard = 0, ShowMore = 1, ShowAll = 2 };
 
 private slots:
-    void on_gotoEntry_returnPressed();
+    /**
+     * @brief Seeks to the address of selected entry/flag and shows it in the last memory widget
+     */
+    void goToEntry();
 
-    void restoreCompleter();
+    /**
+     * @brief Filters or searches entries "containing" the text
+     *
+     * Appends "Show More" and "Show All" entries at the end if there are more found matches then
+     * currently shown
+     *
+     * @param text The string to match against
+     * @param append If false, resets the search to the beginning. If true, continues from the last
+     * found position
+     */
+    void handleSearch(const QString &text, bool append = false);
+
+protected:
+    bool eventFilter(QObject *obj, QEvent *event) override;
 
 public slots:
     void clear();
 
 private:
     void setupCompleter();
+    void handleShowMore(int currentRow);
+    void handleShowAll(int currentRow);
 
     MainWindow *main;
-    QStringList flags;
+    QStringList m_flags;
+
+    QStringList m_filteredFlags;
+    QStandardItemModel *m_completerModel;
+    QCompleter *m_completer;
+
+    QString m_searchedText;
+    int m_maxShownItems;
+    int m_lastIndex;
+    int m_matchCount;
 };
 
 #endif // OMNIBAR_H


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

In binaries which contain a large amount of flags, searching through the omnibar (the universal bar at the top) becomes a pain. Typing every character initiates a search through all, potentially thousands of flags. 
This PR does the following:
* Shows 100 flag matches by default
* Gives two new entries at the bottom only if there are more matches than currently shown
    - Show More
    - Show All (also shows the current amount of results shown and total matches)
* Pressing "Show More" will show 100 more entries and "Show All" will show all of the found matches
* `Ctrl + Return` triggers "Show More"
* `Ctrl + Shift + Return` triggers "Show All"
* `Return` jumps to the address of flag, just as before
* When selecting "Show More" or "Show All" entries inside the completer, the original text (whatever was shown in the omnibar before selecting Show More/All) is preserved i.e: it doesn't autofill searchbar to "Show More"

Note that the number of visible entries resets back to 100 when the text is changed by the user (i.e: typing more characters or deleting)
Also the results are sorted by numeric mode, meaning sym.secret.100 will be shown after sym.secret.99

Update: whether to show visible entries or not and their count can be adjusted in `Edit->Preferences->Interface->Omnibar`. The number of entries to add when clicking on "Show More" can also be adjusted. By default both of these values are set to 100 with the visibility set to true 

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

* Open Cutter with a large binary OR add a large amount of flags manually - maybe through rizin script
    - Refresh if you added flags manually `View->Refresh Contents` OR `Ctrl + R`
*  Search for flag name in omnibar. Note that similar to before the search is "MatchContains" meaning if the flag name contains what's typed in the omnibar - it will count as a match and will be shown
* Observe it doesn't lag
* Scroll to the bottom of entries
* Try Show More and Show All
* Observe Show More and Show All don''t change the typed text and they are hidden if match count is not more than visible entries

I was also thinking it would be nice to provide users with the ability to change the default 100 entries count through preferences, user might also have the option to force Show All 
it would require a new tab in preferences because more customizations for other widgets might be added in the future

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Media**
Comparison, searching through a list of 200,000 flags
Before: 
![omnibar-before](https://github.com/user-attachments/assets/20fd38e3-bc03-48e6-9b17-7db0f7801e75)

After (lag on scrolling is just the gif):
![omnibar-after](https://github.com/user-attachments/assets/aec36a24-5296-49d2-9f56-1be607b1c648)

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3581 