### PR TITLE
Bundle z.dll in Windows ZIP package for rz-ghidra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,7 +538,7 @@ jobs:
           -DCUTTER_ENABLE_DEPENDENCY_DOWNLOADS=ON ^
           -DCMAKE_PREFIX_PATH="%CUTTER_DEPS%\pyside" ^
           -DCPACK_PACKAGE_FILE_NAME=%PACKAGE_NAME% ^
-          -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake ^
+          -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%/scripts/buildsystems/vcpkg.cmake ^
           -G Ninja ^
           ..
         cmake --build . --config Release

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -217,6 +217,16 @@ if(CUTTER_PACKAGE_RZ_GHIDRA)
 	else()
 		set (GHIDRA_OPTIONS "-DCUTTER_INSTALL_PLUGDIR=\${CMAKE_INSTALL_PREFIX}/share/rizin/cutter/plugins/native")
 	endif()
+	
+	if(WIN32)
+        if(EXISTS "$ENV{VCPKG_INSTALLATION_ROOT}/packages/zlib_x64-windows/bin/z.dll")
+            install(FILES "$ENV{VCPKG_INSTALLATION_ROOT}/packages/zlib_x64-windows/bin/z.dll" DESTINATION .)
+            message(STATUS "Found z.dll for rz-ghidra")
+        else()
+            message(WARNING "z.dll was not found at the expected vcpkg path. rz-ghidra might not load properly")
+        endif()
+    endif()
+
 	install(CODE "
 		execute_process(
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rz-ghidra-prefix/src/rz-ghidra-build


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Adds zlib (z.dll) in the final package zip for windows

Also changed `C:/vcpkg` to `%VCPKG_INSTALLATION_ROOT%` 

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

* Download the package/artifact from windows runner, once CI passes
* Run it
* Observe "Ghidra" option is available in decompiler tab and works fine
* Also if ran from cmd/powershell observe there is no error/warning about "module not found in core_ghidra.dll"

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
