### PR TITLE
PluginsManager: handle type index case for shiboken6

### DIFF
--- a/src/plugins/PluginManager.cpp
+++ b/src/plugins/PluginManager.cpp
@@ -215,10 +215,12 @@ CutterPlugin *PluginManager::loadPythonPlugin(const char *moduleName)
     }
 
     PythonToCppFunc pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(
-#    if QT_VERSION < QT_VERSION_CHECK(6, 2, 0)
+#    if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
             reinterpret_cast<SbkObjectType *>(SbkCutterBindingsTypes[SBK_CUTTERPLUGIN_IDX]),
+#    elif QT_VERSION < QT_VERSION_CHECK(6, 2, 0)
+            reinterpret_cast<SbkObjectType *>(SbkCutterBindingsTypes[SBK_CutterPlugin_IDX]),
 #    else
-            reinterpret_cast<PyTypeObject **>(SbkCutterBindingsTypeStructs)[SBK_CUTTERPLUGIN_IDX],
+            reinterpret_cast<PyTypeObject **>(SbkCutterBindingsTypeStructs)[SBK_CutterPlugin_IDX],
 #    endif
             pluginObject);
     if (!pythonToCpp) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Fixes the case mismatch for `SBK_CUTTERPLUGIN_IDX`. Seems like it was written for old shiboken2 version since the newer shiboken6 version does not make all type indices name uppercase by default   

Tested against
Shiboken6 and Qt6 latest
```
shiboken v6.11.0
PySide 6.11.0
Qt version 6.11.0
```

Shiboken6 and Qt6  
```
shiboken v6.10.3
PySide 6.10.3
Qt version 6.10.2
```

Shiboken2 and Qt5
```
shiboken v5.15.18
PySide 5.15.18
Qt version 5.15.17
```

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

* Make sure shiboken6 and Pyside6 are installed and you're using Qt6
* Clone this PR
* configure cmake by enabling python bindings
    - `cmake .. -DCUTTER_ENABLE_PYTHON=ON -DCUTTER_ENABLE_PYTHON_BINDINGS=ON`
    - might need to manually specify `-DShiboken6_DIR` ,  `-DShiboken6Tools_DIR` and `PySide6_DIR` if installed through pip
* Compile
* Observe it should compile and run without any erros

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3599 