### PR TITLE
Switch to widget on seek change

### DIFF
--- a/src/common/CutterSeekable.cpp
+++ b/src/common/CutterSeekable.cpp
@@ -75,14 +75,14 @@ void CutterSeekable::seekToReference(RVA offset)
         // Try first call
         for (auto &ref : refs) {
             if (ref.to != RVA_INVALID && ref.type == "CALL") {
-                seek(ref.to);
+                Core()->seekAndShow(ref.to);
                 return;
             }
         }
         // Fallback to first valid, if any
         for (auto &ref : refs) {
             if (ref.to != RVA_INVALID) {
-                seek(ref.to);
+                Core()->seekAndShow(ref.to);
                 return;
             }
         }

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1163,14 +1163,12 @@ AddressTypeHint CutterCore::getAddressType(RVA addr)
         return AddressTypeHint::Unknown;
     }
 
-    if (addr >= section.vaddr && addr < section.vaddr + section.vsize) {
-        if (section.perm.toLower().contains('x')) {
-            return AddressTypeHint::Code;
-        }
-        if (section.perm.toLower().contains('r') || section.perm.toLower().contains('w')) {
-            return AddressTypeHint::Data;
-        }
-        return AddressTypeHint::Unknown;
+    if (section.perm.contains('x', Qt::CaseInsensitive)) {
+        return AddressTypeHint::Code;
+    }
+    if (section.perm.contains('r', Qt::CaseInsensitive)
+        || section.perm.contains('w', Qt::CaseInsensitive)) {
+        return AddressTypeHint::Data;
     }
 
     return AddressTypeHint::Unknown;

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1158,17 +1158,19 @@ AddressTypeHint CutterCore::getAddressType(RVA addr)
         return AddressTypeHint::Function;
     }
 
-    auto sections = getAllSections();
-    for (const auto &sect : sections) {
-        if (addr >= sect.vaddr && addr < sect.vaddr + sect.vsize) {
-            if (sect.perm.toLower().contains('x')) {
-                return AddressTypeHint::Code;
-            }
-            if (sect.perm.toLower().contains('r') || sect.perm.toLower().contains('w')) {
-                return AddressTypeHint::Data;
-            }
-            return AddressTypeHint::Unknown;
+    auto section = getSectionAtAddress(addr);
+    if (section.name.isEmpty()) {
+        return AddressTypeHint::Unknown;
+    }
+
+    if (addr >= section.vaddr && addr < section.vaddr + section.vsize) {
+        if (section.perm.toLower().contains('x')) {
+            return AddressTypeHint::Code;
         }
+        if (section.perm.toLower().contains('r') || section.perm.toLower().contains('w')) {
+            return AddressTypeHint::Data;
+        }
+        return AddressTypeHint::Unknown;
     }
 
     return AddressTypeHint::Unknown;
@@ -3529,6 +3531,42 @@ QList<FlagDescription> CutterCore::getAllFlags(QString flagspace)
             },
             &flags);
     return flags;
+}
+
+SectionDescription CutterCore::getSectionAtAddress(RVA addr)
+{
+    CORE_LOCK();
+    RzBinObject *o = rz_bin_cur_object(core->bin);
+    if (!o) {
+        return {};
+    }
+    RzBinSection *section = rz_bin_get_section_at(o, addr, 0);
+    if (!section) {
+        return {};
+    }
+    RzList *hashnames = rz_list_newf(free);
+    if (!hashnames) {
+        return {};
+    }
+    SectionDescription desc;
+    desc.vaddr = section->vaddr;
+    desc.paddr = section->paddr;
+    desc.size = section->size;
+    desc.name = section->name;
+    desc.vsize = section->vsize;
+    desc.perm = rz_str_rwx_i(section->perm);
+    if (desc.size > 0) {
+        HtSS *digests = rz_core_bin_create_digests(core, desc.paddr, desc.size, hashnames);
+        if (!digests) {
+            return {};
+        }
+
+        const char *entropy = (const char *)ht_ss_find(digests, "entropy", NULL);
+        desc.entropy = rz_str_get(entropy);
+        ht_ss_free(digests);
+    }
+
+    return desc;
 }
 
 QList<SectionDescription> CutterCore::getAllSections()

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1009,13 +1009,13 @@ void CutterCore::showMemoryWidget()
 void CutterCore::seekAndShow(ut64 offset)
 {
     seek(offset);
-    showMemoryWidget();
+    emit showAddressRequested(offset);
 }
 
 void CutterCore::seekAndShow(QString offset)
 {
     seek(offset);
-    showMemoryWidget();
+    emit showAddressRequested(math(offset));
 }
 
 void CutterCore::seek(QString thing)
