### PR TITLE
Rzasm info page enhancement

### DIFF
--- a/src/common/DisassemblyPreview.cpp
+++ b/src/common/DisassemblyPreview.cpp
@@ -49,10 +49,11 @@ bool DisassemblyPreview::showDisasPreviewAt(QWidget *parent, const QPoint &point
     QStringList disasmPreview = Core()->getDisassemblyPreview(offset, 10);
     if (!disasmPreview.isEmpty()) {
         const QFont &fnt = Config()->getFont();
-        QString tooltip = QString { "<html><div style=\"font-family: %1; font-size: %2pt; "
-                                    "white-space: nowrap;\"><div style=\"margin-bottom: "
-                                    "10px;\"><strong>Disassembly Preview</strong>:<br>%3<div>" }
-                                  .arg(fnt.family())
+        QString tooltip = QString("<html><div style=\"font-family: '%1'; font-size: %2pt; "
+                                  "white-space: nowrap;\"><div style=\"margin-bottom: "
+                                  "10px;\"><strong>Disassembly Preview</strong>:</div>"
+                                  "%3</div></html>")
+                                  .arg(fnt.family().toHtmlEscaped())
                                   .arg(qMax(8, fnt.pointSize() - 1))
                                   .arg(disasmPreview.join("<br>"));
 

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3182,9 +3182,15 @@ QList<RzAsmPluginDescription> CutterCore::getRAsmPluginDescriptions()
 
                 // Bits
                 QStringList bitsList;
-                for (int bits = 4; bits <= 64; bits *= 2) {
-                    if (ap->bits & bits) {
-                        bitsList << QString::number(bits);
+                if (ap->bits == 27) {
+                    bitsList << "27";
+                } else if (ap->bits == 0) {
+                    bitsList << "any";
+                } else {
+                    for (int bits = 4; bits <= 64; bits *= 2) {
+                        if (ap->bits & bits) {
+                            bitsList << QString::number(bits);
+                        }
                     }
                 }
                 plugin.bits = bitsList.join(" ");

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3168,8 +3168,8 @@ QList<RzAsmPluginDescription> CutterCore::getRAsmPluginDescriptions()
     CORE_LOCK();
     QList<RzAsmPluginDescription> ret;
 
-    CutterHtSP<RzAsmPlugin>(rz_asm_get_plugins(core->rasm))
-            .ForEach([&ret](const char *k, const RzAsmPlugin *ap) {
+    CutterHtSP<RzAsmPlugin>(core->rasm->plugins)
+            .ForEach([&ret, &core, this](const char *k, const RzAsmPlugin *ap) {
                 RzAsmPluginDescription plugin;
 
                 plugin.name = ap->name;
@@ -3179,6 +3179,32 @@ QList<RzAsmPluginDescription> CutterCore::getRAsmPluginDescriptions()
                 plugin.cpus = ap->cpus;
                 plugin.description = ap->desc;
                 plugin.license = ap->license;
+
+                // Bits
+                QStringList bitsList;
+                for (int bits = 4; bits <= 64; bits *= 2) {
+                    if (ap->bits & bits) {
+                        bitsList << QString::number(bits);
+                    }
+                }
+                plugin.bits = bitsList.join(" ");
+
+                // Capabilities
+                QString caps;
+                caps += ap->assemble ? "a" : "_";
+                caps += ap->disassemble ? "d" : "_";
+
+                bool foundAnalysis = false;
+                auto analysisPlugin = CutterHtSP<RzAnalysisPlugin>(core->analysis->plugins)
+                                              .Find(ap->name, &foundAnalysis);
+                if (foundAnalysis && analysisPlugin) {
+                    caps += "A";
+                    caps += analysisPlugin->esil ? "e" : "_";
+                    caps += analysisPlugin->il_config ? "I" : "_";
+                } else {
+                    caps += "__";
+                }
+                plugin.capabilities = caps;
 
                 ret << plugin;
                 return true;

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3168,7 +3168,7 @@ QList<RzAsmPluginDescription> CutterCore::getRAsmPluginDescriptions()
     CORE_LOCK();
     QList<RzAsmPluginDescription> ret;
 
-    CutterHtSP<RzAsmPlugin>(core->rasm->plugins)
+    CutterHtSP<RzAsmPlugin>(rz_asm_get_plugins(core->rasm))
             .ForEach([&ret, &core, this](const char *k, const RzAsmPlugin *ap) {
                 RzAsmPluginDescription plugin;
 
@@ -3201,8 +3201,9 @@ QList<RzAsmPluginDescription> CutterCore::getRAsmPluginDescriptions()
                 caps += ap->disassemble ? "d" : "_";
 
                 bool foundAnalysis = false;
-                auto analysisPlugin = CutterHtSP<RzAnalysisPlugin>(core->analysis->plugins)
-                                              .Find(ap->name, &foundAnalysis);
+                auto analysisPlugin =
+                        CutterHtSP<RzAnalysisPlugin>(rz_analysis_get_plugins(core->analysis))
+                                .Find(ap->name, &foundAnalysis);
                 if (foundAnalysis && analysisPlugin) {
                     caps += "A";
                     caps += analysisPlugin->esil ? "e" : "_";

--- a/src/core/CutterDescriptions.h
+++ b/src/core/CutterDescriptions.h
@@ -207,6 +207,8 @@ struct RzAsmPluginDescription
     QString cpus;
     QString description;
     QString license;
+    QString capabilities;
+    QString bits;
 };
 
 struct DisassemblyLine

--- a/src/core/RizinCpp.h
+++ b/src/core/RizinCpp.h
@@ -209,7 +209,11 @@ public:
         {                                                                                          \
             ht_##xx##_foreach(ht, ForEachCb<F>, &f);                                               \
         }                                                                                          \
-    }
+        const V *Find(K k, bool *found = nullptr)                                                  \
+        {                                                                                          \
+            return reinterpret_cast<const V *>(ht_##xx##_find(ht, k, found));                      \
+        }                                                                                          \
+    };
 
 CutterHtDef(sp, SP, const char *, void *);
 

--- a/src/dialogs/RizinPluginsDialog.cpp
+++ b/src/dialogs/RizinPluginsDialog.cpp
@@ -1,9 +1,14 @@
 #include "RizinPluginsDialog.h"
 #include "ui_RizinPluginsDialog.h"
 
+#include "Configuration.h"
+#include "common/DisassemblyPreview.h"
 #include "core/Cutter.h"
 #include "common/Helpers.h"
 #include "plugins/PluginManager.h"
+
+#include <QString>
+#include <QTreeWidgetItem>
 
 RizinPluginsDialog::RizinPluginsDialog(QWidget *parent)
     : QDialog(parent), ui(new Ui::RizinPluginsDialog)
@@ -47,6 +52,19 @@ RizinPluginsDialog::RizinPluginsDialog(QWidget *parent)
         item->setText(0, plugin.name);
         item->setText(1, plugin.architecture);
         item->setText(2, plugin.cpus);
+        if (!plugin.cpus.isEmpty()) {
+            QString cpus = plugin.cpus;
+            cpus.replace(",", ", ");
+
+            const QFont &fnt = Config()->getFont();
+            const QString tooltip =
+                    QString("<html><div style='font-family:%1;font-size:%2pt;'>%3</div></html>")
+                            .arg(fnt.family())
+                            .arg(qMax(8, fnt.pointSize() - 1))
+                            .arg(cpus.toHtmlEscaped());
+
+            item->setToolTip(2, tooltip);
+        }
         item->setText(3, plugin.version);
         item->setText(4, plugin.description);
         item->setText(5, plugin.license);
@@ -54,7 +72,13 @@ RizinPluginsDialog::RizinPluginsDialog(QWidget *parent)
         ui->RzAsmTreeWidget->addTopLevelItem(item);
     }
     ui->RzAsmTreeWidget->sortByColumn(0, Qt::AscendingOrder);
+    ui->RzAsmTreeWidget->setStyleSheet(DisassemblyPreview::getToolTipStyleSheet());
     qhelpers::adjustColumns(ui->RzAsmTreeWidget, 0);
+
+    int cpuCol = 2;
+    if (ui->RzAsmTreeWidget->columnWidth(cpuCol) > 200) {
+        ui->RzAsmTreeWidget->setColumnWidth(cpuCol, 200);
+    }
 }
 
 RizinPluginsDialog::~RizinPluginsDialog()

--- a/src/dialogs/RizinPluginsDialog.cpp
+++ b/src/dialogs/RizinPluginsDialog.cpp
@@ -58,8 +58,8 @@ RizinPluginsDialog::RizinPluginsDialog(QWidget *parent)
 
             const QFont &fnt = Config()->getFont();
             const QString tooltip =
-                    QString("<html><div style='font-family:%1;font-size:%2pt;'>%3</div></html>")
-                            .arg(fnt.family())
+                    QString("<html><div style='font-family:'%1';font-size:%2pt;'>%3</div></html>")
+                            .arg(fnt.family().toHtmlEscaped())
                             .arg(qMax(8, fnt.pointSize() - 1))
                             .arg(cpus.toHtmlEscaped());
 

--- a/src/dialogs/RizinPluginsDialog.cpp
+++ b/src/dialogs/RizinPluginsDialog.cpp
@@ -69,6 +69,8 @@ RizinPluginsDialog::RizinPluginsDialog(QWidget *parent)
         item->setText(4, plugin.description);
         item->setText(5, plugin.license);
         item->setText(6, plugin.author);
+        item->setText(7, plugin.capabilities);
+        item->setText(8, plugin.bits);
         ui->RzAsmTreeWidget->addTopLevelItem(item);
     }
     ui->RzAsmTreeWidget->sortByColumn(0, Qt::AscendingOrder);

--- a/src/dialogs/RizinPluginsDialog.ui
+++ b/src/dialogs/RizinPluginsDialog.ui
@@ -189,6 +189,16 @@
            <string>Author</string>
           </property>
          </column>
+         <column>
+           <property name="text">
+            <string>Capabilities</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Bits</string>
+           </property>
+          </column>
         </widget>
        </item>
       </layout>

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -252,9 +252,9 @@ QVariant FunctionModel::data(const QModelIndex &index, int role) const
             return {};
 
         QString toolTipContent =
-                QString("<html><div style=\"font-family: %1; font-size: %2pt; white-space: "
+                QString("<html><div style=\"font-family: '%1'; font-size: %2pt; white-space: "
                         "nowrap;\">")
-                        .arg(fnt.family())
+                        .arg(fnt.family().toHtmlEscaped())
                         .arg(qMax(6, fnt.pointSize() - 1)); // slightly decrease font size, to
                                                             // keep more text in the same box
 

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -152,9 +152,9 @@ QVariant SearchModel::data(const QModelIndex &index, int role) const
         QFontMetrics fm { fnt };
 
         QString toolTipContent =
-                QString("<html><div style=\"font-family: %1; font-size: %2pt; white-space: "
+                QString("<html><div style=\"font-family: '%1'; font-size: %2pt; white-space: "
                         "nowrap;\">")
-                        .arg(fnt.family())
+                        .arg(fnt.family().toHtmlEscaped())
                         .arg(qMax(6, fnt.pointSize() - 1)); // slightly decrease font size, to keep
                                                             // more text in the same box
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

> Limit default "CPU's'" column width (don't prevent expanding it) or move it to the end. Some of the cpu lists are very long. It took me some time to notice that there are more columns to the right

Lowered the width of the `CPU's` column, added a tooltip with the style from `DisassemblyPreview::getToolTipStyleSheet()` to be able to see the whole value when hovering.

> Add columns displaying asm plugin capabilities adAE (assemble, disassemble, analyze, esil) and bits similar to La command output.

Extended `CutterCore::getRAsmPluginDescriptions()` function to return the number of bits and capabilities. The implementation is based on Rizin's `const char *has_esil(RzCore *core, const char *name)` and `void bits_to_string(int bits, char output[32])` from `casm.c`. I have also added a `const V *Find(K k, bool *found = nullptr)` method to `CutterHt##XX` to search for analysis plugins.

Before:

https://github.com/user-attachments/assets/efaa7dd2-2f6d-46a2-b5d5-9334e35325fd

<img width="2523" height="1282" alt="image" src="https://github.com/user-attachments/assets/e312fe0b-4bd0-4b13-bfc8-b562d663d730" />

<img width="2540" height="1286" alt="image" src="https://github.com/user-attachments/assets/11555c00-8e55-4da2-a435-ad3c3262542c" />


CPU's columns is very long and no 'Capabilities' and 'Bits' columns

After:

https://github.com/user-attachments/assets/3973d3c0-1c48-434c-8b3d-248f1e583e26

<img width="2541" height="1284" alt="image" src="https://github.com/user-attachments/assets/52fb8abe-b01e-4273-afea-7ce019700450" />


**Test plan (required)**
<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->
- Open Cutter with any binary
- In the 'Open file' dialog press About -> Show Rizin Plugin Information -> RzAsm **OR** Choose and open a binary -> Edit -> Preferences -> Plugins -> Show Rizin Plugin Information -> RzAsm
- Verify that `CPU's` column has smaller width, when hovering you can see values in tooltips
- Scroll to the right, see the 'Capabilities' and 'Bits' columns

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**
closes #2385
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
