### PR TITLE
Add PJ wrapper

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SOURCES
     common/Configuration.cpp
     common/Colors.cpp
     common/TempConfig.cpp
+    common/PjHandle.cpp
     common/SvgIconEngine.cpp
     common/SyntaxHighlighter.cpp
     widgets/DecompilerWidget.cpp
@@ -226,6 +227,7 @@ set(HEADER_FILES
     common/Configuration.h
     common/Colors.h
     common/TempConfig.h
+    common/PjHandle.h
     common/SvgIconEngine.h
     common/SyntaxHighlighter.h
     widgets/DecompilerWidget.h

--- a/src/common/PjHandle.cpp
+++ b/src/common/PjHandle.cpp
@@ -2,10 +2,7 @@
 
 #include <rz_util/rz_pj.h>
 
-PjHandle::PjHandle()
-    : m_pj(pj_new())
-{
-}
+PjHandle::PjHandle() : m_pj(pj_new()) {}
 
 PjHandle::~PjHandle()
 {
@@ -14,8 +11,7 @@ PjHandle::~PjHandle()
     }
 }
 
-PjHandle::PjHandle(PjHandle &&other) noexcept
-    : m_pj(other.m_pj)
+PjHandle::PjHandle(PjHandle &&other) noexcept : m_pj(other.m_pj)
 {
     other.m_pj = nullptr;
 }

--- a/src/common/PjHandle.cpp
+++ b/src/common/PjHandle.cpp
@@ -4,34 +4,22 @@
 
 PjHandle::PjHandle() : m_pj(pj_new()) {}
 
-PjHandle::~PjHandle()
-{
-    if (m_pj) {
-        pj_free(m_pj);
-    }
-}
+PjHandle::~PjHandle() = default;
 