@@ -1148,6 +1148,30 @@ void CutterCore::setConfig(const char *k, const QString &v)
 {
     CORE_LOCK();
     rz_config_set(core->config, k, v.toUtf8().constData());
+}
+
+AddressTypeHint CutterCore::getAddressType(RVA addr)
+{
+    CORE_LOCK();
+
+    if (functionIn(addr)) {
+        return AddressTypeHint::Function;
+    }
+
+    auto sections = getAllSections();
+    for (const auto &sect : sections) {
+        if (addr >= sect.vaddr && addr < sect.vaddr + sect.vsize) {
+            if (sect.perm.toLower().contains('x')) {
+                return AddressTypeHint::Code;
+            }
+            if (sect.perm.toLower().contains('r') || sect.perm.toLower().contains('w')) {
+                return AddressTypeHint::Data;
+            }
+            return AddressTypeHint::Unknown;
+        }
+    }
+
+    return AddressTypeHint::Unknown;
 }
 
 void CutterCore::setConfig(const char *k, int v)

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -3540,7 +3540,7 @@ SectionDescription CutterCore::getSectionAtAddress(RVA addr)
     if (!o) {
         return {};
     }
-    RzBinSection *section = rz_bin_get_section_at(o, addr, 0);
+    RzBinSection *section = rz_bin_get_section_at(o, addr, true);
     if (!section) {
         return {};
     }

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -79,6 +79,8 @@ enum class SearchKind {
     MagicSignature,
 };
 
