### PR TITLE
Add Export disassembly of current function action

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1429,6 +1429,13 @@ RVA CutterCore::getFunctionEnd(RVA addr)
     return fcn ? fcn->addr : RVA_INVALID;
 }
 
+ut64 CutterCore::getFunctionSize(RVA addr)
+{
+    const auto core = Core()->lock();
+    RzAnalysisFunction *fcn = Core()->functionIn(addr);
+    return fcn ? rz_analysis_function_linear_size(fcn) : 0;
+}
+
 RVA CutterCore::getLastFunctionInstruction(RVA addr)
 {
     const auto core = Core()->lock();

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1422,6 +1422,13 @@ RVA CutterCore::getFunctionStart(RVA addr)
     return fcn ? fcn->addr : RVA_INVALID;
 }
 
+RVA CutterCore::getFunctionMinAddr(RVA addr)
+{
+    const auto core = Core()->lock();
+    const RzAnalysisFunction *fcn = Core()->functionIn(addr);
+    return fcn ? rz_analysis_function_min_addr(const_cast<RzAnalysisFunction *>(fcn)) : RVA_INVALID;
+}
+
 RVA CutterCore::getFunctionEnd(RVA addr)
 {
     const auto core = Core()->lock();

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -254,6 +254,12 @@ public:
      */
     RVA getFunctionEnd(RVA addr);
     /**
+     * @brief gets the linear size of a function at a given address
+     * @param addr - an address which belongs to a function
+     * @returns if function exists, return its linear size in bytes. Otherwise return 0
+     */
+    ut64 getFunctionSize(RVA addr);
+    /**
      * @brief finds the last instruction of a function in a given address
      * @param addr - an address which belongs to a function
      * @returns if function exists, return the address of its last instruction. Otherwise return

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -248,6 +248,12 @@ public:
      */
     RVA getFunctionStart(RVA addr);
     /**
+     * @brief finds the minimum address of a function in a given address
+     * @param addr - an address which belongs to a function
+     * @returns if function exists, return its minimum address. Otherwise return RVA_INVALID
+     */
+    RVA getFunctionMinAddr(RVA addr);
+    /**
      * @brief finds the end address of a function in a given address
      * @param addr - an address which belongs to a function
      * @returns if function exists, return its end address. Otherwise return RVA_INVALID

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1814,15 +1814,15 @@ void MainWindow::exportDisassembly(RVA funcStart)
     }
 
     const QString disassembly = Core()->getFunctionExecOut(
-            [size](RzCore *core) {
+            [funcStart, size](RzCore *core) {
                 ut8 *buf = static_cast<ut8 *>(malloc(size));
                 if (!buf) {
                     return false;
                 }
-                rz_io_read_at_mapped(core->io, core->offset, buf, size);
+                rz_io_read_at_mapped(core->io, funcStart, buf, size);
                 RzCoreDisasmOptions options = {};
                 options.cbytes = 1;
-                rz_core_print_disasm(core, core->offset, buf, size, 0, nullptr, &options);
+                rz_core_print_disasm(core, funcStart, buf, size, 0, nullptr, &options);
                 free(buf);
                 return true;
             },

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1785,9 +1785,8 @@ void MainWindow::onActionImportPdbTriggered()
     }
 }
 
-void MainWindow::onActionExportDisassemblyTriggered()
+void MainWindow::exportDisassembly(RVA funcStart)
 {
-    const RVA funcStart = Core()->getFunctionStart(Core()->getOffset());
     if (funcStart == RVA_INVALID) {
         qWarning() << "No function at current offset.";
         return;
@@ -1808,14 +1807,34 @@ void MainWindow::onActionExportDisassemblyTriggered()
         return;
     }
 
-    TempConfig tempConfig;
-    tempConfig.set("scr.color", 0);
-
     const ut64 size = Core()->getFunctionSize(funcStart);
-    const QString disassembly = Core()->cmdRawAt(QString("pD %1").arg(size), funcStart);
+    if (size == 0) {
+        qWarning() << "Function size is 0.";
+        return;
+    }
+
+    const QString disassembly = Core()->getFunctionExecOut(
+            [size](RzCore *core) {
+                ut8 *buf = static_cast<ut8 *>(malloc(size));
+                if (!buf) {
+                    return false;
+                }
+                rz_io_read_at_mapped(core->io, core->offset, buf, size);
+                RzCoreDisasmOptions options = {};
+                options.cbytes = 1;
+                rz_core_print_disasm(core, core->offset, buf, size, 0, nullptr, &options);
+                free(buf);
+                return true;
+            },
+            funcStart);
 
     QTextStream fileOut(&file);
     fileOut << disassembly;
+}
+
+void MainWindow::onActionExportDisassemblyTriggered()
+{
+    exportDisassembly(Core()->getFunctionStart(Core()->getOffset()));
 }
 
 void MainWindow::onActionExportAsCodeTriggered()

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -390,6 +390,8 @@ void MainWindow::initToolBar()
             &MainWindow::onActionImportPdbTriggered);
     connect(ui->actionExportAsCode, &QAction::triggered, this,
             &MainWindow::onActionExportAsCodeTriggered);
+    connect(ui->actionExportDisassembly, &QAction::triggered, this,
+            &MainWindow::onActionExportDisassemblyTriggered);
     connect(ui->actionApplySigFromFile, &QAction::triggered, this,
             &MainWindow::onActionApplySigFromFileTriggered);
     connect(ui->actionCreateNewSig, &QAction::triggered, this,
@@ -1781,6 +1783,38 @@ void MainWindow::onActionImportPdbTriggered()
         core->message(tr("%1 loaded.").arg(pdbFile));
         this->refreshAll();
     }
+}
+
+void MainWindow::onActionExportDisassemblyTriggered()
+{
+    const RVA funcStart = Core()->getFunctionStart(Core()->getOffset());
+    if (funcStart == RVA_INVALID) {
+        qWarning() << "No function at current offset.";
+        return;
+    }
+
+    QFileDialog dialog(this, tr("Export Disassembly"));
+    dialog.setAcceptMode(QFileDialog::AcceptSave);
+    dialog.setFileMode(QFileDialog::AnyFile);
+    dialog.setNameFilter(tr("Text file (*.txt)"));
+    dialog.setDefaultSuffix("txt");
+    if (!dialog.exec()) {
+        return;
+    }
+
+    QFile file(dialog.selectedFiles()[0]);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << tr("Can't open file");
+        return;
+    }
+
+    TempConfig tempConfig;
+    tempConfig.set("scr.color", 0);
+
+    const QString disassembly = Core()->cmdRawAt("pdf", funcStart);
+
+    QTextStream fileOut(&file);
+    fileOut << disassembly;
 }
 
 void MainWindow::onActionExportAsCodeTriggered()

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1796,8 +1796,8 @@ void MainWindow::onActionExportDisassemblyTriggered()
     QFileDialog dialog(this, tr("Export Disassembly"));
     dialog.setAcceptMode(QFileDialog::AcceptSave);
     dialog.setFileMode(QFileDialog::AnyFile);
-    dialog.setNameFilter(tr("Text file (*.txt)"));
-    dialog.setDefaultSuffix("txt");
+    dialog.setNameFilters({ tr("Assembly (*.asm *.S)"), tr("All files (*)") });
+    dialog.setDefaultSuffix("asm");
     if (!dialog.exec()) {
         return;
     }
@@ -1811,7 +1811,8 @@ void MainWindow::onActionExportDisassemblyTriggered()
     TempConfig tempConfig;
     tempConfig.set("scr.color", 0);
 
-    const QString disassembly = Core()->cmdRawAt("pdf", funcStart);
+    const ut64 size = Core()->getFunctionSize(funcStart);
+    const QString disassembly = Core()->cmdRawAt(QString("pD %1").arg(size), funcStart);
 
     QTextStream fileOut(&file);
     fileOut << disassembly;

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -1785,9 +1785,9 @@ void MainWindow::onActionImportPdbTriggered()
     }
 }
 
-void MainWindow::exportDisassembly(RVA funcStart)
+void MainWindow::exportDisassembly(RVA funcMinAddr)
 {
-    if (funcStart == RVA_INVALID) {
+    if (funcMinAddr == RVA_INVALID) {
         qWarning() << "No function at current offset.";
         return;
     }
@@ -1807,26 +1807,26 @@ void MainWindow::exportDisassembly(RVA funcStart)
         return;
     }
 
-    const ut64 size = Core()->getFunctionSize(funcStart);
+    const ut64 size = Core()->getFunctionSize(funcMinAddr);
     if (size == 0) {
         qWarning() << "Function size is 0.";
         return;
     }
 
     const QString disassembly = Core()->getFunctionExecOut(
-            [funcStart, size](RzCore *core) {
+            [funcMinAddr, size](RzCore *core) {
                 ut8 *buf = static_cast<ut8 *>(malloc(size));
                 if (!buf) {
                     return false;
                 }
-                rz_io_read_at_mapped(core->io, funcStart, buf, size);
+                rz_io_read_at_mapped(core->io, funcMinAddr, buf, size);
                 RzCoreDisasmOptions options = {};
                 options.cbytes = 1;
-                rz_core_print_disasm(core, funcStart, buf, size, 0, nullptr, &options);
+                rz_core_print_disasm(core, funcMinAddr, buf, size, 0, nullptr, &options);
                 free(buf);
                 return true;
             },
-            funcStart);
+            funcMinAddr);
 
     QTextStream fileOut(&file);
     fileOut << disassembly;
@@ -1834,7 +1834,7 @@ void MainWindow::exportDisassembly(RVA funcStart)
 
 void MainWindow::onActionExportDisassemblyTriggered()
 {
-    exportDisassembly(Core()->getFunctionStart(Core()->getOffset()));
+    exportDisassembly(Core()->getFunctionMinAddr(Core()->getOffset()));
 }
 
 void MainWindow::onActionExportAsCodeTriggered()

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -216,6 +216,8 @@ private slots:
 
     void onActionExportAsCodeTriggered();
 
+    void onActionExportDisassemblyTriggered();
+
     void onActionApplySigFromFileTriggered();
 
     void onActionCreateNewSigTriggered();

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -73,7 +73,7 @@ public:
 
     explicit MainWindow(QWidget *parent = nullptr);
 
-    void exportDisassembly(RVA funcStart);
+    void exportDisassembly(RVA funcMinAddr);
     ~MainWindow() override;
 
     void openNewFile(InitialOptions &options, bool skipOptionsDialog = false);

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -72,6 +72,8 @@ public:
     bool responsive;
 
     explicit MainWindow(QWidget *parent = nullptr);
+
+    void exportDisassembly(RVA funcStart);
     ~MainWindow() override;
 
     void openNewFile(InitialOptions &options, bool skipOptionsDialog = false);
@@ -230,6 +232,7 @@ private slots:
     bool eventFilter(QObject *object, QEvent *event) override;
     bool event(QEvent *event) override;
     void toggleDebugView();
+
     /**
      * @brief When theme changed, change icons which have a special version for the theme.
      */

--- a/src/core/MainWindow.ui
+++ b/src/core/MainWindow.ui
@@ -86,6 +86,7 @@
     <addaction name="actionSave"/>
     <addaction name="actionSaveAs"/>
     <addaction name="actionExportAsCode"/>
+    <addaction name="actionExportDisassembly"/>
     <addaction name="separator"/>
     <addaction name="actionRunScript"/>
     <addaction name="separator"/>
@@ -754,6 +755,11 @@
   <action name="actionExportAsCode">
    <property name="text">
     <string>Export as code</string>
+   </property>
+  </action>
+  <action name="actionExportDisassembly">
+   <property name="text">
+    <string>Export disassembly of current function</string>
    </property>
   </action>
   <action name="actionApplySigFromFile">

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -740,8 +740,8 @@ void DisassemblyContextMenu::exportDisassemblyTriggered()
     QFileDialog dialog(parentForDialog(), tr("Export Disassembly"));
     dialog.setAcceptMode(QFileDialog::AcceptSave);
     dialog.setFileMode(QFileDialog::AnyFile);
-    dialog.setNameFilter(tr("Text file (*.txt)"));
-    dialog.setDefaultSuffix("txt");
+    dialog.setNameFilters({ tr("Assembly (*.asm *.S)"), tr("All files (*)") });
+    dialog.setDefaultSuffix("asm");
     if (!dialog.exec()) {
         return;
     }
@@ -755,7 +755,8 @@ void DisassemblyContextMenu::exportDisassemblyTriggered()
     TempConfig tempConfig;
     tempConfig.set("scr.color", 0);
 
-    const QString disassembly = Core()->cmdRawAt("pdf", funcStart);
+    const ut64 size = Core()->getFunctionSize(funcStart);
+    const QString disassembly = Core()->cmdRawAt(QString("pD %1").arg(size), funcStart);
 
     QTextStream fileOut(&file);
     fileOut << disassembly;
@@ -1041,7 +1042,7 @@ void DisassemblyContextMenu::editFunctionTriggered()
                 rz_analysis_function_set_cc(core->analysis, fcn, newCC.constData());
             }
 
