### PR TITLE
Reuse memory data blocks in HexWidget to eliminate redundant IO reads

### DIFF
--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -244,7 +244,7 @@ public:
         RzCoreLocked core(Core());
         rz_core_write_at(core, adr, in, len);
         writeToCache(in, adr, len);
-        emit Core() -> instructionChanged(adr);
+        emit Core()->instructionChanged(adr);
         return true;
     }
 

--- a/src/widgets/HexWidget.h
+++ b/src/widgets/HexWidget.h
@@ -158,11 +158,14 @@ public:
 
     void fetch(uint64_t address, int length) override
     {
-        // FIXME: reuse data if possible
         const uint64_t blockSize = 0x1000ULL;
         const uint64_t alignedAddr = address & ~(blockSize - 1);
         const int offset = address - alignedAddr;
         int len = (offset + length + (blockSize - 1)) & ~(blockSize - 1);
+
+        uint64_t oldFirstBlockAddr = mFirstBlockAddr;
+        QVector<QByteArray> oldBlocks = mBlocks;
+
         mFirstBlockAddr = alignedAddr;
         mLastValidAddr = length ? alignedAddr + len - 1 : 0;
         if (mLastValidAddr < mFirstBlockAddr) {
@@ -172,6 +175,13 @@ public:
         mBlocks.clear();
         uint64_t addr = alignedAddr;
         for (ut64 i = 0; i < len / blockSize; ++i, addr += blockSize) {
+            if (!oldBlocks.isEmpty() && addr >= oldFirstBlockAddr) {
+                uint64_t oldIdx = (addr - oldFirstBlockAddr) / blockSize;
+                if (oldIdx < static_cast<uint64_t>(oldBlocks.size())) {
+                    mBlocks.append(oldBlocks[static_cast<int>(oldIdx)]);
+                    continue;
+                }
+            }
             mBlocks.append(Core()->ioRead(addr, blockSize));
         }
     }
@@ -234,7 +244,7 @@ public:
         RzCoreLocked core(Core());
         rz_core_write_at(core, adr, in, len);
         writeToCache(in, adr, len);
-        emit Core()->instructionChanged(adr);
+        emit Core() -> instructionChanged(adr);
         return true;
     }
 


### PR DESCRIPTION


<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed description**
- Modified `MemoryData::fetch` in `src/widgets/HexWidget.h`.
- Avoided redundant `Core()->ioRead` calls by reusing previously fetched QByteArray blocks.
- Takes advantage of Qt's implicit sharing for O(1) performance.
- Resolves the existing `// FIXME: reuse data if possible` comment.
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. If you have used AI tools to generate these code changes, please disclose software used, model name. -->

**Test plan (required)**
**1. Basic Functional Verification (UI/Scrolling):**
Build Cutter with this branch and open any moderately sized binary.
Navigate to the Hexdump widget.
Scroll smoothly up and down using the mouse wheel, and also use the scrollbar to jump to different sections (both small contiguous steps and large jumps).
Expected Outcome: The memory values should display correctly without any visual corruption, missing chunks, or crashes. Scrolling should feel smooth and responsive.
**2. View Resizing & Cache Edge Cases:**
Resize the Hexdump widget window significantly (make it much taller and wider) to trigger variable block length fetches.
Expected Outcome: The widget should correctly fetch and stitch together the new blocks along with the reused blocks without rendering artifacts.
**3. Developer/Performance Verification (Optional but recommended to prove the optimization):**
Temporarily add qDebug() << "ioRead called"; inside the Core()->ioRead fallback loop in MemoryData::fetch (src/widgets/HexWidget.h).
Scroll one line down in the hex view.
Expected Outcome (Master branch): You will see multiple ioRead called prints equivalent to the entire visible screen's blocks.
Expected Outcome (This PR): You will see zero or only one ioRead called print, proving the partial cache overlap is successfully reusing the existing QByteArray blocks.

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran clang-format on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/contributing/code/getting-started.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
