### PR TITLE
Update rizin for string set config vars

### DIFF
--- a/cmake/BundledRizin.cmake
+++ b/cmake/BundledRizin.cmake
@@ -53,7 +53,7 @@ endif()
 
 # TODO: This version number should be fetched automatically
 # instead of being hardcoded.
-set (Rizin_VERSION 0.9)
+set (Rizin_VERSION 0.10)
 
 set (RZ_LIBS rz_core rz_config rz_cons rz_io rz_util rz_flag rz_mark rz_arch rz_debug
         rz_hash rz_bin rz_lang rz_il rz_egg rz_reg rz_search rz_syscall

--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -1187,19 +1187,15 @@ void CutterCore::setConfig(const char *k, const RzInterval &itv)
 void CutterCore::setConfig(const char *k, const QStringList &list)
 {
     CORE_LOCK();
-    RzList *rzList = rz_list_newf(free);
-    if (!rzList) {
+    RzSetS *set = rz_set_s_new(HT_STR_DUP);
+    if (!set) {
         return;
     }
-
     for (const QString &str : list) {
-        char *dupStr = strdup(str.toUtf8().constData());
-        if (dupStr) {
-            rz_list_append(rzList, dupStr);
-        }
+        rz_set_s_add(set, str.toUtf8().constData());
     }
-
-    rz_config_set_list(core->config, k, rzList);
+    rz_config_set_set(core->config, k, set);
+    rz_set_s_free(set);
 }
 
 int CutterCore::getConfigi(const char *k)
@@ -1226,16 +1222,12 @@ RzInterval CutterCore::getConfigItv(const char *k)
     return rz_config_get_interval(core->config, k);
 }
 
-QStringList CutterCore::getConfigList(const char *k)
+QSet<QString> CutterCore::getConfigSet(const char *k)
 {
     CORE_LOCK();
-
-    QStringList res;
-    RzList *list = rz_config_get_list(core->config, k);
-    for (const auto *s : CutterRzList<const char>(list)) {
-        res << QString::fromUtf8(s);
-    }
-    rz_list_free(list);
+    RzSetS *set = rz_config_get_set(core->config, k);
+    QSet<QString> res = convertRzSetS(set);
+    rz_set_s_free(set);
     return res;
 }
 
@@ -1295,18 +1287,18 @@ QString CutterCore::getConfig(const char *k)
     return { rz_config_get(core->config, k) };
 }
 
-QStringList CutterCore::getConfigOptions(const char *k)
+QSet<QString> CutterCore::getConfigOptions(const char *k)
 {
     CORE_LOCK();
     const RzConfigNode *node = rz_config_node_get(core->config, k);
     if (!(node && node->options)) {
         return {};
     }
-    QStringList list;
-    for (const auto &s : CutterRzList<char>(node->options)) {
-        list << s;
+    QSet<QString> res;
+    for (auto it = CutterRzIter<const char *>(rz_set_s_as_iter(node->options)); it; ++it) {
+        res << QString::fromUtf8(*it);
     }
-    return list;
+    return res;
 }
 
 void CutterCore::setConfig(const char *k, const QVariant &v)
@@ -4154,13 +4146,11 @@ QList<EvaluableVarDescription> CutterCore::getAllEvaluableVars()
                 var.type = EvaluableVarDescription::Interval;
                 const RzInterval itv = rz_config_var_get_interval(v);
                 value = QVariant::fromValue(itv);
-            } else if (RZ_CONFIG_VAR_IS_TYPE(flags, RZ_CONFIG_VAR_TYPE_LIST)) {
-                var.type = EvaluableVarDescription::List;
-                const RzList *list = rz_config_var_get_list(v);
-                QStringList stringList;
-                for (const auto *c : CutterRzList<const char>(list)) {
-                    stringList << QString(c);
-                }
+            } else if (RZ_CONFIG_VAR_IS_TYPE(flags, RZ_CONFIG_VAR_TYPE_SET)) {
+                var.type = EvaluableVarDescription::Set;
+                RzSetS *set = rz_config_var_get_set(v);
+                value = QVariant::fromValue(convertRzSetS(set));
+                rz_set_s_free(set);
             }
 
             if (value.isNull()) {
@@ -4168,13 +4158,9 @@ QList<EvaluableVarDescription> CutterCore::getAllEvaluableVars()
             }
             var.value = value;
 