-            emit Core()->functionsChanged();
+            emit Core() -> functionsChanged();
         }
     }
 }

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -1042,7 +1042,7 @@ void DisassemblyContextMenu::editFunctionTriggered()
                 rz_analysis_function_set_cc(core->analysis, fcn, newCC.constData());
             }
 
-            emit Core() -> functionsChanged();
+            emit Core()->functionsChanged();
         }
     }
 }

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -1041,7 +1041,7 @@ void DisassemblyContextMenu::editFunctionTriggered()
                 rz_analysis_function_set_cc(core->analysis, fcn, newCC.constData());
             }
 
-            emit Core() -> functionsChanged();
+            emit Core()->functionsChanged();
         }
     }
 }

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -737,29 +737,9 @@ void DisassemblyContextMenu::exportDisassemblyTriggered()
         return;
     }
 
-    QFileDialog dialog(parentForDialog(), tr("Export Disassembly"));
-    dialog.setAcceptMode(QFileDialog::AcceptSave);
-    dialog.setFileMode(QFileDialog::AnyFile);
-    dialog.setNameFilters({ tr("Assembly (*.asm *.S)"), tr("All files (*)") });
-    dialog.setDefaultSuffix("asm");
-    if (!dialog.exec()) {
-        return;
+    if (mainWindow) {
+        mainWindow->exportDisassembly(funcStart);
     }
-
-    QFile file(dialog.selectedFiles()[0]);
-    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        qWarning() << tr("Can't open file");
-        return;
-    }
-
-    TempConfig tempConfig;
-    tempConfig.set("scr.color", 0);
-
-    const ut64 size = Core()->getFunctionSize(funcStart);
-    const QString disassembly = Core()->cmdRawAt(QString("pD %1").arg(size), funcStart);
-
-    QTextStream fileOut(&file);
-    fileOut << disassembly;
 }
 
 void DisassemblyContextMenu::addBreakpointTriggered() const

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -731,14 +731,14 @@ void DisassemblyContextMenu::copyInstrBytesTriggered() const
 
 void DisassemblyContextMenu::exportDisassemblyTriggered()
 {
-    const RVA funcStart = Core()->getFunctionStart(offset);
-    if (funcStart == RVA_INVALID) {
+    const RVA funcMinAddr = Core()->getFunctionMinAddr(offset);
+    if (funcMinAddr == RVA_INVALID) {
         qWarning() << "No function at current offset.";
         return;
     }
 
     if (mainWindow) {
-        mainWindow->exportDisassembly(funcStart);
+        mainWindow->exportDisassembly(funcMinAddr);
     }
 }
 

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -1,6 +1,8 @@
 #include "DisassemblyContextMenu.h"
 
 #include "MainWindow.h"
+#include "common/CommandTask.h"
+#include "common/TempConfig.h"
 #include "dialogs/BreakpointsDialog.h"
 #include "dialogs/CommentsDialog.h"
 #include "dialogs/EditFunctionDialog.h"
@@ -15,6 +17,7 @@
 
 #include <QApplication>
 #include <QClipboard>
+#include <QFileDialog>
 #include <QInputDialog>
 #include <QJsonArray>
 #include <QPushButton>
@@ -35,6 +38,7 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
       copySeparator(addSeparator()),
       actionCopyAddr(this),
       actionCopyInstrBytes(this),
+      actionExportDisassembly(this),
       actionAddComment(this),
       actionAnalyzeFunction(this),
       actionEditFunction(this),
@@ -82,6 +86,10 @@ DisassemblyContextMenu::DisassemblyContextMenu(QWidget *parent, MainWindow *main
     initShortcutAction(&actionCopyInstrBytes, "Disassembly.copyInstructionBytes",
                        &DisassemblyContextMenu::copyInstrBytesTriggered);
     addAction(&actionCopyInstrBytes);
+
+    initAction(&actionExportDisassembly, tr("Export disassembly of current function"),
+               &DisassemblyContextMenu::exportDisassemblyTriggered);
+    addAction(&actionExportDisassembly);
 
     initAction(&showInSubmenu, tr("Show in"), nullptr);
     addAction(&showInSubmenu);
@@ -721,6 +729,38 @@ void DisassemblyContextMenu::copyInstrBytesTriggered() const
     clipboard->setText(Core()->getInstructionBytes(offset));
 }
 
+void DisassemblyContextMenu::exportDisassemblyTriggered()
+{
+    const RVA funcStart = Core()->getFunctionStart(offset);
+    if (funcStart == RVA_INVALID) {
+        qWarning() << "No function at current offset.";
+        return;
+    }
+
+    QFileDialog dialog(parentForDialog(), tr("Export Disassembly"));
+    dialog.setAcceptMode(QFileDialog::AcceptSave);
+    dialog.setFileMode(QFileDialog::AnyFile);
+    dialog.setNameFilter(tr("Text file (*.txt)"));
+    dialog.setDefaultSuffix("txt");
+    if (!dialog.exec()) {
+        return;
+    }
+
+    QFile file(dialog.selectedFiles()[0]);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << tr("Can't open file");
+        return;
+    }
+
+    TempConfig tempConfig;
+    tempConfig.set("scr.color", 0);
+
+    const QString disassembly = Core()->cmdRawAt("pdf", funcStart);
+
+    QTextStream fileOut(&file);
+    fileOut << disassembly;
+}
+
 void DisassemblyContextMenu::addBreakpointTriggered() const
 {
     Core()->toggleBreakpoint(offset);
@@ -1001,7 +1041,7 @@ void DisassemblyContextMenu::editFunctionTriggered()
                 rz_analysis_function_set_cc(core->analysis, fcn, newCC.constData());
             }
 
