### PR TITLE
cmake: add CUTTER_ENABLE_TRANSLATIONS option to skip translation build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CUTTER_EXTRA_PLUGIN_DIRS "" CACHE STRING "List of addition plugin locations"
 option(CUTTER_ENABLE_DEPENDENCY_DOWNLOADS "Enable downloading of dependencies. Setting to OFF doesn't affect any downloads done by rizin build." OFF)
 option(CUTTER_ENABLE_PACKAGING "Enable building platform-specific packages for distributing" OFF)
 option(CUTTER_ENABLE_SIGDB "Downloads and installs sigdb (only available when CUTTER_USE_BUNDLED_RIZIN=ON)." OFF)
+option(CUTTER_ENABLE_TRANSLATIONS "Build and install translation files" ON)
 option(CUTTER_PACKAGE_DEPENDENCIES "During install step include the third party dependencies." OFF)
 option(CUTTER_PACKAGE_RZ_GHIDRA "Compile and install rz-ghidra during install step." OFF)
 option(CUTTER_PACKAGE_RZ_LIBSWIFT "Compile and install rz-libswift demangler during the install step." OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -613,7 +613,9 @@ if(CUTTER_ENABLE_PACKAGING)
     target_compile_definitions(Cutter PRIVATE CUTTER_ENABLE_PACKAGING)
 endif()
 
-include(Translations)
+if(CUTTER_ENABLE_TRANSLATIONS)
+    include(Translations)
+endif()
 
 # Install files
 install(TARGETS Cutter


### PR DESCRIPTION
## Summary

Adds a CMake option `CUTTER_ENABLE_TRANSLATIONS` (default `ON`) to `cmake/Translations.cmake` that allows skipping the translation file build and install step.

## Motivation

When building from a GitHub commit/tag archive rather than a full git clone, the `.ts` source files are not present (they live in the repository but are not included in the archive tarballs). Without this option, CMake fails at install time with:

```
file INSTALL cannot find ".../translations/cutter_ar_SA.qm": No such file or directory
```

Passing `-DCUTTER_ENABLE_TRANSLATIONS=OFF` avoids the issue cleanly without requiring any other changes.

## Test plan

- [ ] Build with `-DCUTTER_ENABLE_TRANSLATIONS=ON` (default) — translations build as before
- [ ] Build with `-DCUTTER_ENABLE_TRANSLATIONS=OFF` — translation step is skipped, install succeeds