-            const RzList *optionsList = rz_config_var_get_options(v);
-            if (optionsList) {
-                RzListIter *iter;
-                char *option;
-                CutterRzListForeach (optionsList, iter, char, option) {
-                    var.options << QString::fromUtf8(option);
-                }
+            const RzSetS *optionsSet = rz_config_var_get_options(v);
+            if (optionsSet) {
+                var.options = convertRzSetS(optionsSet);
             }
         } else {
             const RzConfigNode *node = &entry->node;
@@ -4189,10 +4175,8 @@ QList<EvaluableVarDescription> CutterCore::getAllEvaluableVars()
 
             var.value = QString::fromUtf8(rz_config_entry_get_as_string(entry));
 
-            RzListIter *iter;
-            char *option;
-            CutterRzListForeach (node->options, iter, char, option) {
-                var.options << QString::fromUtf8(option);
+            if (node->options) {
+                var.options = convertRzSetS(node->options);
             }
         }
 

--- a/src/core/Cutter.h
+++ b/src/core/Cutter.h
@@ -495,12 +495,12 @@ public:
     bool getConfigb(const QString &k) { return getConfigb(k.toUtf8().constData()); }
     RzInterval getConfigItv(const char *k);
     RzInterval getConfigItv(const QString &k) { return getConfigItv(k.toUtf8().constData()); }
-    QStringList getConfigList(const char *k);
-    QStringList getConfigList(const QString &k) { return getConfigList(k.toUtf8().constData()); }
+    QSet<QString> getConfigSet(const char *k);
+    QSet<QString> getConfigSet(const QString &k) { return getConfigSet(k.toUtf8().constData()); }
     QString getConfig(const char *k);
     QString getConfig(const QString &k) { return getConfig(k.toUtf8().constData()); }
     QString getConfigDescription(const char *k);
-    QStringList getConfigOptions(const char *k);
+    QSet<QString> getConfigOptions(const char *k);
     QStringList getColorThemes();
     QHash<QString, QColor> getTheme();
     QStringList getThemeKeys();

--- a/src/core/CutterDescriptions.h
+++ b/src/core/CutterDescriptions.h
@@ -10,8 +10,8 @@
 #include <QColor>
 #include <QList>
 #include <QMetaType>
+#include <QSet>
 #include <QString>
-#include <QStringList>
 #include <QVariant>
 
 struct FunctionDescription
@@ -448,11 +448,11 @@ struct EvaluableVarDescription
     QString description;
     bool readOnly;
 
-    enum Type : ut8 { Bool = 0, Int, String, Interval, List };
+    enum Type : ut8 { Bool = 0, Int, String, Interval, Set };
     Type type;
 
-    QVariant value; ///< Can be either QString, QStringList or RzInterval depending on type
-    QList<QString> options;
+    QVariant value; ///< Can be either QString, QSet<QString> or RzInterval depending on type
+    QSet<QString> options;
 };
 
 Q_DECLARE_METATYPE(FunctionDescription)

--- a/src/core/RizinCpp.cpp
+++ b/src/core/RizinCpp.cpp
@@ -1,1 +1,12 @@
 #include "RizinCpp.h"
+
+#include <QSet>
+
+QSet<QString> convertRzSetS(const RzSetS *set)
+{
+    QSet<QString> res;
+    for (auto it = CutterRzIter<const char *>(rz_set_s_as_iter(set)); it; ++it) {
+        res << QString::fromUtf8(*it);
+    }
+    return res;
+}

--- a/src/core/RizinCpp.h
+++ b/src/core/RizinCpp.h
@@ -187,9 +187,9 @@ public:
         return *this;
     }
     operator bool() { return rzIter && rzIter->cur; }
