### PR TITLE
macos_sign.sh: shrink signed DMG before conversion

### DIFF
--- a/scripts/macos_sign.sh
+++ b/scripts/macos_sign.sh
@@ -108,11 +108,17 @@ resign_dmg() {
 	notarize_bundle Cutter-rw/Cutter.app
 	unmount
 	trap - EXIT
-	# Remove temporary signing space and keep the HFS+ volume consistent.
+	# Remove temporary signing space and restore HFS+ volume consistency.
 	ee hdiutil resize -size min Cutter-rw.dmg
 	OUTPUT="${1%.*}-signed.dmg"
 	echo_step "Creating final read-only ${OUTPUT}"
 	ee hdiutil convert -format UDZO -o "${OUTPUT}" Cutter-rw.dmg
+	echo_step "Verifying filesystem in ${OUTPUT}"
+	ee hdiutil attach "${OUTPUT}" -readonly -nobrowse -noautofsck -mountpoint Cutter-rw
+	trap unmount EXIT
+	ee diskutil verifyVolume Cutter-rw
+	unmount
+	trap - EXIT
 }
 
 case "$1" in

--- a/scripts/macos_sign.sh
+++ b/scripts/macos_sign.sh
@@ -108,6 +108,8 @@ resign_dmg() {
 	notarize_bundle Cutter-rw/Cutter.app
 	unmount
 	trap - EXIT
+	# Remove temporary signing space and keep the HFS+ volume consistent.
+	ee hdiutil resize -size min Cutter-rw.dmg
 	OUTPUT="${1%.*}-signed.dmg"
 	echo_step "Creating final read-only ${OUTPUT}"
 	ee hdiutil convert -format UDZO -o "${OUTPUT}" Cutter-rw.dmg


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contribution guidelines](https://cutter.re/docs/contributing/code/getting-started.html)
- [x] I followed the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] Documentation is not needed for this packaging-only fix
- [x] I used AI tools and verified the change

**Detailed description**

PR #3630 grows the writable macOS image to 4 GB so codesigning has enough temporary space. The Cutter 2.5.0 release kept that enlarged HFS+ volume in the final DMG, where `fsck_hfs` reports `Invalid number of allocation blocks`. Homebrew then cannot mount the quarantined image non-interactively.

This change shrinks the image after signing and unmounting, but before the final read-only conversion. It also mounts the final DMG and runs `diskutil verifyVolume`, so a filesystem error stops the release process instead of being shipped. The same path is used for arm64 and x86_64.

AI disclosure: OpenAI Codex (GPT-5) was used for investigation and the patch. Claude Opus independently reviewed both the fix and the final verification flow.

**Test plan**

Tested with the official Cutter 2.5.0 arm64 DMG on macOS 27:

- The published broken DMG is rejected by the new check with `Invalid number of allocation blocks`.
- After `hdiutil resize -size min` and UDZO conversion, the same check passes with exit code 0.
- The failure path exits nonzero and its `EXIT` trap detaches the image.
- `hdiutil verify` passes, and the final DMG remains about 115 MB.
- `bash -O extglob -n scripts/macos_sign.sh` passes.

No UI screenshot is applicable to this packaging-only change.

**Closing issues**

No existing issue found.