-PjHandle::PjHandle(PjHandle &&other) noexcept : m_pj(other.m_pj)
-{
-    other.m_pj = nullptr;
-}
+PjHandle::PjHandle(PjHandle &&) noexcept = default;
 
 PjHandle &PjHandle::operator=(PjHandle &&other) noexcept
 {
+    // unique_ptr self move isn't safe, so guarding.
     if (this != &other) {
-        if (m_pj) {
-            pj_free(m_pj);
-        }
-        m_pj = other.m_pj;
-        other.m_pj = nullptr;
+        m_pj = std::move(other.m_pj);
     }
     return *this;
 }
 
 char *PjHandle::drain()
 {
-    PJ *pj = m_pj;
-    m_pj = nullptr;
+    PJ *pj = m_pj.release();
     if (!pj) {
         return nullptr;
     }

--- a/src/common/PjHandle.cpp
+++ b/src/common/PjHandle.cpp
@@ -1,0 +1,43 @@
+#include "PjHandle.h"
+
+#include <rz_util/rz_pj.h>
+
+PjHandle::PjHandle()
+    : m_pj(pj_new())
+{
+}
+
+PjHandle::~PjHandle()
+{
+    if (m_pj) {
+        pj_free(m_pj);
+    }
+}
+
+PjHandle::PjHandle(PjHandle &&other) noexcept
+    : m_pj(other.m_pj)
+{
+    other.m_pj = nullptr;
+}
+
+PjHandle &PjHandle::operator=(PjHandle &&other) noexcept
+{
+    if (this != &other) {
+        if (m_pj) {
+            pj_free(m_pj);
+        }
+        m_pj = other.m_pj;
+        other.m_pj = nullptr;
+    }
+    return *this;
+}
+
+char *PjHandle::drain()
+{
+    PJ *pj = m_pj;
+    m_pj = nullptr;
+    if (!pj) {
+        return nullptr;
+    }
+    return pj_drain(pj);
+}

--- a/src/common/PjHandle.h
+++ b/src/common/PjHandle.h
@@ -2,6 +2,7 @@
 #define PJHANDLE_H
 
 #include "core/CutterCommon.h"
+
 #include <memory>
 
 /**

--- a/src/common/PjHandle.h
+++ b/src/common/PjHandle.h
@@ -1,0 +1,54 @@
+#ifndef PJHANDLE_H
+#define PJHANDLE_H
+
+#include "core/CutterCommon.h"
+
+/**
+ * @brief RAII handle for a rizin PJ (JSON builder).
+ *
+ * Owns a pj_new() alloc, the destructor calls pj_free() on early return
+ * paths before the PJ is drained. drain() releases ownership (pj_drain frees
+ * the PJ and returns its buffer), so the destructor is a no-op after drain.
+ *
+ * move used, as copying would alias the PJ and do double free.
+ *
+ * @code
+ * {
+ *     PjHandle pj;
+ *     if (!pj) {
+ *         return;
+ *     }
+ *     pj_o(pj.get());
+ *     pj_ks(pj.get(), "name", "value");
+ *     pj_end(pj.get());
+ *     char *json = pj.drain();
+ *     // caller frees json
+ * }
+ * @endcode
+ */
+class CUTTER_EXPORT PjHandle
+{
+public:
+    PjHandle();
+    ~PjHandle();
+
+    PjHandle(const PjHandle &) = delete;
+    PjHandle &operator=(const PjHandle &) = delete;
+    PjHandle(PjHandle &&other) noexcept;
+    PjHandle &operator=(PjHandle &&other) noexcept;
+
+    explicit operator bool() const { return m_pj != nullptr; }
+    PJ *get() const { return m_pj; }
+
+    /**
+     * @brief Drain the PJ into its JSON buffer.
+     * @return buffer of the drained PJ, or nullptr if already drained. The
+     * caller takes ownership and must free() the returned buffer.
+     */
+    char *drain();
+
+private:
+    PJ *m_pj;
+};
+
+#endif // PJHANDLE_H

--- a/src/common/PjHandle.h
+++ b/src/common/PjHandle.h
@@ -2,6 +2,7 @@
 #define PJHANDLE_H
 
 #include "core/CutterCommon.h"
+#include <memory>
 
 /**
  * @brief RAII handle for a rizin PJ (JSON builder).
@@ -38,7 +39,7 @@ public:
     PjHandle &operator=(PjHandle &&other) noexcept;
 
     explicit operator bool() const { return m_pj != nullptr; }
-    PJ *get() const { return m_pj; }
+    PJ *get() const { return m_pj.get(); }
 
     /**
      * @brief Drain the PJ into its JSON buffer.
@@ -48,7 +49,11 @@ public:
     char *drain();
 
 private:
-    PJ *m_pj;
+    struct Deleter
+    {
+        void operator()(PJ *pj) const { pj_free(pj); }
+    };
+    std::unique_ptr<PJ, Deleter> m_pj;
 };
 
 #endif // PJHANDLE_H


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [ ] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

As per: 
https://github.com/IndAlok/rz-frida/pull/9#discussion_r3698443347
https://github.com/IndAlok/rz-frida/pull/9#issuecomment-5168341330
https://github.com/IndAlok/rz-frida/pull/9#discussion_r3708982650


Adds `PjHandle`, an RAII wrapper for rizin's `PJ` JSON builder, in `src/common/`.

Plugins that call rizin C APIs taking a `PJ *` (e.g. the [rz-frida](https://github.com/IndAlok/rz-frida) Cutter plugin) must pair every `pj_new()` with a `pj_free()` or `pj_drain()` on every code path, including early returns. The class owns a `pj_new()` alloc and frees it in the dtor, so ownership is released automatically. `drain()` nulls the internal ptr before calling `pj_drain` (which frees the PJ struct and returns its buffer), making the dtor a no-op after drain, so a double free doesn't happen.

**Test plan (required)**

- `clang-format` passes
- compile-fail check, implicit conversion `PJ *p = handle;` is rejected

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