-    T &operator*() { return *reinterpret_cast<RzCoreDecodedBytes *>(rzIter->cur); }
-    T *get() { return reinterpret_cast<RzCoreDecodedBytes *>(rzIter->cur); }
-    T *operator->() { return reinterpret_cast<RzCoreDecodedBytes *>(rzIter->cur); }
+    T &operator*() { return *reinterpret_cast<T *>(rzIter->cur); }
+    T *get() { return reinterpret_cast<T *>(rzIter->cur); }
+    T *operator->() { return reinterpret_cast<T *>(rzIter->cur); }
 };
 
 #define CutterHtDef(xx, XX, K, VB)                                                                 \
@@ -218,5 +218,7 @@ public:
     };
 
 CutterHtDef(sp, SP, const char *, void *);
+
+QSet<QString> convertRzSetS(const RzSetS *set);
 
 #endif // RIZINCPP_H

--- a/src/dialogs/preferences/RizinConfigOptionsWidget.cpp
+++ b/src/dialogs/preferences/RizinConfigOptionsWidget.cpp
@@ -125,7 +125,7 @@ QVariant RizinConfigOptionsModel::data(const QModelIndex &index, int role) const
                 const auto itv = evalVar.value.value<RzInterval>();
                 return QString("%1+%2").arg(rzAddressString(itv.addr), rzSizeString(itv.size));
             }
-            if (evalVar.type == EvaluableVarDescription::List) {
+            if (evalVar.type == EvaluableVarDescription::Set) {
                 const QStringList list = evalVar.value.toStringList();
                 if (list.isEmpty()) {
                     return QString();
@@ -344,14 +344,16 @@ QWidget *RizinConfigOptionsDelegate::createEditor(QWidget *parent,
 
     if (evalVar.type == EvaluableVarDescription::Bool
         || evalVar.type == EvaluableVarDescription::Interval
-        || evalVar.type == EvaluableVarDescription::List) {
+        || evalVar.type == EvaluableVarDescription::Set) {
         // handled in lambda  connected to ui->treeView::doubleClicked
         return nullptr;
     }
 
     if (!evalVar.options.isEmpty()) {
         auto *comboBox = new QComboBox(parent);
-        for (const auto &opt : evalVar.options) {
+        QStringList opts = evalVar.options.values();
+        opts.sort();
+        for (const auto &opt : opts) {
             comboBox->addItem(opt);
         }
         return comboBox;
@@ -486,7 +488,7 @@ RizinConfigOptionsWidget::RizinConfigOptionsWidget(PreferencesDialog *parent)
             return;
         }
 
-        if (evalVar.type == EvaluableVarDescription::List) {
+        if (evalVar.type == EvaluableVarDescription::Set) {
             StringListDialog dialog(evalVar.value.toStringList(), this);
             dialog.setWindowTitle(tr("Edit List for %1").arg(evalVar.name));
 
@@ -596,8 +598,8 @@ void RizinConfigOptionsWidget::handleConfigOptionChanged(const QModelIndex &topL
     if (!originalValues.contains(evalVar.name)) {
         if (evalVar.type == EvaluableVarDescription::Interval) {
             originalValues[evalVar.name] = QVariant::fromValue(Core()->getConfigItv(evalVar.name));
-        } else if (evalVar.type == EvaluableVarDescription::List) {
-            originalValues[evalVar.name] = QVariant::fromValue(Core()->getConfigList(evalVar.name));
+        } else if (evalVar.type == EvaluableVarDescription::Set) {
+            originalValues[evalVar.name] = QVariant::fromValue(Core()->getConfigSet(evalVar.name));
         } else {
             originalValues[evalVar.name] = Core()->getConfig(evalVar.name);
         }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Changed in rizin fa2db74f86c3432c7b68a4f1913a72722b4ac6ac: Config vars storing multiple strings do not use a list anymore but a set as the strings are meant to be unique.

**Test plan (required)**

Open the preferences dialog and in "Rizin Config":
* Editing string set vars still work (rizin has none, but I tested with inquiry.trace from https://github.com/rizinorg/rizin/pull/6648)
* Options for vars that have any should be populated, e.g. zoom.in