### PR TITLE
Fix shellcode dialog dropping trailing odd nibble

### DIFF
--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -156,16 +156,24 @@ void NewFileDialog::onLoadProjectButtonClicked()
     loadProject(ui->projectFileEdit->text());
 }
 
-void NewFileDialog::onShellcodeButtonClicked()
+QString NewFileDialog::extractShellcodeHex(const QString &shellcode)
 {
-    const QString shellcode = ui->shellcodeText->toPlainText();
-    QString extractedCode = "";
-    static const QRegularExpression rx("([0-9a-f]{2})", QRegularExpression::CaseInsensitiveOption);
+    QString extractedCode;
+    static const QRegularExpression rx("([0-9a-f])", QRegularExpression::CaseInsensitiveOption);
     QRegularExpressionMatchIterator i = rx.globalMatch(shellcode);
     while (i.hasNext()) {
-        const QRegularExpressionMatch match = i.next();
-        extractedCode.append(match.captured(1));
+        extractedCode.append(i.next().captured(1));
     }
+    // Pad a trailing lone nibble so it is not discarded (#2831)
+    if (extractedCode.size() % 2) {
+        extractedCode.append(QLatin1Char('0'));
+    }
+    return extractedCode;
+}
+
+void NewFileDialog::onShellcodeButtonClicked()
+{
+    const QString extractedCode = extractShellcodeHex(ui->shellcodeText->toPlainText());
     const int size = extractedCode.size() / 2;
     if (size > 0) {
         loadShellcode(extractedCode, size);
@@ -427,23 +435,14 @@ void NewFileDialog::onTabWidgetCurrentChanged(int index)
 
 bool NewFileDialog::eventFilter(QObject * /*obj*/, QEvent *event)
 {
-    const QString shellcode = ui->shellcodeText->toPlainText();
-    QString extractedCode = "";
-    static const QRegularExpression rx("([0-9a-f]{2})", QRegularExpression::CaseInsensitiveOption);
-    QRegularExpressionMatchIterator i = rx.globalMatch(shellcode);
-    int size = 0;
-
     if (event->type() == QEvent::KeyPress) {
         const auto *keyEvent = static_cast<QKeyEvent *>(event);
 
         // Confirm comment by pressing Ctrl/Cmd+Return
         if ((keyEvent->modifiers() & Qt::ControlModifier)
             && ((keyEvent->key() == Qt::Key_Enter) || (keyEvent->key() == Qt::Key_Return))) {
-            while (i.hasNext()) {
-                const QRegularExpressionMatch match = i.next();
-                extractedCode.append(match.captured(1));
-            }
-            size = extractedCode.size() / 2;
+            const QString extractedCode = extractShellcodeHex(ui->shellcodeText->toPlainText());
+            const int size = extractedCode.size() / 2;
             if (size > 0) {
                 loadShellcode(extractedCode, size);
             }

--- a/src/dialogs/NewFileDialog.h
+++ b/src/dialogs/NewFileDialog.h
@@ -73,6 +73,8 @@ private:
     void loadFile(const QString &filename);
     void loadProject(const QString &project);
     void loadShellcode(const QString &shellcode, const int size);
+    /** Extract hex digits; pad a trailing lone nibble with 0 (issue #2831). */
+    static QString extractShellcodeHex(const QString &shellcode);
     /**
      * @brief Updates IO plugin and file path based on the selected recent item
      * @param item The list item containing the IO mode and file path in its UserRole data


### PR DESCRIPTION
## Summary
- Pad a trailing lone hex nibble with `0` when loading shellcode from the New File dialog, so odd-length input is not silently discarded (fixes #2831).
- Deduplicate the hex extraction used by the button and Ctrl+Enter path.

## Test plan
- [ ] Open Cutter → New File → Shellcode tab
- [ ] Enter `abc` → Load → memory should contain `0xab 0xc0` (not only `0xab`)
- [ ] Enter `abcd` → still loads `0xab 0xcd` unchanged
- [ ] Enter empty / non-hex only → still does not load
- [ ] Ctrl+Enter on shellcode field behaves the same as the button