### PR TITLE
Fix portable rizin system themes loading

### DIFF
--- a/src/common/ColorThemeWorker.cpp
+++ b/src/common/ColorThemeWorker.cpp
@@ -56,8 +56,8 @@ ColorThemeWorker::ColorThemeWorker(QObject *parent) : QObject(parent)
         QDir().mkpath(customRzThemesLocationPath);
     }
 
-    RzPath *sysPath = rz_path_new();
-    const char *themeDir = rz_path_system(sysPath, RZ_THEMES);
+    RzCoreLocked core = Core()->lock();
+    const char *themeDir = rz_path_system(core->sys_path, RZ_THEMES);
     const QDir currDir { themeDir };
     if (currDir.exists()) {
         standardRzThemesLocationPath = currDir.absolutePath();
@@ -67,7 +67,6 @@ ColorThemeWorker::ColorThemeWorker(QObject *parent) : QObject(parent)
                                  "Most likely, Rizin is not properly installed.")
                                       .arg(currDir.path()));
     }
-    rz_path_free(sysPath);
 }
 
 QColor ColorThemeWorker::mergeColors(const QColor &upper, const QColor &lower) const


### PR DESCRIPTION


<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else. **No code was generated, but Claude Opus 4.8 was used to scan the history for when the regression was introduced and how the portability originally was supposed to work. Fix was implemented by hand.**


**Detailed description**

Regression introduced in 4e53fd64 for the macOS application bundle: rz_path_set_prefix() is only applied to the core-global RzPath instance, but the ColorThemeWorker created its own instance, ignoring this setting.
This led to the message box saying "The Rizin standard themes could not be found in..." on startup.

Do not merge befor I have not tested the builds.

**Test plan (required)**

macOS builds produced by the CI should not show any error on startup and load themes properly.