+enum class AddressTypeHint { Function, Code, Data, Unknown };
+
 class CUTTER_EXPORT CutterCore : public QObject
 {
     Q_OBJECT
@@ -236,6 +238,7 @@ public:
     RVA getFunctionEnd(RVA addr);
     RVA getLastFunctionInstruction(RVA addr);
     QString flagAt(RVA addr, bool getClosestFlag = true);
+    AddressTypeHint getAddressType(RVA addr);
     void createFunctionAt(RVA addr);
     void createFunctionAt(RVA addr, QString name);
     QStringList getDisassemblyPreview(RVA address, int num_of_lines);
@@ -924,6 +927,7 @@ signals:
     void newDebugMessage(const QString &msg);
 
     void showMemoryWidgetRequested();
+    void showAddressRequested(RVA addr);
 
     /**
      * @brief emitted when a specific type is requested to be shown in the Types Widget

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -563,6 +563,12 @@ public:
     QList<RVA> getBreakpointsAddresses();
 
     /**
+     * @brief Get the section at the given address
+     * @param addr Address to get the section for
+     * @return SectionDescription of the section at the given address
+     */
+    SectionDescription getSectionAtAddress(RVA addr);
+    /**
      * @brief Sets the RzRun profile directives by writing them to a file
      * If a profile path is already set in 'dbg.profile', this method overwrites that file
      * If no path is set, it creates a temporary file and updates 'dbg.profile' to point to it

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1109,20 +1109,22 @@ MemoryDockWidget *MainWindow::getLastMemoryWidget()
 
 void MainWindow::showAddress(RVA addr)
 {
-    AddressTypeHint addressType = core->getAddressType(addr);
+    if (lastMemoryWidget && lastMemoryWidget->getType() == MemoryWidgetType::Graph) {
+        AddressTypeHint addressType = core->getAddressType(addr);
 
-    MemoryWidgetType targetType;
-    if (addressType == AddressTypeHint::Data) {
-        targetType = MemoryWidgetType::Hexdump;
-    } else if (addressType == AddressTypeHint::Function) {
-        targetType = MemoryWidgetType::Graph;
-    } else {
-        targetType = MemoryWidgetType::Disassembly;
+        MemoryWidgetType targetType;
+        if (addressType == AddressTypeHint::Data) {
+            targetType = MemoryWidgetType::Hexdump;
+        } else if (addressType == AddressTypeHint::Function) {
+            targetType = MemoryWidgetType::Graph;
+        } else {
+            targetType = MemoryWidgetType::Disassembly;
+        }
+
+        auto memoryWidget = getOrCreateMemoryWidget(targetType, addr, true);
+        memoryWidget->tryRaiseMemoryWidget();
+        setCurrentMemoryWidget(memoryWidget);
     }
-
-    auto memoryWidget = getOrCreateMemoryWidget(targetType, addr, true);
-    memoryWidget->tryRaiseMemoryWidget();
-    setCurrentMemoryWidget(memoryWidget);
 }
 
 MemoryDockWidget *MainWindow::addNewMemoryWidget(MemoryWidgetType type, RVA address,
@@ -1670,9 +1672,7 @@ void MainWindow::on_actionForward_triggered()
 
 void MainWindow::on_core_seekChanged(RVA addr, CutterCore::SeekHistoryType type)
 {
-    if (type == CutterCore::SeekHistoryType::Undo || type == CutterCore::SeekHistoryType::Redo) {
-        this->showAddress(addr);
-    }
+    this->showAddress(addr);
 }
 
 void MainWindow::on_actionDisasAdd_comment_triggered()

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -203,6 +203,7 @@ void MainWindow::initUI()
 
     connect(core, &CutterCore::showMemoryWidgetRequested, this,
             static_cast<void (MainWindow::*)()>(&MainWindow::showMemoryWidget));
+    connect(core, &CutterCore::showAddressRequested, this, &MainWindow::showAddress);
 
     connect(core, &CutterCore::showTypeRequested, typesDock, [this](const QString &typeName) {
         typesDock->toggleDockWidget(true);
@@ -1020,6 +1021,27 @@ void MainWindow::showMemoryWidget(MemoryWidgetType type)
     memoryDockWidget->raiseMemoryWidget();
 }
 
+MemoryDockWidget *MainWindow::getOrCreateMemoryWidget(MemoryWidgetType type, RVA address,
+                                                      bool synchronized)
+{
+    for (auto &dock : dockWidgets) {
+        if (auto memoryWidget = qobject_cast<MemoryDockWidget *>(dock)) {
+            if (memoryWidget->getType() == type
+                && memoryWidget->getSeekable()->isSynchronized() == synchronized) {
+                if (address != RVA_INVALID) {
+                    memoryWidget->getSeekable()->seek(address);
+                }
+                return memoryWidget;
+            }
+        }
+    }
+
+    if (address == RVA_INVALID) {
+        address = Core()->getOffset();
+    }
+    return addNewMemoryWidget(type, address, synchronized);
+}
+
 QMenu *MainWindow::createShowInMenu(QWidget *parent, RVA address, AddressTypeHint addressType)
 {
     QMenu *menu = new QMenu(parent);
@@ -1082,6 +1104,40 @@ void MainWindow::setCurrentMemoryWidget(MemoryDockWidget *memoryWidget)
 MemoryDockWidget *MainWindow::getLastMemoryWidget()
 {
     return lastMemoryWidget;
+}
+
+void MainWindow::showAddress(RVA addr)
+{
+    AddressTypeHint addressType = core->getAddressType(addr);
+
+    if (addressType == AddressTypeHint::Unknown) {
+        if (lastMemoryWidget) {
+            lastMemoryWidget->getSeekable()->seek(addr);
+            lastMemoryWidget->tryRaiseMemoryWidget();
+            setCurrentMemoryWidget(lastMemoryWidget);
+            return;
+        }
+
+        addressType = AddressTypeHint::Code;
+    }
+
+    MemoryWidgetType targetType;
+    switch (addressType) {
+    case AddressTypeHint::Function:
+        targetType = MemoryWidgetType::Graph;
+        break;
+    case AddressTypeHint::Code:
+        targetType = MemoryWidgetType::Disassembly;
+        break;
+    case AddressTypeHint::Data:
+    default:
+        targetType = MemoryWidgetType::Hexdump;
+        break;
+    }
+
+    auto memoryWidget = getOrCreateMemoryWidget(targetType, addr, true);
+    memoryWidget->tryRaiseMemoryWidget();
+    setCurrentMemoryWidget(memoryWidget);
 }
 
 MemoryDockWidget *MainWindow::addNewMemoryWidget(MemoryWidgetType type, RVA address,

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1111,29 +1111,13 @@ void MainWindow::showAddress(RVA addr)
 {
     AddressTypeHint addressType = core->getAddressType(addr);
 
-    if (addressType == AddressTypeHint::Unknown) {
-        if (lastMemoryWidget) {
-            lastMemoryWidget->getSeekable()->seek(addr);
-            lastMemoryWidget->tryRaiseMemoryWidget();
-            setCurrentMemoryWidget(lastMemoryWidget);
-            return;
-        }
-
-        addressType = AddressTypeHint::Code;
-    }
-
     MemoryWidgetType targetType;
-    switch (addressType) {
-    case AddressTypeHint::Function:
-        targetType = MemoryWidgetType::Graph;
-        break;
-    case AddressTypeHint::Code:
-        targetType = MemoryWidgetType::Disassembly;
-        break;
-    case AddressTypeHint::Data:
-    default:
+    if (addressType == AddressTypeHint::Data) {
         targetType = MemoryWidgetType::Hexdump;
-        break;
+    } else if (addressType == AddressTypeHint::Function) {
+        targetType = MemoryWidgetType::Graph;
+    } else {
+        targetType = MemoryWidgetType::Disassembly;
     }
 
     auto memoryWidget = getOrCreateMemoryWidget(targetType, addr, true);

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -204,7 +204,6 @@ void MainWindow::initUI()
     connect(core, &CutterCore::showMemoryWidgetRequested, this,
             static_cast<void (MainWindow::*)()>(&MainWindow::showMemoryWidget));
     connect(core, &CutterCore::showAddressRequested, this, &MainWindow::showAddress);
-    connect(core, &CutterCore::seekChanged, this, &MainWindow::on_core_seekChanged);
 
     connect(core, &CutterCore::showTypeRequested, typesDock, [this](const QString &typeName) {
         typesDock->toggleDockWidget(true);
@@ -1668,11 +1667,6 @@ void MainWindow::on_actionBackward_triggered()
 void MainWindow::on_actionForward_triggered()
 {
     core->seekNext();
-}
-
-void MainWindow::on_core_seekChanged(RVA addr, CutterCore::SeekHistoryType type)
-{
-    this->showAddress(addr);
 }
 
 void MainWindow::on_actionDisasAdd_comment_triggered()

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -648,9 +648,6 @@ bool MainWindow::openProject(const QString &file)
 
 void MainWindow::finalizeOpen()
 {
-    widgetHistoryList.clear();
-    widgetHistoryIndex = -1;
-
     core->getRegs();
     core->updateSeek();
     refreshAll();
@@ -693,20 +690,17 @@ void MainWindow::finalizeOpen()
             graphContainsFunc = !graphWidget->getGraphView()->getBlocks().empty();
             if (graphContainsFunc) {
                 dockWidget->raiseMemoryWidget();
-                recordFirstWidget(graphWidget);
                 break;
             }
         }
         auto disasmWidget = qobject_cast<DisassemblyWidget *>(dockWidget);
         if (disasmWidget && dockWidget->isVisibleToUser()) {
             disasmWidget->raiseMemoryWidget();
-            recordFirstWidget(disasmWidget);
             // continue looping in case there is a graph widget
         }
         auto decompilerWidget = qobject_cast<DecompilerWidget *>(dockWidget);
         if (decompilerWidget && dockWidget->isVisibleToUser()) {
             decompilerWidget->raiseMemoryWidget();
-            recordFirstWidget(decompilerWidget);
             // continue looping in case there is a graph widget
         }
     }
@@ -1115,25 +1109,17 @@ MemoryDockWidget *MainWindow::getLastMemoryWidget()
 
 void MainWindow::showAddress(RVA addr)
 {
+    AddressTypeHint addressType = core->getAddressType(addr);
+
     MemoryWidgetType targetType;
-    if (lastMemoryWidget != nullptr && lastMemoryWidget->getType() == MemoryWidgetType::Graph) {
-        AddressTypeHint addressType = core->getAddressType(addr);
-
-        if (addressType == AddressTypeHint::Data) {
-            targetType = MemoryWidgetType::Hexdump;
-        } else if (addressType == AddressTypeHint::Function) {
-            targetType = MemoryWidgetType::Graph;
-        } else {
-            targetType = MemoryWidgetType::Disassembly;
-        }
+    if (addressType == AddressTypeHint::Data) {
+        targetType = MemoryWidgetType::Hexdump;
+    } else if (addressType == AddressTypeHint::Function) {
+        targetType = MemoryWidgetType::Graph;
     } else {
-        targetType = lastMemoryWidget ? lastMemoryWidget->getType() : MemoryWidgetType::Disassembly;
+        targetType = MemoryWidgetType::Disassembly;
     }
-    showAddressWithTargetType(addr, targetType);
-}
 
-void MainWindow::showAddressWithTargetType(RVA addr, MemoryWidgetType targetType)
-{
     auto memoryWidget = getOrCreateMemoryWidget(targetType, addr, true);
     memoryWidget->tryRaiseMemoryWidget();
     setCurrentMemoryWidget(memoryWidget);
@@ -1329,8 +1315,11 @@ void MainWindow::addWidget(CutterDockWidget *widget)
 
 void MainWindow::addMemoryDockWidget(MemoryDockWidget *widget)
 {
-    connect(widget, &CutterDockWidget::becameVisibleToUser, this,
-            [this, widget]() { setCurrentMemoryWidget(widget); });
+    connect(widget, &QDockWidget::visibilityChanged, this, [this, widget](bool visibility) {
+        if (visibility) {
+            setCurrentMemoryWidget(widget);
+        }
+    });
 }
 
 void MainWindow::removeWidget(CutterDockWidget *widget)
@@ -1679,50 +1668,10 @@ void MainWindow::on_actionForward_triggered()
     core->seekNext();
 }
 
-void MainWindow::recordFirstWidget(MemoryDockWidget *widget)
-{
-    if (!widget) {
-        return;
-    }
-    if (widgetHistoryList.isEmpty()) {
-        widgetHistoryList.append(widget->getType());
-        widgetHistoryIndex = 0;
-    } else {
-        widgetHistoryList[0] = widget->getType();
-    }
-}
-
 void MainWindow::on_core_seekChanged(RVA addr, CutterCore::SeekHistoryType type)
 {
-    if (!widgetHistoryList.isEmpty() && type == CutterCore::SeekHistoryType::New) {
+    if (type == CutterCore::SeekHistoryType::Undo || type == CutterCore::SeekHistoryType::Redo) {
         this->showAddress(addr);
-
-        if (lastMemoryWidget != nullptr) {
-
-            MemoryWidgetType newType = lastMemoryWidget->getType();
-            // Drop redo history
-            if (widgetHistoryIndex >= 0 && widgetHistoryIndex < widgetHistoryList.size() - 1) {
-                widgetHistoryList.erase(widgetHistoryList.begin() + widgetHistoryIndex + 1,
-                                        widgetHistoryList.end());
-            }
-
-            widgetHistoryList.append(newType);
-            widgetHistoryIndex = widgetHistoryList.size() - 1;
-        }
-    } else if (type == CutterCore::SeekHistoryType::Undo) {
-        if (widgetHistoryIndex > 0) {
-            widgetHistoryIndex--;
-            this->showAddressWithTargetType(addr, widgetHistoryList[widgetHistoryIndex]);
-        } else {
-            this->showAddress(addr);
-        }
-    } else if (type == CutterCore::SeekHistoryType::Redo) {
-        if (widgetHistoryIndex >= 0 && widgetHistoryIndex < widgetHistoryList.size() - 1) {
-            widgetHistoryIndex++;
-            this->showAddressWithTargetType(addr, widgetHistoryList[widgetHistoryIndex]);
-        } else {
-            this->showAddress(addr);
-        }
     }
 }
 

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -648,6 +648,9 @@ bool MainWindow::openProject(const QString &file)
 
 void MainWindow::finalizeOpen()
 {
+    widgetHistoryList.clear();
+    widgetHistoryIndex = -1;
+
     core->getRegs();
     core->updateSeek();
     refreshAll();
@@ -690,17 +693,20 @@ void MainWindow::finalizeOpen()
             graphContainsFunc = !graphWidget->getGraphView()->getBlocks().empty();
             if (graphContainsFunc) {
                 dockWidget->raiseMemoryWidget();
+                recordFirstWidget(graphWidget);
                 break;
             }
         }
         auto disasmWidget = qobject_cast<DisassemblyWidget *>(dockWidget);
         if (disasmWidget && dockWidget->isVisibleToUser()) {
             disasmWidget->raiseMemoryWidget();
+            recordFirstWidget(disasmWidget);
             // continue looping in case there is a graph widget
         }
         auto decompilerWidget = qobject_cast<DecompilerWidget *>(dockWidget);
         if (decompilerWidget && dockWidget->isVisibleToUser()) {
             decompilerWidget->raiseMemoryWidget();
+            recordFirstWidget(decompilerWidget);
             // continue looping in case there is a graph widget
         }
     }
@@ -1109,17 +1115,25 @@ MemoryDockWidget *MainWindow::getLastMemoryWidget()
 
 void MainWindow::showAddress(RVA addr)
 {
-    AddressTypeHint addressType = core->getAddressType(addr);
-
     MemoryWidgetType targetType;
-    if (addressType == AddressTypeHint::Data) {
-        targetType = MemoryWidgetType::Hexdump;
-    } else if (addressType == AddressTypeHint::Function) {
-        targetType = MemoryWidgetType::Graph;
-    } else {
-        targetType = MemoryWidgetType::Disassembly;
-    }
+    if (lastMemoryWidget != nullptr && lastMemoryWidget->getType() == MemoryWidgetType::Graph) {
+        AddressTypeHint addressType = core->getAddressType(addr);
 
+        if (addressType == AddressTypeHint::Data) {
+            targetType = MemoryWidgetType::Hexdump;
+        } else if (addressType == AddressTypeHint::Function) {
+            targetType = MemoryWidgetType::Graph;
+        } else {
+            targetType = MemoryWidgetType::Disassembly;
+        }
+    } else {
+        targetType = lastMemoryWidget ? lastMemoryWidget->getType() : MemoryWidgetType::Disassembly;
+    }
+    showAddressWithTargetType(addr, targetType);
+}
+
+void MainWindow::showAddressWithTargetType(RVA addr, MemoryWidgetType targetType)
+{
     auto memoryWidget = getOrCreateMemoryWidget(targetType, addr, true);
     memoryWidget->tryRaiseMemoryWidget();
     setCurrentMemoryWidget(memoryWidget);
@@ -1315,11 +1329,8 @@ void MainWindow::addWidget(CutterDockWidget *widget)
 
 void MainWindow::addMemoryDockWidget(MemoryDockWidget *widget)
 {
-    connect(widget, &QDockWidget::visibilityChanged, this, [this, widget](bool visibility) {
-        if (visibility) {
-            setCurrentMemoryWidget(widget);
-        }
-    });
+    connect(widget, &CutterDockWidget::becameVisibleToUser, this,
+            [this, widget]() { setCurrentMemoryWidget(widget); });
 }
 
 void MainWindow::removeWidget(CutterDockWidget *widget)
@@ -1668,10 +1679,50 @@ void MainWindow::on_actionForward_triggered()
     core->seekNext();
 }
 
+void MainWindow::recordFirstWidget(MemoryDockWidget *widget)
+{
+    if (!widget) {
+        return;
+    }
+    if (widgetHistoryList.isEmpty()) {
+        widgetHistoryList.append(widget->getType());
+        widgetHistoryIndex = 0;
+    } else {
+        widgetHistoryList[0] = widget->getType();
+    }
+}
+
 void MainWindow::on_core_seekChanged(RVA addr, CutterCore::SeekHistoryType type)
 {
-    if (type == CutterCore::SeekHistoryType::Undo || type == CutterCore::SeekHistoryType::Redo) {
+    if (!widgetHistoryList.isEmpty() && type == CutterCore::SeekHistoryType::New) {
         this->showAddress(addr);
+
+        if (lastMemoryWidget != nullptr) {
+
+            MemoryWidgetType newType = lastMemoryWidget->getType();
+            // Drop redo history
+            if (widgetHistoryIndex >= 0 && widgetHistoryIndex < widgetHistoryList.size() - 1) {
+                widgetHistoryList.erase(widgetHistoryList.begin() + widgetHistoryIndex + 1,
+                                        widgetHistoryList.end());
+            }
+
+            widgetHistoryList.append(newType);
+            widgetHistoryIndex = widgetHistoryList.size() - 1;
+        }
+    } else if (type == CutterCore::SeekHistoryType::Undo) {
+        if (widgetHistoryIndex > 0) {
+            widgetHistoryIndex--;
+            this->showAddressWithTargetType(addr, widgetHistoryList[widgetHistoryIndex]);
+        } else {
+            this->showAddress(addr);
+        }
+    } else if (type == CutterCore::SeekHistoryType::Redo) {
+        if (widgetHistoryIndex >= 0 && widgetHistoryIndex < widgetHistoryList.size() - 1) {
+            widgetHistoryIndex++;
+            this->showAddressWithTargetType(addr, widgetHistoryList[widgetHistoryIndex]);
+        } else {
+            this->showAddress(addr);
+        }
     }
 }
 

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -204,6 +204,7 @@ void MainWindow::initUI()
     connect(core, &CutterCore::showMemoryWidgetRequested, this,
             static_cast<void (MainWindow::*)()>(&MainWindow::showMemoryWidget));
     connect(core, &CutterCore::showAddressRequested, this, &MainWindow::showAddress);
+    connect(core, &CutterCore::seekChanged, this, &MainWindow::on_core_seekChanged);
 
     connect(core, &CutterCore::showTypeRequested, typesDock, [this](const QString &typeName) {
         typesDock->toggleDockWidget(true);
@@ -1681,6 +1682,13 @@ void MainWindow::on_actionBackward_triggered()
 void MainWindow::on_actionForward_triggered()
 {
     core->seekNext();
+}
+
+void MainWindow::on_core_seekChanged(RVA addr, CutterCore::SeekHistoryType type)
+{
+    if (type == CutterCore::SeekHistoryType::Undo || type == CutterCore::SeekHistoryType::Redo) {
+        this->showAddress(addr);
+    }
 }
 
 void MainWindow::on_actionDisasAdd_comment_triggered()

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1024,6 +1024,10 @@ void MainWindow::showMemoryWidget(MemoryWidgetType type)
 MemoryDockWidget *MainWindow::getOrCreateMemoryWidget(MemoryWidgetType type, RVA address,
                                                       bool synchronized)
 {
+    if (address == RVA_INVALID) {
+        address = Core()->getOffset();
+    }
+
     for (auto &dock : dockWidgets) {
         if (auto memoryWidget = qobject_cast<MemoryDockWidget *>(dock)) {
             if (memoryWidget->getType() == type
@@ -1036,9 +1040,6 @@ MemoryDockWidget *MainWindow::getOrCreateMemoryWidget(MemoryWidgetType type, RVA
         }
     }
 
-    if (address == RVA_INVALID) {
-        address = Core()->getOffset();
-    }
     return addNewMemoryWidget(type, address, synchronized);
 }
 

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -116,11 +116,12 @@ public:
     QString getUniqueObjectName(const QString &widgetType) const;
     void showMemoryWidget();
     void showMemoryWidget(MemoryWidgetType type);
-    enum class AddressTypeHint { Function, Data, Unknown };
     QMenu *createShowInMenu(QWidget *parent, RVA address,
                             AddressTypeHint addressType = AddressTypeHint::Unknown);
     void setCurrentMemoryWidget(MemoryDockWidget *memoryWidget);
     MemoryDockWidget *getLastMemoryWidget();
+    MemoryDockWidget *getOrCreateMemoryWidget(MemoryWidgetType type, RVA address = RVA_INVALID,
+                                              bool synchronized = true);
 
     /* Context menu plugins */
     enum class ContextMenuType { Disassembly, Addressable };
@@ -133,6 +134,7 @@ public:
 
 public slots:
     void finalizeOpen();
+    void showAddress(RVA addr);
 
     void refreshAll();
     void seekToFunctionLastInstruction();

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -14,6 +14,7 @@
 
 #include <QMainWindow>
 #include <QList>
+#include <QStack>
 
 class CutterCore;
 class Omnibar;
@@ -135,6 +136,7 @@ public:
 public slots:
     void finalizeOpen();
     void showAddress(RVA addr);
+    void showAddressWithTargetType(RVA addr, MemoryWidgetType targetType);
 
     void refreshAll();
     void seekToFunctionLastInstruction();
@@ -313,6 +315,8 @@ private:
 
     void setOverviewData();
     bool isOverviewActive();
+
+    void recordFirstWidget(MemoryDockWidget *widget);
     /**
      * @brief Check if a widget is one of debug specific dock widgets.
      * @param dock
@@ -322,6 +326,9 @@ private:
     bool isExtraMemoryWidget(QDockWidget *dock) const;
 
     MemoryWidgetType getMemoryWidgetTypeToRestore();
+
+    QList<MemoryWidgetType> widgetHistoryList;
+    int widgetHistoryIndex = -1;
 
     /**
      * @brief Map from a widget type (e.g. DisassemblyWidget::getWidgetType()) to the respective

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -14,7 +14,6 @@
 
 #include <QMainWindow>
 #include <QList>
-#include <QStack>
 
 class CutterCore;
 class Omnibar;
@@ -136,7 +135,6 @@ public:
 public slots:
     void finalizeOpen();
     void showAddress(RVA addr);
-    void showAddressWithTargetType(RVA addr, MemoryWidgetType targetType);
 
     void refreshAll();
     void seekToFunctionLastInstruction();
@@ -315,8 +313,6 @@ private:
 
     void setOverviewData();
     bool isOverviewActive();
-
-    void recordFirstWidget(MemoryDockWidget *widget);
     /**
      * @brief Check if a widget is one of debug specific dock widgets.
      * @param dock
@@ -326,9 +322,6 @@ private:
     bool isExtraMemoryWidget(QDockWidget *dock) const;
 
     MemoryWidgetType getMemoryWidgetTypeToRestore();
-
-    QList<MemoryWidgetType> widgetHistoryList;
-    int widgetHistoryIndex = -1;
 
     /**
      * @brief Map from a widget type (e.g. DisassemblyWidget::getWidgetType()) to the respective

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -158,6 +158,7 @@ private slots:
     void on_actionBaseFind_triggered();
     void on_actionAbout_triggered();
     void on_actionIssue_triggered();
+    void on_core_seekChanged(RVA addr, CutterCore::SeekHistoryType type);
     void documentationClicked();
     void addExtraGraph();
     void addExtraHexdump();

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -158,7 +158,6 @@ private slots:
     void on_actionBaseFind_triggered();
     void on_actionAbout_triggered();
     void on_actionIssue_triggered();
-    void on_core_seekChanged(RVA addr, CutterCore::SeekHistoryType type);
     void documentationClicked();
     void addExtraGraph();
     void addExtraHexdump();

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -575,7 +575,7 @@ void DecompilerContextMenu::updateTargetMenuActions()
         if (annotationHere->type == RZ_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE
             || annotationHere->type == RZ_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE) {
             menu = mainWindow->createShowInMenu(this, annotationHere->reference.offset,
-                                                MainWindow::AddressTypeHint::Data);
+                                                AddressTypeHint::Data);
             RVA var_addr = annotationHere->reference.offset;
             RzFlagItem *flagDetails = rz_flag_get_i(core->flags, var_addr);
             if (flagDetails) {
@@ -585,7 +585,7 @@ void DecompilerContextMenu::updateTargetMenuActions()
             }
         } else if (annotationHere->type == RZ_CODE_ANNOTATION_TYPE_FUNCTION_NAME) {
             menu = mainWindow->createShowInMenu(this, annotationHere->reference.offset,
-                                                MainWindow::AddressTypeHint::Function);
+                                                AddressTypeHint::Function);
             name = tr("%1 (%2)").arg(QString(annotationHere->reference.name),
                                      RzAddressString(annotationHere->reference.offset));
         }

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -710,10 +710,6 @@ QString DisassemblyWidget::getWindowTitle() const
 
 void DisassemblyWidget::on_seekChanged(RVA offset, CutterCore::SeekHistoryType type)
 {
-    if (!isVisibleToUser()) {
-        return;
-    }
-
     if (type == CutterCore::SeekHistoryType::New) {
         // Erase previous history past this point.
         if (topOffsetHistory.size() > topOffsetHistoryPos + 1) {

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -710,6 +710,10 @@ QString DisassemblyWidget::getWindowTitle() const
 
 void DisassemblyWidget::on_seekChanged(RVA offset, CutterCore::SeekHistoryType type)
 {
+    if (!isVisibleToUser()) {
+        return;
+    }
+
     if (type == CutterCore::SeekHistoryType::New) {
         // Erase previous history past this point.
         if (topOffsetHistory.size() > topOffsetHistoryPos + 1) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Automatically switches to the most appropriate widget (Graph, Disassembly, or Hexdump) based on the target address's content type. This prevents the "empty graph" issue in the Graph view.

Seek to a CODE section:
[Screencast_20260331_001002.webm](https://github.com/user-attachments/assets/26cb67cf-0756-409d-8380-9f1b6950f50f)

Seek to a DATA section:
[Screencast_20260331_001148.webm](https://github.com/user-attachments/assets/4edde086-4f39-4a20-b5c3-dbb299d1fe2a)

**Test plan (required)**

- Open Cutter with any binary and open a Graph widget
- Seek to a function, verify that the Graph widget is focused or opened.
- Seek to a string or a data variable, verify that the Hexdump widget is opened/raised.
- Seek to an address in an executable section that is not part of a function, verify that the Disassembly widget is opened/raised.
- Navigate between a function and a string, then click the Back and Forward buttons in the toolbar, verify that the active widget switches automatically between Graph and Hexdump.

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**
closes #1839
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
