### PR TITLE
Fix scroll reset when renaming variables in DecompilerWidget

### DIFF
--- a/src/widgets/DecompilerWidget.cpp
+++ b/src/widgets/DecompilerWidget.cpp
@@ -282,6 +282,12 @@ void DecompilerWidget::doRefresh()
     mCtxMenu->setDecompiledFunctionAddress(decompiledFunctionAddr);
     connect(dec, &Decompiler::finished, this, &DecompilerWidget::decompilationFinished);
     decompilerBusy = true;
+
+    if (!scrollHistory.empty() && previousFunctionAddr == decompiledFunctionAddr) {
+        scrollHistory[historyPos] = { ui->textEdit->horizontalScrollBar()->sliderPosition(),
+                                      ui->textEdit->verticalScrollBar()->sliderPosition() };
+    }
+
     dec->decompileAt(addr);
 }
 


### PR DESCRIPTION

This commit updates the active history index with the current scrollbar positions immediately prior to initiating a new decompilation request.

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**
When renaming variables, `doRefresh()` was triggered without updating the `scrollHistory` with the current position. This caused `decompilationFinished()` to restore the scroll bar to the position of the last explicit seek, effectively resetting the scroll position.

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->

1. Load a Binary: Open Cutter and load any standard executable or binary file. Let the initial analysis complete.
2. Open Decompiler: Navigate to the Decompiler widget (Windows -> Decompiler or select the Decompiler tab).
3. Find a Large Function: Seek to a function that is long enough to require vertical scrolling in the decompilation window. You can find one easily via the Functions widget.
4. Scroll Down: Scroll down to the middle or bottom of the function's decompiled code, so that the top of the function is completely out of view.
5. Rename a Variable: Right-click on any variable name visible in your current viewport and select "Rename..." (or use the shortcut Shift+N).
6. Apply Rename: Enter a new name for the variable and press Enter to confirm.
7. Verify Outcome: Observe the decompiler window. The text should briefly show a loading state and then display the newly decompiled code with the updated variable name. Crucially, the scrollbar position should remain exactly where you left it, rather than jumping back up to the top of the function or the last explicit seek position.

<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**
Closes:#3643
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
