### PR TITLE
Fix odd-length hex conversion crash

### DIFF
--- a/src/core/Cutter.cpp
+++ b/src/core/Cutter.cpp
@@ -5124,9 +5124,9 @@ QByteArray CutterCore::hexStringToBytes(const QString &hex)
 {
     const QByteArray hexChars = hex.toUtf8();
     QByteArray bytes;
-    bytes.reserve(hexChars.length() / 2);
+    bytes.resize(hexChars.length() / 2 + 1);
     const int size = rz_hex_str2bin(hexChars.constData(), reinterpret_cast<ut8 *>(bytes.data()));
-    bytes.resize(size);
+    bytes.resize(qAbs(size));
     return bytes;
 }
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

`rz_hex_str2bin` writes one byte for a trailing lone nibble and returns the byte count as a negative value. The old code only reserved `hex.length() / 2` bytes, so a single nibble passed an unwritable zero-capacity buffer to Rizin and crashed in `rz_hex_str2bin`.

I resize the buffer to `(length / 2) + 1` before conversion, then use the absolute return value as the final byte count. Odd inputs now keep the padded low nibble without writing past the buffer or passing a negative size to `QByteArray::resize`.

I used OpenAI Codex (GPT-5.6 Sol) to inspect the affected conversion path and help verify the change.

**Test plan (required)**

- built the full `Cutter` target against the bundled Rizin submodule
- before this change, `hexStringToBytes("e")` crashes with `SIGBUS` (`exit 138`)
- after this change, empty input stays empty, `6162` returns `6162`, `e` returns `e0`, and `61626` returns `616260`
- ran `xcrun clang-format --dry-run --Werror -style=file src/core/Cutter.cpp`

**Closing issues**

Closes #3641