-            emit Core()->functionsChanged();
+            emit Core() -> functionsChanged();
         }
     }
 }

--- a/src/menus/DisassemblyContextMenu.h
+++ b/src/menus/DisassemblyContextMenu.h
@@ -46,6 +46,7 @@ private slots:
     void copyTriggered();
     void copyAddrTriggered() const;
     void copyInstrBytesTriggered() const;
+    void exportDisassemblyTriggered();
     void addCommentTriggered();
     void analyzeFunctionTriggered();
     void renameTriggered();
@@ -97,6 +98,7 @@ private:
     QAction *copySeparator;
     QAction actionCopyAddr;
     QAction actionCopyInstrBytes;
+    QAction actionExportDisassembly;
 
     QAction actionAddComment;
     QAction actionAnalyzeFunction;


### PR DESCRIPTION

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**
Adds a new UI action to both the main File menu and the Disassembly context menu to allow users to export the disassembly of the currently selected function directly to a .txt file. It temporarily sets the `scr.color` to `0` to prevent ANSI color codes from being written into the output file.

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

**Test plan (required)**
1. Open a binary in Cutter.

2. Navigate to the **Disassembly** view and ensure you are inside a recognized function.

3. **Test Context Menu Export:**
   - Right-click anywhere within the disassembly of the function.
   - Select the new option: **"Export disassembly of current function"**.
   - A file save dialog will appear. Save it as `export_context.txt` (or any preferred name).
   - Open the saved file in a text editor and verify it contains the full disassembly of the function without any ANSI color escape sequences (e.g. `\x1b[31m`).

4. **Test Main Menu Export:**
   - With the disassembly view active and focused inside a function, click on **File → Export disassembly of current function** in the main menu bar.
   - Save the file as `export_main.txt`.
   - Open the saved file and verify its contents match the context menu export.

5. **Test Invalid Offset/No Function:**
   - Seek to an offset in the binary that is **not** part of any defined function.
   - Right-click and choose **"Export disassembly of current function"**.
   - Verify that nothing is exported and a warning is appropriately suppressed/handled (no empty file should be created).
<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**
Closes:#3631
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
